### PR TITLE
docs: add comprehensive documentation suite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [feat, fix, docs, refactor, test, chore, perf, ci, build, revert]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+DocSpec is a streaming document conversion library in Rust. Documents are streams of typed events (StartHeading, Text, EndHeading, etc.) flowing from EventSource readers to EventSink writers. Readers and writers are fully decoupled. This architecture processes documents larger than available memory using constant memory regardless of file size.
+
+## Read These First
+
+- [MANIFESTO.md](MANIFESTO.md) — philosophy and values
+- [ARCHITECTURE.md](ARCHITECTURE.md) — streaming pipeline and design
+- [EVENTS.md](EVENTS.md) — event types and well-formedness rules
+- [CODING_STANDARDS.md](CODING_STANDARDS.md) — code quality rules
+- [TESTING.md](TESTING.md) — 99.5% coverage requirement and test types
+- [CONTRIBUTING.md](CONTRIBUTING.md) — branching, commits, PRs, semver
+- [SECURITY.md](SECURITY.md) — error handling by context, resource limits
+
+## Hard Rules
+
+- **No unsafe code** — workspace forbids it entirely
+- **No unwrap() or expect()** — use Result and ?
+- **No inline #[allow]** — fix the code, not the warning
+- **Never buffer full documents** — stream always
+- **Fail fast** — return errors immediately
+- **99.5% test coverage floor**
+
+See [CODING_STANDARDS.md](CODING_STANDARDS.md) for full details.
+
+## Before You Submit
+
+- `cargo fmt` and `cargo clippy` pass with zero warnings
+- All tests pass, coverage maintained
+- All public items have doc comments
+- Commits follow conventional format: `type(scope): description`
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for commit format and PR process.
+
+## Core Pattern
+
+Sources emit events in document order. Sinks consume them. Adapters transform between them. Events flow one at a time. Never accumulate. Never buffer.
+
+See [ARCHITECTURE.md](ARCHITECTURE.md) for the streaming pipeline design and [EVENTS.md](EVENTS.md) for event types.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,158 @@
+# DocSpec Architecture
+
+This document explains how DocSpec works architecturally. For the philosophy behind our design decisions, see the companion [Manifesto](MANIFESTO.md).
+
+---
+
+## 1. The Problem With Traditional Document Conversion
+
+Most document conversion libraries buffer everything: load the entire file into memory, parse it into a tree, walk the tree to transform it, then serialize the result. This fails catastrophically at scale. A 100 MB document becomes 500 MB in heap allocation. Memory consumption grows linearly with document size, often worse due to tree node overhead. Production systems crash when users upload documents larger than expected.
+
+The buffering approach also creates architectural coupling. Readers and writers know about each other. Each conversion direction is written separately with its own bugs. Adding a new format requires modifying every existing conversion path. The combinatorial explosion becomes unmanageable.
+
+Large allocations cause heap fragmentation, garbage collection overhead, and poor cache locality. A system that buffers everything might work for most documents but fails unpredictably under memory pressure.
+
+DocSpec rejects all of this. Documents are streams of content, not static structures. A streaming model presents a simple interface: receive events, process them, emit output. As the system grows, the streaming model scales gracefully. New formats add linear complexity, not quadratic.
+
+---
+
+## 2. The Event-Based Pipeline
+
+DocSpec treats every document as a stream of events. Instead of building a tree, we emit events as we parse. A heading becomes StartHeading and EndHeading events. A paragraph becomes StartParagraph, Text events, then EndParagraph. A table becomes StartTable, StartTableRow, StartTableCell, cell content, EndTableCell, EndTableRow, EndTable.
+
+Events flow in strict document order. Nothing accumulates. Nothing buffers. The document enters as bytes and exits as bytes. In between, it is a stream of events flowing through a pipeline.
+
+This architecture rests on two core abstractions: sources and sinks.
+
+A source takes a document in some format and produces events. It walks through the input and emits events as it encounters structural elements. It knows nothing about what happens to those events.
+
+A sink takes events and produces a document in some format. It receives events one at a time and writes output bytes incrementally. It knows nothing about where those events came from.
+
+This decoupling is the key architectural insight. Sources and sinks are fully independent. They communicate only through the event protocol. Any source can connect to any sink. A system with four readers and four writers needs only eight implementations instead of sixteen. Complexity grows linearly, not quadratically.
+
+The pipeline is transparent and inspectable. You can insert adapters between source and sink without either knowing the adapter exists. An adapter is a sink that consumes events and a source that emits events. This composability enables powerful transformation chains: filter events, remap event types, validate events, count events.
+
+The event model is universal across all formats. A document is a sequence of structural elements: headings, paragraphs, lists, tables, text runs with styling, links, images. By separating structure from encoding, we achieve true interoperability.
+
+The event flow is predictable. StartDocument begins the stream. EndDocument terminates it. Between these, events arrive in document order. Block-level elements use paired Start and End events. Inline content uses flat events with styling. This consistency makes reasoning about event sequences straightforward.
+
+---
+
+## 3. Why Streaming Beats Trees
+
+The dominant alternative to streaming is building an abstract syntax tree. Parse the whole document, construct a tree in memory, walk the tree recursively, emit output. These advantages come at a steep cost that grows with document size.
+
+Memory usage in a tree-based system is O(document size) at best, often worse. A 100 MB document typically needs 100 MB for content storage, plus overhead for tree node structures: pointers, sibling links, type tags, metadata. A 100 MB document can easily become 200-300 MB in memory.
+
+Streaming uses O(1) memory regardless of document size. Events flow through and are immediately consumed. Only a small, fixed-size buffer is needed for the current event. A 1 KB document and a 1 GB document use essentially the same amount of memory.
+
+The tradeoff is that streaming is strictly one-pass. You cannot go back to a previous event. You cannot look ahead. We accept this constraint because it delivers correctness at scale. Documents are fundamentally sequential structures.
+
+When you truly need multi-pass processing, you have options: write an adapter that buffers only the specific events you need, run multiple pipelines sequentially, or externalize state to temporary storage. These are deliberate choices with explicit resource costs.
+
+Tree structures complicate error handling and resource management. With streaming, errors occur in context. You know exactly where you are in the document. Resource management is simple: events are processed and discarded.
+
+Performance characteristics differ dramatically. Trees cause cache misses as the processor jumps between scattered nodes. Streaming keeps data in cache-friendly sequences. Trees allocate frequently. Streaming reuses buffers. Trees fragment the heap. Streaming keeps allocation minimal and predictable.
+
+For document conversion, the tree advantages rarely matter. You are translating from one format to another, not modifying the document structure arbitrarily. The transformations are largely local. The global context you need is minimal and can be tracked with simple state variables.
+
+The streaming model enables processing of documents larger than available memory. A tree-based system must load the entire document before processing. A streaming system processes as it reads.
+
+---
+
+## 4. The Image Problem — Flagship Example
+
+Images are where the memory abuse of traditional approaches is most visible. Traditional converters load the full image bytes before deciding what to do with them. A document containing a 50 MB embedded image requires the entire 50 MB in heap memory. A document with twenty such images requires 1 GB of image data in memory simultaneously.
+
+DocSpec never does this. Images are represented as references in the event stream, not as data payloads. When the source encounters an image, it emits an Image event containing a reference. The event itself is tiny, just a few dozen bytes.
+
+When the sink needs the actual image bytes, it requests them through an asset provider. The asset provider is an abstraction that can serve bytes on demand. The sink asks for the image by its reference, and the provider streams it piece by piece. The sink writes each chunk directly to its output buffer without ever holding the complete image.
+
+A 50 MB image flows through DocSpec using a 32 KB buffer. The image size is completely irrelevant to memory usage. Whether the image is 1 MB or 500 MB, the memory footprint stays constant at the buffer size.
+
+This approach also enables lazy loading and conditional processing. If a sink does not need the image bytes, the image data is never fetched. The reference flows through, the sink ignores it, and no memory is allocated.
+
+---
+
+## 5. Error Philosophy
+
+Events flow until they cannot. When a reader encounters a malformed byte sequence, corrupted structure, or unsupported feature, it surfaces an error immediately. There is no attempt to recover and continue. There is no partial output. There is no "best effort" conversion that produces garbage.
+
+Fail fast means the caller receives one of exactly two outcomes: a complete, correct conversion that processed the entire document successfully, or a clear error describing precisely what went wrong and where. Never a partial conversion. Never truncated output. Never corrupted output that propagates downstream.
+
+Error information is structured, typed, and contextual. Each error carries relevant context: what operation was being performed, where in the document the problem occurred, what values were expected and what was actually found.
+
+The fail-fast approach simplifies reasoning about the system. You do not need to wonder if a conversion succeeded partially. The result is binary: success or failure. This clarity is valuable in production systems where reliability matters.
+
+---
+
+## 6. The Sync-First Model
+
+The conversion pipeline is synchronous and pull-based. The consumer calls `next_event()` on the source to request each event, then passes it to the sink. This pull model provides natural backpressure — the source only produces when the consumer is ready, which is what enables constant memory usage. There are no background threads, message channels, or async machinery.
+
+This synchronous design is intentional. Document conversion is fundamentally CPU-bound work. Async machinery adds overhead without benefit for CPU-bound work. Task scheduling requires coordination. Context switching costs CPU cycles. Memory allocation for futures and task states adds pressure to the allocator.
+
+The synchronous model is simpler in every way. Execution flows predictably through function calls. It is faster because there is no scheduling overhead. It uses less memory because there are no task structures. Error propagation is straightforward. Stack traces are meaningful and point directly to the source of problems.
+
+If you need concurrency, add it at the caller level, not inside the pipeline. Run multiple conversion pipelines simultaneously in separate threads. Each individual pipeline stays synchronous and single-threaded.
+
+The sync-first design makes the code more portable. It runs identically on all targets: native servers, WebAssembly in browsers, embedded systems. No runtime dependencies on thread pools or async executors.
+
+---
+
+## 7. Extension Points
+
+The architecture is designed for extension from the ground up. Adding new formats, transformations, and behaviors is straightforward because of the clear, minimal interfaces between components.
+
+To add a new reader, implement the source trait for that format. Parse the format according to its specification. Emit events in document order as you encounter structural elements.
+
+To add a new writer, implement the sink trait for that format. Consume events in document order as they arrive. Produce bytes in your target format incrementally.
+
+To add a new adapter, implement both traits. Consume events as a sink, transform or analyze them, emit new events as a source. Chain adapters together in any order: source into adapter into adapter into sink.
+
+Common adapter patterns include:
+
+- **Filtering adapters** remove events matching certain criteria. Strip all images to create a text-only version. Remove hidden text. Skip metadata sections.
+- **Remapping adapters** change event types to transform document structure. Convert all headings down by one level. Turn block quotations into indented paragraphs.
+- **Counting adapters** track statistics without modifying the event stream. Count words, paragraphs, images, tables.
+- **Validating adapters** check invariants and fail fast if violated. Ensure every StartParagraph has a corresponding EndParagraph. Verify heading levels are within valid ranges.
+
+The trait interfaces are intentionally minimal. A source has one main method: return the next event when requested. A sink has two methods: receive an event, and finish. This minimal surface area makes implementations straightforward.
+
+Testing is simplified by the clear interfaces. To test a source, connect it to a test sink that collects events. To test a sink, create a test source that emits known events.
+
+---
+
+## 8. Portability
+
+The streaming design that makes DocSpec memory-efficient on a server also makes it portable to every other computing environment. The same source code compiles for native targets, WebAssembly modules, and embedded microcontrollers.
+
+On native servers, DocSpec runs as a library embedded in larger applications or as a standalone command-line tool. It processes documents using minimal memory, leaving resources available for other work.
+
+In WebAssembly, DocSpec runs directly in web browsers and Node.js server environments. The streaming design is absolutely essential here. WebAssembly modules typically have limited memory available, often 2 GB or less shared with the host JavaScript environment. Streaming keeps memory usage constant and small regardless of document size.
+
+On embedded systems, DocSpec runs on microcontrollers with kilobytes of RAM available. If the software works on a microcontroller with only 512 KB of heap available, it will work anywhere.
+
+This portability is not an accident. It is the direct consequence of the streaming design. Zero runtime dependencies on heavy frameworks. No reliance on garbage collection. No async executor required. No assumptions about the operating system beyond basic byte input and output.
+
+The same code path executes regardless of target. There are no conditional compilation blocks for different platforms. Just straightforward, sequential function calls that work everywhere.
+
+---
+
+## Summary
+
+DocSpec converts documents through a streaming event pipeline. Documents enter as bytes, become events flowing through the pipeline, exit as bytes in the target format. Nothing accumulates in memory. Everything flows through and is immediately processed.
+
+The event-based architecture decouples readers from writers through a shared event protocol. Any reader connects to any writer. Combinatorial power emerges from simple, composable components. Adding a new format instantly enables conversion to and from all existing formats.
+
+Streaming uses O(1) memory regardless of document size. A 50 MB image flows through the pipeline using only a 32 KB buffer. Documents of any size convert reliably without exhausting system resources.
+
+Errors surface immediately with full context. Fail fast. No partial output. No silent corruption. Clear, structured error information enables appropriate responses from calling code.
+
+The pipeline is synchronous with direct function calls. No async machinery. No thread pools. No scheduling overhead. Simple, fast, and portable to every execution environment.
+
+Extension is straightforward through well-defined interfaces. New formats implement the source or sink traits. Adapters chain between source and sink for transformation, filtering, validation, and analysis. Composable, testable, maintainable.
+
+The same code runs natively on servers, in WebAssembly in browsers, on embedded microcontrollers. Portability is a consequence of good design. Constraints force clarity. Clarity produces quality that lasts.
+
+For the philosophy behind these architectural choices, see the [Manifesto](MANIFESTO.md).

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,141 @@
+# Coding Standards
+
+This document explains why we enforce the standards we do. For the exact rules, see the workspace `Cargo.toml`. For the philosophy behind them, see `MANIFESTO.md`.
+
+---
+
+## 1. The Underlying Philosophy
+
+Code quality is about correctness, safety, and maintainability. We enforce standards that eliminate whole categories of bugs. We do not suppress warnings; we fix the underlying problems.
+
+Every rule exists because we have seen what happens when it is not followed: production crashes, silent data corruption, security vulnerabilities, code no one dares touch. The compiler is our first reviewer. It never gets tired. A warning that is ignored will become a bug.
+
+---
+
+## 2. Safety: No Unsafe Code
+
+`unsafe_code` is set to `"forbid"` in the workspace. No unsafe blocks. No exceptions.
+
+Unsafe code opts out of Rust's ownership model and type system. It opens the door to memory corruption, data races, undefined behavior. If you think you need unsafe, the design needs to change. Use safe abstractions. The streaming architecture was designed specifically to avoid unsafe.
+
+---
+
+## 3. Documentation: Missing Docs Is Denied
+
+`missing_docs` is set to `"deny"`. Every public function, struct, enum, trait, constant, and module must have a documentation comment.
+
+Undocumented public API is incomplete API. Document the intent, not the implementation. "Returns the writer's current byte count" is good. "Increments self.count and returns it" is bad. Document panics, errors, safety invariants, and performance characteristics. Use examples.
+
+---
+
+## 4. Error Handling: Unwrap and Expect Are Banned
+
+`unwrap()` and `expect()` are banned across the codebase. Every operation that can fail returns a Result. Every error propagates with the `?` operator.
+
+`unwrap()` is a panic waiting to happen. In a library, panics are unacceptable. The `?` operator makes propagation ergonomic. If you need a default, use `unwrap_or` or `unwrap_or_else`. Error types are descriptive and implement `std::error::Error` for interoperability.
+
+---
+
+## 5. Linting: No Warning Suppressions
+
+`allow_attributes` is set to `"deny"`. No `#[allow]` attribute is permitted in source code. If clippy flags something, we fix it.
+
+Warnings are signal. Suppressing them hides the signal. We run Clippy at the strictest settings: restriction, pedantic, and correctness groups, all at deny level. If Clippy is genuinely wrong (rare), we add a workspace-level exception in `Cargo.toml` with documented reasoning — never inline `#[allow]`.
+
+---
+
+## 6. Code Formatting: Consistency Over Style
+
+`cargo fmt` is non-negotiable. All code is formatted before commit (enforced by pre-commit hooks).
+
+Consistency eliminates style debates and makes diffs cleaner. If rustfmt produces unexpected output, the code structure is the problem, not the formatter. Refactor the code so the formatter is happy.
+
+---
+
+## 7. Naming Conventions
+
+Rust has well-established naming conventions. We follow them without deviation:
+
+- Types (structs, enums, traits): PascalCase
+- Functions, methods, variables: snake_case
+- Constants, statics: SCREAMING_SNAKE_CASE
+- Modules, crates: snake_case (kebab-case for crate names)
+- Lifetimes: short, single-letter or short descriptive ('a, 'doc, 'sink)
+
+Names should describe what something IS or DOES, not how it works internally. `ConversionError`, not `InternalConversionResultWrapper`. Boolean names should read naturally in conditionals: `is_valid`, not `valid_flag`.
+
+---
+
+## 8. Fail-Fast Error Propagation
+
+Return errors immediately on failure. No partial recovery. If an operation fails, propagate the error to the caller.
+
+Partial recovery creates ambiguity. A clear error is better than a silent partial success. Error propagation respects the caller's autonomy. The caller knows the context and whether to retry, abort, provide defaults, or escalate. Propagation is the default via the `?` operator.
+
+---
+
+## 9. The Review Standard
+
+Code review is where standards are enforced. Reviewers check:
+
+- Does this code do what it claims?
+- Are there suppressions or workarounds?
+- Is the documentation complete?
+- Are errors handled correctly?
+- Is coverage maintained?
+
+Review is the last line of defense. Automated tools catch mechanical issues. Review catches design issues, logic errors, and deviations that tools cannot detect. Every PR is reviewed by at least one person other than the author. No self-merge.
+
+---
+
+## 10. Testing: Verification Over Trust
+
+See [TESTING.md](TESTING.md) for our complete testing philosophy, coverage requirements, and test type guidelines.
+
+---
+
+## 11. Dependencies: Earned, Not Assumed
+
+Every new dependency requires written justification in the pull request description. What does it do? Why can we not do it ourselves? What is the cost?
+
+Dependencies are liabilities. They update, break, have licenses, vulnerabilities, and transitive dependencies. Small code you wrote is better than large code you imported. When we do add a dependency, we pin it carefully and audit it periodically.
+
+---
+
+## 12. Type Safety: Leverage the Compiler
+
+Use the type system to prevent bugs. Encode invariants in types. Use newtypes to distinguish between different kinds of strings. Use enums instead of booleans when there are more than two states.
+
+The compiler can check types. It cannot check comments. When you encode an invariant in a type, the compiler enforces it. Use `NonZeroUsize` when zero is invalid. Use `Option` when a value might be absent. Use `Result` when an operation might fail.
+
+---
+
+## 13. Comments: Explain the Why
+
+Comments should explain why code exists, not what it does. The code tells you what it does. Comments tell you why it does it. If the code is unclear, rewrite the code.
+
+Use comments for: explaining why a non-obvious approach was chosen, documenting workarounds for external bugs, warning about subtle behavior, referencing specifications. Do not use comments for: restating what the code does, marking sections, leaving notes to yourself.
+
+---
+
+## 14. Module Organization
+
+Modules should be small and focused. A module does one thing completely. It has a clear interface. Internal details are private.
+
+Small modules are understandable. Clear interfaces reduce coupling. Use `mod.rs` to define the public interface. Re-export public items explicitly. Keep implementation details in submodules. If a file exceeds 300 lines, consider splitting it.
+
+---
+
+## Summary
+
+These standards exist to produce correct, safe, maintainable code. They are enforced automatically where possible and by review where necessary. They are not suggestions. They are requirements.
+
+Quality is not accidental. It is the result of discipline applied consistently over time.
+
+---
+
+## Further Reading
+
+- **MANIFESTO.md** — The philosophy that drives these standards
+- **ARCHITECTURE.md** — The streaming pipeline design
+- **CONTRIBUTING.md** — The workflow that enforces these standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,202 @@
+# Contributing to DocSpec
+
+Thank you for considering a contribution. DocSpec is a memory-conscious streaming document conversion library with strict quality standards.
+
+## Getting Started
+
+### Prerequisites
+
+- Rust stable toolchain (latest stable version)
+- Git with your user name and email configured
+- pre-commit for running pre-commit hooks
+
+Clone the repository:
+```bash
+git clone https://github.com/docspec/docspec.git
+cd docspec
+pre-commit install
+```
+
+The pre-commit hooks enforce conventional commit format and code style. Before diving into code, read the [Manifesto](MANIFESTO.md) to understand our philosophy: memory efficiency, streaming design, and strict quality above convenience.
+
+## Branching Strategy
+
+We follow GitHub Flow:
+
+1. Create a feature branch from `main`
+2. Make your changes with clean, focused commits
+3. Push your branch and open a pull request to `main`
+4. Address review feedback
+5. A reviewer merges when approved
+
+### Branch Naming
+
+Use descriptive branch names:
+```
+feat/add-odt-writer
+fix/docx-image-handling
+docs/update-api-examples
+refactor/event-pipeline
+test/html-roundtrip-coverage
+```
+
+## Commit Messages
+
+Every commit must follow the [Conventional Commits](https://www.conventionalcommits.org/) specification (enforced by pre-commit hook).
+
+### Format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+[optional footer(s)]
+```
+
+### Types
+
+- **feat**: New feature or capability
+- **fix**: Bug fix
+- **docs**: Documentation only changes
+- **refactor**: Code change that neither fixes a bug nor adds a feature
+- **test**: Adding or correcting tests
+- **chore**: Maintenance tasks, dependency updates, tooling changes
+
+### Examples
+
+```
+feat(http): add streaming response support
+```
+
+```
+fix(docx): handle corrupted image entries
+
+Previously, corrupted image entries in DOCX files caused a panic.
+Now we surface a proper error and abort gracefully.
+```
+
+```
+chore(deps): update zip to 2.2.1
+
+Security advisory GHSA-xxxx-xxxx-xxxx affects zip < 2.2.0.
+```
+
+### Guidelines
+
+- Use imperative mood: "add" not "added", "fix" not "fixed"
+- Do not capitalize the first letter of the description
+- No period at the end of the description
+- Keep the first line under 72 characters
+- Use the body to explain WHY the change was made, not WHAT was changed
+
+## Pull Requests
+
+### Opening a Pull Request
+
+- Push your branch to the repository
+- Open a pull request against `main`
+- Use conventional commit format for the PR title
+- Fill out the PR description template completely
+- Link related issues: `Fixes #123`, `Closes #456`, `Relates to #789`
+
+### Review Requirements
+
+Every pull request requires at least one reviewer approval before merging. Reviewers verify:
+- All CI checks pass (tests, lint, format)
+- Test coverage remains at or above 99.5%
+- New code has tests covering the changes
+- Public APIs are documented
+- Error handling is thorough (no unwrap, no expect)
+- Memory usage is reasonable and documented if changed
+- The change fits the streaming-first architecture
+
+### Review Process
+
+1. Author opens PR
+2. Reviewer requests changes or approves
+3. Author addresses feedback (amend and force push, or add commits)
+4. Reviewer approves or requests additional changes
+5. Once approved, the reviewer (not the author) merges
+
+Review is collaboration, not gatekeeping. Ask questions. Push back when needed.
+
+## Code Standards
+
+See [CODING_STANDARDS.md](CODING_STANDARDS.md) for complete rules. The essentials: no unsafe, no unwrap/expect, no #[allow], all public items documented, 99.5% test coverage, `cargo fmt` before every commit.
+
+## Adding Dependencies
+
+Every new dependency requires written justification in the pull request description. Dependencies are liabilities, not conveniences. Your justification must explain:
+- What problem the dependency solves
+- Why we cannot solve it ourselves in reasonable code
+- The transitive dependency count
+- The maintenance status
+- License compatibility
+
+Example:
+
+> Adding `memchr` for fast byte search within buffers.
+> Problem: We need to find byte sequences in streaming buffers efficiently.
+> Self-implementation: Possible but `memchr` uses SIMD and is heavily optimized.
+> Transitive deps: 0 (no dependencies)
+> Maintenance: Actively maintained by the `regex` crate author
+> License: MIT + Unlicense (compatible)
+
+## Versioning
+
+DocSpec follows strict Semantic Versioning (semver):
+
+- **MAJOR**: Breaking changes (API changes, behavior changes)
+- **MINOR**: New features, backwards compatible
+- **PATCH**: Bug fixes, backwards compatible
+
+### Breaking Changes
+
+Breaking changes ALWAYS bump the major version. No exceptions. Breaking changes include:
+- Removing or renaming public functions, types, or modules
+- Changing function signatures
+- Changing behavior of existing functions
+- Removing support for features or formats
+- Changing error types or their behavior
+
+During 0.x releases, breaking changes are expected and documented. After 1.0, breaking changes require strong justification. When in doubt, bump major.
+
+## Releases
+
+DocSpec uses [release-please](https://github.com/googleapis/release-please) to generate changelogs automatically from conventional commits. Do not edit the changelog manually—it is a function of commit history.
+
+### How It Works
+
+1. Commits land on main with conventional commit format
+2. Release Please opens a release PR when enough changes accumulate
+3. The release PR contains the proposed version bump and generated changelog
+4. A maintainer merges the release PR
+5. A new release is tagged and published automatically
+
+### Release Types
+
+- `feat` commits trigger a minor version bump
+- `fix` commits trigger a patch version bump
+- Commits with `BREAKING CHANGE` in the body trigger a major version bump
+
+### Writing Good Commit Messages for Changelog
+
+Your commit messages become the changelog. Write them for users, not for other maintainers.
+
+Bad: `fix(parser): handle edge case in loop`
+
+Better: `fix(docx): prevent panic on documents with missing content types`
+
+## Questions and Support
+
+- Open an issue for bug reports or feature requests
+- Use discussions for questions about usage or architecture
+- Read existing documentation before asking
+
+## Attribution
+
+Contributions are attributed in the git history. Your commits are your contribution record. By contributing, you agree that your contributions will be licensed under the same license as the project.
+
+---
+
+Thank you for helping make DocSpec better.

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -1,0 +1,207 @@
+# Streaming Events Specification
+
+DocSpec documents are streams of typed events. Readers emit events. Writers consume them. Events flow one at a time in document order. This specification defines every event type, its semantics, and the rules that govern well-formed streams.
+
+## Design Decisions
+
+**SAX-like structure.** Block elements use Start/End pairs.
+
+**Formatting as attributes.** Inline formatting lives on `Text` as attributes, not wrapper events. Links are the exception: they use Start/End because they carry `href`.
+
+**Semantic fidelity.** Events capture meaning, not appearance. Visual properties (font, color, size) are not represented — except mark color for highlighting.
+
+**Lazy asset references.** Images carry references, not bytes. Writers resolve via `AssetProvider`.
+
+**No warnings.** Errors are out-of-band via `Result`. Events carry content only.
+
+**Flat list model.** List items carry nesting level as a field. No `StartList`/`EndList`. Maps cleanly to DOCX/RTF where list structure is implicit.
+
+---
+
+## Error Handling
+
+```rust
+fn next_event(&mut self) -> Result<Option<Event>, Error>
+```
+
+| Return            | Meaning                      |
+| ----------------- | ---------------------------- |
+| `Ok(Some(event))` | Content event                |
+| `Ok(None)`        | Stream ended normally        |
+| `Err(e)`          | Fatal error, stop processing |
+
+Events never carry errors or warnings. If a reader cannot continue, it returns `Err`. If it can recover silently, it does — no event emitted for the recovery.
+
+**Recoverable:** missing optional attributes, unrecognized elements (skip them), unsupported features.
+**Fatal:** malformed structure, truncated stream, invalid encoding.
+
+---
+
+## Asset References
+
+```rust
+trait AssetProvider: Send + Sync {
+    fn content_type(&self, asset_ref: &str) -> Option<Cow<'_, str>>;
+    fn stream_to(&self, asset_ref: &str, writer: &mut dyn Write) -> Option<io::Result<u64>>;
+}
+```
+
+Readers register assets as encountered. Writers call `stream_to()` on demand — bytes stream, never buffer. Assets must remain accessible until `EndDocument`.
+
+---
+
+## Type Definitions
+
+```rust
+enum TextAlignment { Left, Center, Right, Justify }
+
+enum ListType { Ordered, Unordered }
+
+enum ListStyleType {
+    // Ordered list styles
+    Decimal, LowerAlpha, UpperAlpha, LowerRoman, UpperRoman,
+    // Unordered list styles
+    Disc, Circle, Square,
+}
+// Writers ignore mismatched styles (e.g., Disc on an ordered list).
+
+enum TableHeaderScope { Column, Row }  // Column: header describes cells below; Row: header describes cells to the right
+
+enum Color { Rgb { r: u8, g: u8, b: u8 } }
+
+enum ImageSource {
+    Asset { asset_id: String },   // resolved through AssetProvider
+    Uri { uri: String },          // external resource
+}
+
+struct DocumentMeta {
+    title: Option<String>,
+    authors: Option<Vec<Author>>,
+    description: Option<String>,
+}
+
+struct Author {
+    name: String,
+    email: Option<String>,
+}
+
+```
+
+All strings are UTF-8. No normalization form is required; readers preserve source encoding, writers preserve normalization.
+
+---
+
+## Event Reference
+
+All events in the `Event` enum, grouped by category.
+
+**Document structure:**
+
+| Event                  | Fields                                                       | Pair                 |
+| ---------------------- | ------------------------------------------------------------ | -------------------- |
+| `StartDocument`        | `language: Option<String>`, `metadata: Option<DocumentMeta>` | `EndDocument`        |
+| `StartHeading`         | `level: u8`                                                  | `EndHeading`         |
+| `StartParagraph`       | `alignment: Option<TextAlignment>`                           | `EndParagraph`       |
+| `StartBlockQuote`      | —                                                            | `EndBlockQuote`      |
+| `StartPreformatted`    | `syntax: Option<String>`                                     | `EndPreformatted`    |
+| `StartFootnote`        | `id: u32`                                                    | `EndFootnote`        |
+
+**Lists:**
+
+| Event            | Fields                                                                                         | Pair           |
+| ---------------- | ---------------------------------------------------------------------------------------------- | -------------- |
+| `StartListItem`  | `level: u8`, `list_type: ListType`, `start: Option<u32>`, `style_type: Option<ListStyleType>` | `EndListItem`  |
+
+**Tables:**
+
+| Event              | Fields                                                                                                    | Pair             |
+| ------------------ | --------------------------------------------------------------------------------------------------------- | ---------------- |
+| `StartTable`       | —                                                                                                         | `EndTable`       |
+| `StartCaption`     | —                                                                                                         | `EndCaption`     |
+| `StartTableRow`    | —                                                                                                         | `EndTableRow`    |
+| `StartTableHeader` | `scope: Option<TableHeaderScope>`, `abbr: Option<String>`, `colspan: Option<u32>`, `rowspan: Option<u32>` | `EndTableHeader` |
+| `StartTableCell`   | `colspan: Option<u32>`, `rowspan: Option<u32>`                                                            | `EndTableCell`   |
+
+**Definition lists:**
+
+| Event                   | Fields | Pair                  |
+| ----------------------- | ------ | --------------------- |
+| `StartDefinitionList`   | —      | `EndDefinitionList`   |
+| `StartDefinitionTerm`   | —      | `EndDefinitionTerm`   |
+| `StartDefinitionDetail` | —      | `EndDefinitionDetail` |
+
+**Inline containers:**
+
+| Event       | Fields                                  | Pair      |
+| ----------- | --------------------------------------- | --------- |
+| `StartLink` | `href: String`, `title: Option<String>` | `EndLink` |
+
+**Block (self-contained):**
+
+| Event           | Fields |
+| --------------- | ------ |
+| `ThematicBreak` | —      |
+
+**Inline (self-contained):**
+
+| Event         | Fields                                                                                                                                                                 |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Text`        | `content: String`, `bold: bool`, `italic: bool`, `code: bool`, `strikethrough: bool`, `underline: bool`, `subscript: bool`, `superscript: bool`, `mark: Option<Color>` |
+| `Image`       | `source: ImageSource`, `alt: Option<String>`, `title: Option<String>`, `decorative: bool`                                                                              |
+| `FootnoteRef` | `id: u32`                                                                                                                                                              |
+| `LineBreak`   | —                                                                                                                                                                      |
+
+---
+
+## Semantics
+
+Every `Start*` has a matching `End*`. They nest but never overlap.
+
+**Document.** The root container. `language` is a BCP 47 tag.
+
+**Heading.** Levels 1–6 are standard (HTML). DOCX/ODT/RTF support 1–9. Writers clamp higher levels. Both heading and list levels are 1-based (range 1–255); no format exceeds 9.
+
+**List items.** Nesting is flat — children follow parents sequentially, distinguished by `level`. No `StartList`/`EndList` exists. The `start` field sets numbering base until another `start` appears. **Boundary rules:** a new list begins when (a) a non-list block intervenes, (b) `list_type` changes at the same level, or (c) level decreases then increases without a parent.
+
+**Table.** `StartCaption` is optional, appears before rows. Header cells carry `scope`/`abbr` for accessibility; data cells omit these. Cells may contain any block element.
+
+**BlockQuote.** May contain any block element.
+
+**Preformatted.** When `syntax` is present, block has code semantics. Formatting attributes on inner `Text` are ignored. Newlines in content are literal.
+
+**Definition list.** Terms contain inline content only. Details can contain any block element.
+
+**Footnote.** Readers emit `StartFootnote` as soon as practical (placement varies by source format). `FootnoteRef` may appear before or after its corresponding `StartFootnote`. Writers decide final placement and must buffer if needed. Footnotes contain paragraphs only; this may relax in future.
+
+**Link.** An inline container (uses Start/End because it carries `href`). Valid inside paragraphs, headings, list items, cells, definition details. Cannot nest.
+
+**Text.** Formatting changes produce new events. Default: all bools `false`, mark `None`. Empty content is valid but meaningless. `subscript` and `superscript` may both be true; writers that can't represent both prefer `superscript`. Whitespace is significant. Outside preformatted blocks, newlines in content are collapsed to whitespace; readers emit `LineBreak` for semantically meaningful line breaks.
+
+**Image.** Asset bytes resolve lazily via `AssetProvider`. `decorative` means purely visual. May appear inline or directly in block containers.
+
+**FootnoteRef.** Inline marker; corresponding `StartFootnote` appears elsewhere.
+
+**LineBreak.** Soft break within a block.
+
+**ThematicBreak.** Horizontal rule / section separator.
+
+---
+
+## Well-Formedness Rules
+
+Readers MUST produce well-formed streams. Writers MAY assume well-formedness.
+
+1. Every `Start*` has exactly one matching `End*`. They nest but never overlap.
+2. Exactly one root: `StartDocument`. Empty containers (`Start*` immediately followed by `End*`) are valid.
+3. `Text` appears only inside containers, never at root.
+4. `StartLink` appears inside inline-accepting blocks (paragraphs, headings, list items, cells, definition details). Links do not nest.
+5. `StartListItem` appears inside block containers. List items are flat — distinguished by `level` field.
+6. `StartCaption` appears at most once per table, before any rows.
+7. Each footnote ID appears in exactly one `FootnoteRef` and one `StartFootnote`.
+8. Table structure: `StartTableRow` appears only inside `StartTable`. `StartTableCell`/`StartTableHeader` appear only inside `StartTableRow`.
+
+---
+
+## Future Extensions
+
+Deferred (non-breaking additions): named styles, visual properties (`StartSpan`), table sections/metadata, figure/caption, page/section breaks, anchors, in-stream warnings, embedded objects.

--- a/MANIFESTO.md
+++ b/MANIFESTO.md
@@ -1,0 +1,107 @@
+# DocSpec Manifesto
+
+We are memory extremists. We do not apologize for this. We do not compromise.
+
+## The River and the Lake
+
+Software today treats memory like an infinite resource. A single web page consumes more RAM than an entire operating system from two decades ago. Document conversion libraries load entire files into memory before processing a single byte. A 100 MB document becomes 500 MB in heap allocation. This is not engineering. This is negligence.
+
+There is no memory availability crisis. There is a *use* crisis. Your laptop has 16 GB. Your phone has 8 GB. But software squanders it with lazy abstractions, unnecessary buffering, and the assumption that garbage collection will clean up the mess.
+
+Somewhere along the way, the industry decided that hardware would always outpace software's appetite. That Moore's Law would forever excuse Moore's waste. This bet has failed. Devices are plateauing. Edge computing is growing. Embedded systems are everywhere. And the software that runs on them still behaves as if it owns the machine.
+
+We believe something different. Software should earn every byte it uses. Not borrow. Not assume. Earn. Justify. Document. Every allocation must have a purpose. Every buffer must have a boundary. This is not austerity. This is respect, for the hardware, for the user, for the craft.
+
+A document is not a tree sitting in memory. A document is a river.
+
+It has a source and a mouth. Between them, the water moves. It does not stop. It does not pool. It flows. You do not drain a river into a lake to study it. You stand at the bank and observe what passes.
+
+DocSpec treats documents this way. A reader stands at the source, parsing bytes into a stream of structured events, one at a time, in document order. A writer stands at the mouth, consuming those events and emitting bytes in the target format. Between them, nothing accumulates. Everything moves.
+
+This is not a performance optimization bolted onto a conventional design. This is the architecture. The streaming model is not what DocSpec *does*. It is what DocSpec *is*. Every design decision flows from this constraint. The decoupled readers and writers exist because we need to mix and match without buffering intermediates. The strict error handling exists because we cannot afford to crash and restart with half a document still in a pipe.
+
+The result is a library that converts between any supported format combination on a $5 microcontroller with 512 KB of RAM. Not as a party trick. As proof. Proof that streaming-first, memory-conscious design works at the extreme edge. Proof that constraints do not limit, they liberate. When you cannot buffer the world, you must design for flow. When you cannot allocate freely, you must think clearly.
+
+The same code runs unchanged on servers with gigabytes of memory, in browsers through WebAssembly, on desktops and phones and devices that do not exist yet. The architecture that works under extreme constraint works everywhere. That is not a coincidence. That is the point.
+
+## The Language of Proof
+
+We chose Rust because it shares our values.
+
+Memory layout, allocation, lifetimes, all explicit, all controlled, all visible. No garbage collector making decisions behind our backs. The borrow checker enforces at compile time what other languages discover at runtime through crashes and memory leaks. Every byte accounted for. Every lifetime proven correct. Before the program runs.
+
+Rust is not our religion. It is our tool. The type system is our safety net. The ownership model is our guide. The lack of garbage collection is not a limitation, it is a liberation. We decide when memory is allocated, when it is freed, and how it is laid out. Other languages ask you to trust the runtime. Rust asks you to prove your intent. We prefer proof.
+
+## What We Owe to Each Other
+
+Our library runs inside other people's applications. We are guests in their process. We must be good citizens, frugal, predictable, respectful. Every byte we allocate is a debt against someone else's system. We profile obsessively. We measure. We count allocations per document. We earn our footprint, because the alternative is stealing someone else's.
+
+Data flows event by event. Nothing accumulates. Readers produce events. Writers consume them. Any reader connects to any writer. The event model is universal. An embedded image never sits fully in memory, it streams through, chunk by chunk, from source to sink. The only acceptable reason to buffer is when the format itself demands random access, and even then, we buffer the minimum. Everything else flows.
+
+On corruption or error, we surface it immediately. No partial output. No silent truncation. A failed conversion is better than a wrong conversion. Wrong conversions propagate, corrupt databases, and erode the trust that takes years to build. Partial success is failure in disguise. Every operation that can fail returns a Result. Every error propagates with context. Every panic is a bug we must fix.
+
+The workspace forbids unsafe code entirely. No exceptions. We do not suppress warnings. If the compiler is unhappy, we fix the code. The linter is not an annoyance. It is a collaborator. These are not rules we follow because someone told us to. They are constraints we chose because they make the code better than we could make it alone.
+
+Good architecture is fast architecture. Not because of compiler flags or micro-optimizations, but because the design respects the machine. Cache-friendly data structures. Zero-copy where possible. Allocation pools. Streaming instead of buffering. These are architectural decisions, not afterthoughts. Performance is not a feature you bolt on at the end. It is a property you maintain from the start, or you never have it at all.
+
+Every dependency is a bet on someone else's priorities, someone else's schedule, someone else's security practices. They update. They break. They carry transitive weight. Small code you wrote and understand is better than large code you imported and hope works. Every dependency must earn its place with written justification. If we can build it ourselves within reason, we do.
+
+Documentation is not separate from code. It is code. Every public item is documented. Every function has a doc comment. Every module has a purpose statement. Undocumented code does not compile. Code tells you what it does. Documentation tells you why. "I will document it later" is a promise that is never kept. We document now, or we do not ship.
+
+## The Diseases We Refuse to Catch
+
+We have watched projects die from the same diseases, and we refuse to catch them.
+
+The performance trap: "It works on my machine." "The tests pass." "It is fast enough for now." These phrases sound reasonable. They are not. They are the slow death of quality, the quiet acceptance that things will get worse, the assumption that someone else will fix it later. No one fixes it later. We measure. We track. We regress. Every change is checked for impact.
+
+The abstraction trap: treating memory like an infinite scroll, trusting the runtime to clean up, buffering because it is easier than streaming. Easier for the developer. Brutal for the user. We choose the harder path, not because we enjoy difficulty, but because the harder path is the honest one. Streaming is harder to write. It is also the only way to process a document larger than available memory. We do not choose between easy and correct. We choose correct.
+
+The debt trap: skipping tests, relaxing coverage, suppressing warnings instead of fixing code, merging without review, documenting later. Every shortcut is a crack in the foundation. Projects that tolerate cracks eventually collapse under their own weight. We are rigorous not because we distrust contributors, but because we respect the codebase enough to keep it whole.
+
+## The Proof Is in the Running
+
+DocSpec converts documents on microcontrollers. Any reader to any writer. Streaming. Event-based. Memory-conscious. This is not marketing. This is validation.
+
+The constraints forced us to be good. The constraints kept us honest. And the same discipline that lets us run on 512 KB of RAM also makes us fast, portable, and reliable on machines with a thousand times more. Efficiency does not trade off against capability. Efficiency *is* capability.
+
+## The World We Are Building
+
+We build DocSpec for developers integrating document conversion into their applications. But the vision extends beyond our library.
+
+Imagine software that does not force you to upgrade your hardware. Software that runs on the phone you already own, the laptop you bought five years ago, the device that will never see another firmware update. Software that does not assume a fast connection to someone else's cloud. Software that works *here*, on *this* machine, with *these* resources, and works well.
+
+This is sovereignty. When your tools do not demand the latest hardware, you are free to choose when to upgrade, or not to. When your software does not phone home, you own your workflow. When a library respects the memory it is given, it collaborates with every other piece of software on the system instead of competing with them.
+
+Efficient software is also collaborative software. A library that takes only what it needs leaves room for everything else. A process that streams instead of buffering lets the operating system breathe. A tool that fails clearly and immediately lets the developer fix the problem instead of chasing ghosts. This is what it means to be a good citizen of someone else's system.
+
+We believe the industry can build this way. Not every project will run on a microcontroller, nor should they. But every project can ask the question: *do we need this allocation?* Every project can measure its footprint. Every project can stream instead of buffer, fail fast instead of fail silently, document instead of defer.
+
+The future of software is not in bigger machines. It is in better code. Code that respects resources. Code that respects users. Code that gives people sovereignty over their own hardware.
+
+## For Those Who Build With Us
+
+If you are here to contribute: welcome. Know what you are joining.
+
+We are not relaxed. We are not permissive. We have standards, and we enforce them, not as gatekeeping, but as stewardship. Your code will be reviewed carefully. Your tests must pass. Your documentation must be complete. This is how we keep the project alive. This is how we keep the project worth contributing to.
+
+If this sounds demanding, consider the alternative. Projects without standards accumulate debt, become impossible to maintain, and die. We want DocSpec to live. We want it to thrive. Discipline is how.
+
+We want your contributions. We want your ideas. We want your energy. We want them within the boundaries that make them lasting.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and [CODING_STANDARDS.md](CODING_STANDARDS.md) for the technical details.
+
+## For Those Who Build On Us
+
+If you use DocSpec: thank you. You are why we exist.
+
+You do not need to know the manifesto to use the library. But we hope you feel the difference. The conversions that complete without devouring your RAM. The errors that tell you exactly what went wrong. The documentation that actually answers your questions. The dependency that earns its place in your project the way we demand every dependency earns its place in ours.
+
+This is what software should be. Focused. Efficient. Honest. We respect your resources. We respect your time. We respect your trust.
+
+## The Invitation
+
+We are memory extremists. We convert documents using less memory than most applications use to display a settings dialog. We do it safely. We do it correctly. We do it with discipline.
+
+But this manifesto is not really about memory. It is about care. Care for the machine that runs the code. Care for the developer who reads it. Care for the user who depends on it. Care for the craft of building software that lasts.
+
+Software should earn every byte it uses. We write software that does. We invite you to write it with us.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,64 @@
+# DocSpec
+
+DocSpec is a streaming document conversion library. It converts DOCX, ODT, RTF, HTML, Markdown, and BlockNote JSON — event by event, byte by byte, without buffering the world. Built in Rust for memory-conscious systems, from microcontrollers to servers.
+
+## Philosophy
+
+See our [Manifesto](MANIFESTO.md) for what we stand for: memory extremism, streaming-first design, and the belief that software should earn every byte it uses.
+
+## Supported Formats
+
+| Format | Read | Write |
+|--------|------|-------|
+| DOCX | ✓ | — |
+| ODT | ✓ | — |
+| RTF | ✓ | ✓ |
+| HTML | ✓ | ✓ |
+| Markdown | ✓ | ✓ |
+| BlockNote JSON | ✓ | ✓ |
+
+## Quick Start
+
+DocSpec works through a pipeline of readers and writers. A reader (EventSource) parses a document and emits events: StartParagraph, Text, EndParagraph, StartHeading, etc. A writer (EventSink) consumes these events and produces output in the target format.
+
+The architecture is fully decoupled. Any reader connects to any writer. A DOCX reader can feed a Markdown writer. An HTML reader can feed BlockNote JSON. The events are the contract.
+
+To convert a document:
+
+1. Create a reader for your input format
+2. Create a writer for your output format
+3. Connect them through the event pipeline
+4. Let the events flow
+
+No buffering. No intermediate representations. No loading the entire document into memory. The document streams through, event by event.
+
+## Documentation
+
+- **[Manifesto](MANIFESTO.md)** — Philosophy and values: memory extremism, streaming design, quality standards
+- **[Architecture](ARCHITECTURE.md)** — Streaming pipeline design, reader/writer contracts
+- **[Events](EVENTS.md)** — Streaming event types, well-formedness rules
+- **[Coding Standards](CODING_STANDARDS.md)** — Code style rules, formatting conventions, review checklist
+- **[Contributing](CONTRIBUTING.md)** — How to contribute, PR process, development workflow
+- **[Testing](TESTING.md)** — Test philosophy, coverage requirements, testing patterns
+- **[Security](SECURITY.md)** — Security principles, vulnerability reporting, safe practices
+- **[Agents](AGENTS.md)** — Guidance for AI agents analyzing or contributing to this codebase
+
+## Core Principles
+
+- **Memory Conscious**: Every byte allocated must justify its existence. We measure, profile, and optimize relentlessly.
+- **Streaming First**: Data flows event by event. Nothing accumulates. Everything moves.
+- **Fail Fast**: On corruption or error, surface it immediately. No partial output. No silent truncation.
+- **No Unsafe Code**: The workspace forbids unsafe entirely. Safety is not a limitation; it is a foundation.
+- **Strict Quality**: 99.5% test coverage from day one. No unwrap. No expect. No warning suppressions.
+
+## Why Rust
+
+We chose Rust because it gives us control: memory layout, allocation, lifetimes — without a garbage collector making decisions for us. The borrow checker enforces at compile time what other languages discover at runtime through crashes. Ownership is not a feature; it is a discipline.
+
+## Status
+
+DocSpec is under active development. The architecture is stable. The event model is defined. Readers and writers are being implemented incrementally.
+
+## License
+
+See LICENSE file.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,140 @@
+# Security Principles
+
+This document describes the security philosophy and principles that guide how we build DocSpec. It is not a threat model, vulnerability policy, or security audit. It is how we think about security.
+
+---
+
+## 1. Memory Safety as the Foundation
+
+DocSpec is written in Rust with `unsafe_code` forbidden. Memory safety is not a feature we added. It is the default. Buffer overflows, use-after-free, data races: these entire categories of vulnerability are eliminated by construction.
+
+This matters for a document conversion library. Document formats are complex. Parsers for complex formats have historically been fertile ground for memory corruption vulnerabilities. We eliminate this risk at the language level.
+
+The manifesto says: "The compiler is our ally. We do not bypass it." This applies doubly to security. Every bounds check is enforced. Every lifetime is verified. Every pointer is valid or it does not compile.
+
+Memory safety is our first line of defense. It is not perfect — logic errors still exist — but it removes the most common and most dangerous class of security bugs entirely. An attacker cannot exploit a buffer overflow in our code because the language makes buffer overflows impossible.
+
+This is why we forbid unsafe code completely. There are no exceptions. No special cases. If you cannot do it safely, you do not do it. Period.
+
+The choice of Rust is a security decision. Other languages could work. Rust works best because it gives us safety without sacrificing performance. We do not need to choose between fast and safe. We get both.
+
+---
+
+## 2. Error Handling as a Security Boundary
+
+How errors are reported depends on the context. The principle: do not leak internal details to untrusted surfaces.
+
+For CLI tools: the user is a developer or administrator. More detail is appropriate. Full error messages including context help diagnose problems. Stack traces can be enabled with flags. File paths are shown because the user needs to know which file failed.
+
+For library users: the caller receives typed error values. They decide what to show to their users. The library does not make this decision for them. A library user might be building a web service, a desktop app, or an embedded system. Each has different security requirements. We provide the error; they handle the disclosure.
+
+The general rule: the closer to an untrusted surface, the less detail the error contains. Information leakage is a vulnerability. Error messages that reveal internal structure help attackers craft better attacks. We do not help attackers.
+
+---
+
+## 3. Input Validation Philosophy
+
+All input is untrusted. Every byte of every document comes from outside the process — from a user, a network, a filesystem. We parse defensively.
+
+Parsers fail fast on malformed input rather than attempting recovery. A malformed ZIP structure in a DOCX file returns an error immediately. No attempt to "guess" at the correct structure. No partial parsing that could produce wrong output that looks correct.
+
+This is the "fail fast" principle from our manifesto applied to security. A failed conversion is better than a wrong conversion. Wrong conversions propagate. They corrupt databases. They break trust. When the input is broken, we say so immediately.
+
+Parsers are hardened against malicious input through continuous fuzzing. Fuzz tests send random and adversarial byte sequences at every parser. The goal: no input causes a crash, a panic, or undefined behavior. The fuzz corpus grows as new edge cases are discovered.
+
+Fuzzing runs in CI on every commit. It runs for hours, not minutes. We use coverage-guided fuzzing to find inputs that exercise new code paths. We track the corpus over time. A crash in fuzzing is treated as a security bug, even if it seems hard to exploit. We fix it.
+
+Document formats are attack surfaces. A malicious DOCX could try to exploit a ZIP parser. A malformed HTML document could try to cause excessive memory use. Our parsers are designed to handle these cases gracefully. They validate. They limit. They fail safely.
+
+---
+
+## 4. Resource Limits
+
+Parsers and converters enforce resource bounds. Memory caps prevent a single large document from exhausting the process. Time limits prevent denial of service through documents designed to be slow to process.
+
+Specific bounds depend on the integration surface:
+
+- Inline assets (embedded images) are capped at a maximum size before streaming to output
+- Nested structure depth is limited (e.g., maximum table nesting, list nesting) to prevent stack exhaustion
+- Integrators can configure per-conversion timeouts and maximum input sizes
+
+These limits exist in the implementation. They are not suggestions. They are enforced at the appropriate layer. The parser enforces nesting limits during processing. The converter tracks resource usage.
+
+Resource limits protect against denial of service. A malicious user could upload a document designed to consume excessive memory or CPU. The limits prevent this. A document that exceeds limits fails fast with a clear error message. The server remains stable. Other requests are not affected.
+
+The streaming architecture helps here. Because we process documents as streams rather than loading them whole, we can handle documents larger than available memory. But we still enforce limits. A document with a billion nested tables will hit the nesting limit and fail. This protects the stack and prevents infinite loops.
+
+---
+
+## 5. Dependency Security
+
+Every dependency is a potential attack surface. We minimize the dependency count deliberately. We audit dependencies with cargo-deny, checking for known security advisories. Dependencies from unknown registries or unverified git sources are blocked.
+
+When a security advisory is published for a dependency we use, we update within 24 hours. Non-critical advisories are tracked and resolved in the next scheduled release.
+
+The manifesto says: "Dependencies are not free. They are liabilities." This is especially true for security. Each dependency is code we did not write but must trust. We keep that trust surface small.
+
+Our cargo-deny configuration:
+- Blocks dependencies with known security advisories
+- Blocks dependencies from unknown registries
+- Blocks git dependencies that are not explicitly allowed
+- Requires license verification for all dependencies
+
+We review dependencies before adding them. We ask: what is the security track record? How quickly do they fix vulnerabilities? How many transitive dependencies do they bring? A dependency with 50 sub-dependencies is 50 times more attack surface. We avoid such dependencies when possible.
+
+Vendoring is our friend. When a dependency is small and critical, we consider vendoring it. This means copying the code into our repository. We trade update convenience for control. We can review the code. We can fix issues ourselves. We are not dependent on upstream responsiveness.
+
+---
+
+## 6. Reporting Vulnerabilities
+
+If you find a security vulnerability, do not open a public issue. Contact the maintainers privately at security@docspec.dev.
+
+We will work with you to understand the vulnerability, develop a fix, and coordinate disclosure. Our goal is to protect users while giving you credit for the discovery.
+
+We commit to:
+
+- Acknowledging receipt within 48 hours
+- Providing a timeline for the fix within 7 days
+- Keeping you informed of progress
+- Coordinating disclosure when the fix is released
+
+Public disclosure before a fix is available helps attackers, not users. Please give us time to do this right.
+
+When you report a vulnerability, please include:
+- A description of the vulnerability
+- Steps to reproduce (if possible)
+- The impact you believe it has
+- Whether you have found it in the wild or through analysis
+
+We appreciate security researchers. We will not take legal action against researchers who follow responsible disclosure. We will not blame you for finding our mistakes. We will thank you and fix the issue.
+
+Security researchers who report valid vulnerabilities will be acknowledged in our release notes and security advisories, unless they prefer to remain anonymous. We believe in giving credit where credit is due.
+
+---
+
+## Summary
+
+Security in DocSpec is not a separate concern. It flows from our core values:
+
+- Memory safety through Rust's type system
+- Defensive parsing through fail-fast validation
+- Least-privilege error handling through context-aware reporting
+- Resource protection through enforced limits
+- Supply chain security through minimal, audited dependencies
+
+We build secure software by building correct software. The two are the same. Every principle in our manifesto — fail fast, no unsafe code, strict quality — contributes to security.
+
+We do not claim to be perfect. Vulnerabilities may exist. When they are found, we fix them quickly. We learn from them. We improve.
+
+This is our commitment to our users: we take security seriously. We design for it. We test for it. We respond to it. You can trust DocSpec with your documents because we have built it to be trustworthy.
+
+---
+
+## Related Documents
+
+- **[MANIFESTO.md](MANIFESTO.md)** — Our core philosophy and values
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — Technical design and streaming pipeline
+- **[CODING_STANDARDS.md](CODING_STANDARDS.md)** — Code quality and review standards
+
+These documents work together. The manifesto explains why we care about security. The architecture explains how we implement it. The standards explain how we maintain it.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,161 @@
+# Testing Philosophy
+
+Testing is not a step that happens after development. It is development. Every feature, every bug fix, every refactor comes with tests that prove it works. Untested code is incomplete code.
+
+We target 99.5% test coverage from day one. Not as an aspirational goal. As a floor. The 0.5% tolerance exists for genuinely untestable code: platform-specific initialization, embedded hardware interaction, code that interfaces with external systems beyond our control. If your code does not have tests, it is not done.
+
+## Why 99.5%
+
+Coverage is not a perfect metric. You can have 100% coverage and still have bugs. But low coverage guarantees bugs — code that has never been executed by a test has never been verified. High coverage forces you to think about every path, every edge case, every failure mode.
+
+Going from 80% to 99.5% coverage catches the subtle bugs, the edge cases, the error paths that only trigger in production. These are the bugs that corrupt data. These are the bugs that crash servers. These are the bugs we refuse to ship.
+
+99.5% is not perfectionism. It is discipline. It says we do not ship code we have not thought carefully about. It says we respect our users enough to verify our work.
+
+The 0.5% gap is a recognition that some code lives at the boundary between our system and the outside world. Code that talks to hardware. Code that interfaces with the operating system. Code that handles signals we cannot simulate. Everything else gets tested.
+
+We track coverage religiously. We run coverage reports on every build. We review coverage in pull requests. We question any drop in coverage. Coverage is a team metric, not an individual one.
+
+High coverage is not achieved by writing bad tests that cover lines without asserting anything. Coverage is meaningful only when tests are meaningful. Write assertions. Check the output. Verify the error. Test the edge case. Coverage is a side effect of thoroughness, not the goal itself. A line that is covered but not asserted is not really tested.
+
+## Test-Driven Development
+
+TDD is our preferred approach: write a failing test first, then write the minimum code to make it pass, then refactor. This sequence forces you to think about the interface before the implementation. It prevents over-engineering.
+
+TDD is preferred, not mandated. What is mandated is coverage. Tests may come during or after implementation, but they must come before the PR is merged.
+
+When you practice TDD, you discover the interface through use. The test becomes a design tool, not just a verification tool. But we accept that not every problem yields to this approach. Write the tests when you understand the problem.
+
+The TDD cycle is red, green, refactor. Red: write a test that fails. Green: write the minimum code to make it pass. Refactor: clean up the code while keeping tests passing. This rhythm produces clean, tested code and prevents technical debt.
+
+Code written with TDD tends to be more modular with clearer interfaces and better testability. These properties make the code easier to maintain, extend, and understand.
+
+## Test Types
+
+We use multiple test types because no single approach catches every kind of bug. Each type has a purpose. Each type finds different problems.
+
+### Unit Tests
+
+Unit tests verify individual components in isolation. A parser for a single XML element. A function that converts an event to a string. A utility that escapes special characters. Isolated, fast, focused. They catch logic errors at the component level.
+
+A good unit test has a clear purpose. It tests one thing. It has a descriptive name that explains what is being verified. It sets up minimal state and runs quickly.
+
+Unit tests are the foundation. They are the majority of our test suite. They run on every build in milliseconds, giving immediate feedback when something breaks.
+
+Write unit tests for pure functions, stateless transformations, algorithms, and anything that can be tested in isolation. The more you can test in isolation, the faster your tests run and the clearer your failures are.
+
+Unit tests are also documentation. They show how a function is supposed to be called, what inputs are valid, and what outputs to expect.
+
+### Integration Tests
+
+Integration tests verify components working together. A reader that produces events from a real document format. A writer that produces valid output. A pipeline that connects reader to writer and produces the expected result. They catch interface errors and unexpected interactions.
+
+Integration tests are slower than unit tests and involve more setup, but they find the bugs that unit tests miss: mismatched assumptions between components, subtle incompatibilities in data formats, and ordering problems.
+
+Integration tests use real dependencies and verify that the system works as a whole. They are also the best place to verify error handling, ensuring that errors propagate correctly through the pipeline.
+
+### Snapshot Tests
+
+Snapshot tests capture the exact output of a conversion and alert on any change. They are invaluable for regression testing: if the output changes, a snapshot test fails, forcing a deliberate decision about whether the change is intentional.
+
+Snapshots are change detectors. When a snapshot test fails, you must decide: is this change correct? If yes, update the snapshot. If no, fix the code.
+
+We use snapshots for output formats that are stable and well-defined: HTML output, Markdown rendering, JSON serialization. Snapshots make changes visible in code review and provide a history of how output has evolved.
+
+Snapshots also serve as regression tests. When a bug is fixed, we add a snapshot of the correct output. If the bug ever returns, the snapshot test will fail.
+
+### Fuzz Tests
+
+Fuzz tests send random, malformed, and adversarial inputs at the parsers. The goal is simple: do not crash. A parser must handle any byte sequence without panicking.
+
+Fuzzing is about robustness, not correctness of output. A malformed document should produce an error, not a crash. An unexpected byte sequence should be rejected gracefully.
+
+We run fuzzers continuously. They generate millions of inputs and find edge cases we would never think to test. Fuzzing hardens the code against the real world, where inputs are not always well-formed.
+
+Fuzzing is especially important for document parsers. Documents come from everywhere. They are corrupted in transmission, malformed by buggy software, and crafted by attackers. Fuzzing ensures our parsers handle all of these gracefully.
+
+### Roundtrip Tests
+
+Roundtrip tests convert a document from format A to format B and back to format A, verifying the result matches the original. They catch semantic loss in conversion pipelines.
+
+Not all conversions are reversible. Some formats lose information, and some formats only have readers (no writers). But where roundtripping is possible, we test it. An HTML file converted to Markdown and back to HTML should preserve semantic content.
+
+Roundtrip tests validate our understanding of the formats. If we cannot roundtrip a document, we may not fully understand the format. The test forces us to learn and handle edge cases we might otherwise miss.
+
+## Test Data and Fixtures
+
+Tests use representative documents from real-world sources. Not toy examples. Real DOCX files from word processors. Real ODT files with complex formatting. Real HTML from actual websites.
+
+Fixtures are checked into the repository. They are first-class artifacts, not afterthoughts. When a bug is found in production, the first step is to create a fixture that reproduces it. The fixture stays in the repository forever, preventing regression.
+
+A good fixture is minimal but complete. It contains the minimum structure needed to reproduce the issue, but it is a valid document. It has a descriptive name and lives in the fixtures directory, organized by format and purpose.
+
+We do not generate fixtures programmatically unless the generation itself is under test. Real files from real sources are preferred. They contain the complexity that synthetic data misses.
+
+Fixtures are documentation too. They show what kinds of documents we handle and demonstrate the complexity we support.
+
+## The Fail-Fast Test Principle
+
+Tests fail loudly and specifically. A failing test tells you exactly what failed: which input, which output, what was expected, what was received. Vague test failures are not acceptable.
+
+Good assertions are specific. They check exact values, not just presence or absence. They compare the full output, not just a substring. They fail with messages that explain the context.
+
+When a test fails, you should know immediately what went wrong. You should not need to add print statements or run the test again with debugging enabled. The failure message should be enough.
+
+Specific failures save time and prevent cascading failures. When a test fails early, you fix it before moving on.
+
+## Test as Documentation
+
+A test is a specification. It says "given this input, I expect this output." Reading the tests tells you how the code is supposed to work. Test names matter: "converts_nested_list_to_html" is better than "test_1".
+
+Write tests that are readable. Another developer should be able to understand what is being tested without reading the implementation. The test should tell a story: here is the setup, here is the action, here is the expected result.
+
+Tests are the first documentation a new contributor reads. They show how the code is used, demonstrate the API, and provide examples that compile and run.
+
+When documentation and tests disagree, the tests are right. Update the documentation to match. Or update the tests if the behavior is wrong. But do not let them diverge.
+
+Readable tests use helper functions to reduce boilerplate and descriptive variable names. Structure tests in three parts: arrange, act, assert. This structure makes tests easy to scan and understand.
+
+Tests should be independent. Each test should set up its own state and clean up after itself. Tests should not depend on the order in which they run.
+
+## Testing and Refactoring
+
+Tests enable refactoring. Without tests, refactoring is dangerous. With tests, you change code and know. The tests are the safety net.
+
+Refactoring without tests is not refactoring. It is rewriting. It is risky. It introduces bugs.
+
+When you refactor, run the tests. All of them. If they pass, your refactoring preserved behavior. If they fail, you made a mistake. Fix it.
+
+Good tests are independent of implementation details. They test behavior, not structure. When you refactor, the tests should continue to pass.
+
+Refactoring is how we keep the codebase healthy. Tests are what make refactoring possible. Together, they enable continuous improvement without fear.
+
+## Testing in the Embedded Context
+
+DocSpec runs on microcontrollers with 512 KB of RAM. Tests must respect this constraint. We do not allocate huge buffers in tests. We do not load massive fixtures. We test with the same discipline we apply to production code.
+
+Tests run on the target hardware when possible. They run in constrained environments. They verify that the code works within the limits it was designed for.
+
+Memory-conscious testing means using small fixtures, cleaning up after tests, and not leaking resources. Write tests that would run on a microcontroller.
+
+Embedded tests also verify timing constraints and memory usage stays within bounds.
+
+## The Testing Mindset
+
+Testing is not a chore. It is a way of thinking about code. It is the discipline of verification.
+
+When you write code, ask: how do I know this works? When you fix a bug, ask: how do I know this stays fixed? When you review code, ask: where are the tests?
+
+The testing mindset is skeptical. It does not trust. It verifies. It assumes code is wrong until proven otherwise. This skepticism produces better software.
+
+Testing is a skill. It improves with practice. Write more tests. Read tests. Review tests. Learn what makes a test good.
+
+Good testers are skeptical. They question assumptions. They look for edge cases. They think about what could go wrong. This mindset is valuable beyond testing.
+
+We are memory extremists. We are also testing extremists. We do not ship code we have not verified. We do not trust code we have not tested.
+
+Testing is how we honor our users and the craft. It is how we build software that lasts. Every test is a promise that the code works and will keep working.
+
+The test suite is our safety net. It catches us when we fall. It gives us the courage to refactor and the confidence to release.
+
+Quality is not an accident. It is the result of discipline, care, and verification. Testing is the verification. It is how we know we have done things right.


### PR DESCRIPTION
Adds the foundational documentation for DocSpec covering architecture, coding standards, and contribution guidelines.

## What's included

- **MANIFESTO.md** - Project philosophy: streaming-first, memory-conscious design
- **ARCHITECTURE.md** - Pull-based event pipeline, sync-first model, extension points
- **EVENTS.md** - Full event type reference with well-formedness rules
- **CODING_STANDARDS.md** - No unsafe, no unwrap, no #[allow], 99.5% coverage
- **CONTRIBUTING.md** - Conventional commits, PR process, semver policy
- **TESTING.md** - Coverage requirements, fuzz testing, roundtrip tests
- **SECURITY.md** - Error handling by context, resource limits, input validation
- **AGENTS.md** - Quick reference for contributors
- **README.md** - Project overview and format support matrix

## Design decisions documented

- Pull model for backpressure (source.next_event() not push)
- Flat list model (level field, no StartList/EndList)
- Formatting as Text attributes, not wrapper events
- Links as exception (Start/End because they carry href)

Cross-referenced everything for consistency. Should be ready for implementation work to begin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive project documentation including README, manifesto, architecture, event specifications, coding standards, contribution guidelines, testing philosophy, and security policies.

* **Chores**
  * Added pre-commit configuration to enforce Conventional Commits format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->