### PR TITLE
feat: expand markdown reader and BlockNote writer support

### DIFF
--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -92,6 +92,31 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         Ok(())
     }
 
+    fn handle_blockquote(&mut self, id: Option<&String>) -> Result<()> {
+        self.close_text_block_if_needed()?;
+        self.writer.begin_object().map_err(io_err)?;
+        self.writer.name("type").map_err(io_err)?;
+        self.writer.string_value("quote").map_err(io_err)?;
+        self.write_id(id)?;
+
+        self.writer.name("content").map_err(io_err)?;
+        self.writer.begin_array().map_err(io_err)?;
+
+        self.in_text_block = true;
+        Ok(())
+    }
+
+    fn handle_divider(&mut self, id: Option<&String>) -> Result<()> {
+        self.close_text_block_if_needed()?;
+        self.writer.begin_object().map_err(io_err)?;
+        self.writer.name("type").map_err(io_err)?;
+        self.writer.string_value("divider").map_err(io_err)?;
+        self.write_id(id)?;
+        self.writer.end_object().map_err(io_err)?;
+
+        Ok(())
+    }
+
     fn handle_heading(&mut self, level: u8, id: Option<&String>) -> Result<()> {
         self.close_text_block_if_needed()?;
         self.writer.begin_object().map_err(io_err)?;
@@ -153,10 +178,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         let caption = alt.unwrap_or_default();
 
         self.writer.begin_object().map_err(io_err)?;
-        if let Some(id_val) = id {
-            self.writer.name("id").map_err(io_err)?;
-            self.writer.string_value(id_val).map_err(io_err)?;
-        }
+        self.write_id(id)?;
         self.writer.name("type").map_err(io_err)?;
         self.writer.string_value("image").map_err(io_err)?;
         self.writer.name("props").map_err(io_err)?;
@@ -179,10 +201,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
     fn handle_paragraph(&mut self, id: Option<&String>) -> Result<()> {
         self.close_text_block_if_needed()?;
         self.writer.begin_object().map_err(io_err)?;
-        if let Some(id_val) = id {
-            self.writer.name("id").map_err(io_err)?;
-            self.writer.string_value(id_val).map_err(io_err)?;
-        }
+        self.write_id(id)?;
         self.writer.name("type").map_err(io_err)?;
         self.writer.string_value("paragraph").map_err(io_err)?;
         self.writer.name("props").map_err(io_err)?;
@@ -282,8 +301,18 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
                 self.writer.end_array().map_err(io_err)
             }
             Event::StartHeading { level, id, .. } => self.handle_heading(level, id.as_ref()),
-            Event::EndHeading | Event::EndParagraph => self.close_text_block_if_needed(),
+            Event::EndHeading
+            | Event::EndParagraph
+            | Event::EndBlockQuote
+            | Event::EndPreformatted
+            | Event::EndTable
+            | Event::EndTableCell
+            | Event::EndTableHeader
+            | Event::EndTableRow
+            | Event::EndListItem => self.close_text_block_if_needed(),
             Event::StartParagraph { id, .. } => self.handle_paragraph(id.as_ref()),
+            Event::StartBlockQuote { id, .. } => self.handle_blockquote(id.as_ref()),
+            Event::ThematicBreak { id, .. } => self.handle_divider(id.as_ref()),
             Event::Text {
                 content,
                 bold,
@@ -293,22 +322,14 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             Event::Image {
                 source, alt, id, ..
             } => self.handle_image(source, alt, id.as_ref()),
-            Event::EndBlockQuote
-            | Event::EndCaption
+            Event::EndCaption
             | Event::EndDefinitionDetail
             | Event::EndDefinitionList
             | Event::EndDefinitionTerm
             | Event::EndFootnote
             | Event::EndLink
-            | Event::EndListItem
-            | Event::EndPreformatted
-            | Event::EndTable
-            | Event::EndTableCell
-            | Event::EndTableHeader
-            | Event::EndTableRow
             | Event::FootnoteRef { .. }
             | Event::LineBreak
-            | Event::StartBlockQuote { .. }
             | Event::StartCaption { .. }
             | Event::StartDefinitionDetail { .. }
             | Event::StartDefinitionList { .. }
@@ -321,7 +342,6 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             | Event::StartTableCell { .. }
             | Event::StartTableHeader { .. }
             | Event::StartTableRow { .. }
-            | Event::ThematicBreak
             | _ => Ok(()),
         }
     }

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -216,6 +216,26 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         Ok(())
     }
 
+    fn handle_preformatted(&mut self, id: Option<&String>, syntax: Option<&String>) -> Result<()> {
+        self.close_text_block_if_needed()?;
+        self.writer.begin_object().map_err(io_err)?;
+        self.writer.name("type").map_err(io_err)?;
+        self.writer.string_value("codeBlock").map_err(io_err)?;
+        self.write_id(id)?;
+        if let Some(lang) = syntax {
+            self.writer.name("props").map_err(io_err)?;
+            self.writer.begin_object().map_err(io_err)?;
+            self.writer.name("language").map_err(io_err)?;
+            self.writer.string_value(lang).map_err(io_err)?;
+            self.writer.end_object().map_err(io_err)?;
+        }
+        self.writer.name("content").map_err(io_err)?;
+        self.writer.begin_array().map_err(io_err)?;
+
+        self.in_text_block = true;
+        Ok(())
+    }
+
     fn handle_text(&mut self, content: &str, bold: bool, italic: bool) -> Result<()> {
         if !self.in_text_block {
             self.handle_paragraph(None)?;
@@ -312,6 +332,9 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             | Event::EndListItem => self.close_text_block_if_needed(),
             Event::StartParagraph { id, .. } => self.handle_paragraph(id.as_ref()),
             Event::StartBlockQuote { id, .. } => self.handle_blockquote(id.as_ref()),
+            Event::StartPreformatted { id, syntax, .. } => {
+                self.handle_preformatted(id.as_ref(), syntax.as_ref())
+            }
             Event::ThematicBreak { id, .. } => self.handle_divider(id.as_ref()),
             Event::Text {
                 content,
@@ -337,7 +360,6 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             | Event::StartFootnote { .. }
             | Event::StartLink { .. }
             | Event::StartListItem { .. }
-            | Event::StartPreformatted { .. }
             | Event::StartTable { .. }
             | Event::StartTableCell { .. }
             | Event::StartTableHeader { .. }

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -30,7 +30,7 @@
 //! let mut buf = Vec::<u8>::new();
 //! let mut writer = BlockNoteWriter::new(&mut buf);
 //!
-//! writer.handle_event(Event::StartDocument { language: None, metadata: None })?;
+//! writer.handle_event(Event::StartDocument { id: None, language: None, metadata: None })?;
 //! writer.handle_event(Event::StartParagraph { alignment: None, id: None })?;
 //! writer.handle_event(Event::Text {
 //!     content: "Hello".to_string(),
@@ -95,12 +95,9 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
     fn handle_heading(&mut self, level: u8, id: Option<&String>) -> Result<()> {
         self.close_text_block_if_needed()?;
         self.writer.begin_object().map_err(io_err)?;
-        if let Some(id_val) = id {
-            self.writer.name("id").map_err(io_err)?;
-            self.writer.string_value(id_val).map_err(io_err)?;
-        }
         self.writer.name("type").map_err(io_err)?;
         self.writer.string_value("heading").map_err(io_err)?;
+        self.write_id(id)?;
         self.writer.name("props").map_err(io_err)?;
         self.writer.begin_object().map_err(io_err)?;
         self.writer.name("level").map_err(io_err)?;
@@ -258,6 +255,15 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             writer: JsonStreamWriter::new(writer),
         }
     }
+
+    fn write_id(&mut self, id: Option<&String>) -> Result<()> {
+        if let Some(id_val) = id {
+            self.writer.name("id").map_err(io_err)?;
+            self.writer.string_value(id_val).map_err(io_err)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
@@ -302,19 +308,19 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             | Event::EndTableRow
             | Event::FootnoteRef { .. }
             | Event::LineBreak
-            | Event::StartBlockQuote
-            | Event::StartCaption
-            | Event::StartDefinitionDetail
-            | Event::StartDefinitionList
-            | Event::StartDefinitionTerm
+            | Event::StartBlockQuote { .. }
+            | Event::StartCaption { .. }
+            | Event::StartDefinitionDetail { .. }
+            | Event::StartDefinitionList { .. }
+            | Event::StartDefinitionTerm { .. }
             | Event::StartFootnote { .. }
             | Event::StartLink { .. }
             | Event::StartListItem { .. }
             | Event::StartPreformatted { .. }
-            | Event::StartTable
+            | Event::StartTable { .. }
             | Event::StartTableCell { .. }
             | Event::StartTableHeader { .. }
-            | Event::StartTableRow
+            | Event::StartTableRow { .. }
             | Event::ThematicBreak
             | _ => Ok(()),
         }

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -1382,4 +1382,110 @@ mod tests {
         ]);
         assert!(!json.contains("\"id\""));
     }
+
+    #[test]
+    fn code_block_with_language() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartPreformatted {
+                id: None,
+                syntax: Some("rust".to_string()),
+            },
+            Event::Text {
+                content: "fn main() {}".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndPreformatted,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"codeBlock","props":{"language":"rust"},"content":[{"type":"text","text":"fn main() {}","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn code_block_without_language() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartPreformatted {
+                id: None,
+                syntax: None,
+            },
+            Event::Text {
+                content: "plain code".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndPreformatted,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"codeBlock","content":[{"type":"text","text":"plain code","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn empty_code_block() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartPreformatted {
+                id: None,
+                syntax: Some("python".to_string()),
+            },
+            Event::EndPreformatted,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"codeBlock","props":{"language":"python"},"content":[],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn code_block_with_id() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartPreformatted {
+                id: Some("cb-1".to_string()),
+                syntax: None,
+            },
+            Event::EndPreformatted,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"codeBlock","id":"cb-1","content":[],"children":[]}]"#
+        );
+    }
 }

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -511,10 +511,13 @@ mod tests {
             Event::StartBlockQuote { id: None },
             Event::EndBlockQuote,
             Event::LineBreak,
-            Event::ThematicBreak,
+            Event::ThematicBreak { id: None },
             Event::EndDocument,
         ]);
-        assert_eq!(json, "[]");
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[],"children":[]},{"type":"divider"}]"#
+        );
     }
 
     #[test]

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -131,6 +131,7 @@ mod tests {
     fn empty_document() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -143,6 +144,7 @@ mod tests {
     fn single_paragraph() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -174,6 +176,7 @@ mod tests {
     fn bold_text() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -205,6 +208,7 @@ mod tests {
     fn italic_text() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -236,6 +240,7 @@ mod tests {
     fn bold_and_italic_text() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -267,6 +272,7 @@ mod tests {
     fn heading_level_1() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -295,6 +301,7 @@ mod tests {
     fn heading_level_2() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -323,6 +330,7 @@ mod tests {
     fn multiple_paragraphs() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -370,6 +378,7 @@ mod tests {
     fn image_block() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -394,6 +403,7 @@ mod tests {
     fn image_without_alt() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -419,6 +429,7 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         let mut writer = BlockNoteWriter::new(&mut buf);
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -439,6 +450,7 @@ mod tests {
     fn mixed_content() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -492,10 +504,11 @@ mod tests {
     fn ignored_events() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
-            Event::StartBlockQuote,
+            Event::StartBlockQuote { id: None },
             Event::EndBlockQuote,
             Event::LineBreak,
             Event::ThematicBreak,
@@ -508,6 +521,7 @@ mod tests {
     fn text_outside_block_auto_opens_paragraph() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -534,6 +548,7 @@ mod tests {
     fn multiple_text_in_paragraph() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -576,6 +591,7 @@ mod tests {
     fn two_paragraphs_without_ids() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -623,6 +639,7 @@ mod tests {
     fn json_escaping_quotes() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -654,6 +671,7 @@ mod tests {
     fn json_escaping_backslash() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -685,6 +703,7 @@ mod tests {
     fn json_escaping_newline() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -716,6 +735,7 @@ mod tests {
     fn json_escaping_tab() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -747,6 +767,7 @@ mod tests {
     fn empty_paragraph() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -767,6 +788,7 @@ mod tests {
     fn empty_heading() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -784,6 +806,7 @@ mod tests {
     fn image_in_paragraph() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -824,6 +847,7 @@ mod tests {
     fn heading_then_paragraph() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -868,6 +892,7 @@ mod tests {
     fn json_escaping_carriage_return() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -899,6 +924,7 @@ mod tests {
     fn image_url_escaping() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -923,6 +949,7 @@ mod tests {
     fn end_paragraph_after_image_is_noop() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -952,6 +979,7 @@ mod tests {
     fn error_on_start_document() {
         let mut writer = BlockNoteWriter::new(FailingWriter::new(0));
         let result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -962,6 +990,7 @@ mod tests {
     fn error_on_end_document() {
         let mut writer = BlockNoteWriter::new(FailingWriter::new(1));
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -974,6 +1003,7 @@ mod tests {
     fn error_on_heading_begin_object() {
         let mut writer = BlockNoteWriter::new(FailingWriter::new(1));
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -986,6 +1016,7 @@ mod tests {
     fn error_on_paragraph_begin_object() {
         let mut writer = BlockNoteWriter::new(FailingWriter::new(1));
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -1004,6 +1035,7 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         let mut writer = BlockNoteWriter::with_assets(&mut buf, &provider);
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -1035,6 +1067,7 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         let mut writer = BlockNoteWriter::with_assets(&mut buf, &provider);
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -1059,6 +1092,7 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         let mut writer = BlockNoteWriter::with_assets(&mut buf, &provider);
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -1082,6 +1116,7 @@ mod tests {
         let json = run_events_with_assets(
             &[
                 Event::StartDocument {
+                    id: None,
                     language: None,
                     metadata: None,
                 },
@@ -1110,6 +1145,7 @@ mod tests {
         let json = run_events_with_assets(
             &[
                 Event::StartDocument {
+                    id: None,
                     language: None,
                     metadata: None,
                 },
@@ -1139,6 +1175,7 @@ mod tests {
         let json = run_events_with_assets(
             &[
                 Event::StartDocument {
+                    id: None,
                     language: None,
                     metadata: None,
                 },
@@ -1177,6 +1214,7 @@ mod tests {
         let json = run_events_with_assets(
             &[
                 Event::StartDocument {
+                    id: None,
                     language: None,
                     metadata: None,
                 },
@@ -1215,6 +1253,7 @@ mod tests {
         let json = run_events_with_assets(
             &[
                 Event::StartDocument {
+                    id: None,
                     language: None,
                     metadata: None,
                 },
@@ -1266,6 +1305,7 @@ mod tests {
         let mut buf = Vec::<u8>::new();
         let mut writer = BlockNoteWriter::with_assets(&mut buf, &provider);
         let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         });
@@ -1286,6 +1326,7 @@ mod tests {
     fn heading_with_explicit_id() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },
@@ -1314,6 +1355,7 @@ mod tests {
     fn paragraph_without_id_omits_id_key() {
         let json = run_events(&[
             Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             },

--- a/crates/docspec-core/README.md
+++ b/crates/docspec-core/README.md
@@ -1,0 +1,49 @@
+# docspec-core
+
+Core types and traits for the DocSpec streaming document pipeline. Documents are streams of typed events flowing from `EventSource` readers to `EventSink` writers.
+
+## Events
+
+The `Event` enum defines all atomic units of document structure. Events come in three categories: Start/End pairs for containers, self-contained block events, and self-contained inline events.
+
+### Document Structure
+
+- `StartDocument` / `EndDocument` — `language: Option<String>`, `metadata: Option<DocumentMeta>`
+- `StartHeading` / `EndHeading` — `level: u8`, `id: Option<String>`
+- `StartParagraph` / `EndParagraph` — `alignment: Option<TextAlignment>`, `id: Option<String>`
+- `StartBlockQuote` / `EndBlockQuote`
+- `StartPreformatted` / `EndPreformatted` — `syntax: Option<String>`
+- `StartFootnote` / `EndFootnote` — `id: u32`
+
+### Lists
+
+- `StartListItem` / `EndListItem` — `level: u8`, `list_type: ListType`, `start: Option<u32>`, `style_type: Option<ListStyleType>`
+
+### Tables
+
+- `StartTable` / `EndTable`
+- `StartCaption` / `EndCaption`
+- `StartTableRow` / `EndTableRow`
+- `StartTableHeader` / `EndTableHeader` — `scope: Option<TableHeaderScope>`, `abbr: Option<String>`, `colspan: Option<u32>`, `rowspan: Option<u32>`
+- `StartTableCell` / `EndTableCell` — `colspan: Option<u32>`, `rowspan: Option<u32>`
+
+### Definition Lists
+
+- `StartDefinitionList` / `EndDefinitionList`
+- `StartDefinitionTerm` / `EndDefinitionTerm`
+- `StartDefinitionDetail` / `EndDefinitionDetail`
+
+### Inline Containers
+
+- `StartLink` / `EndLink` — `href: String`, `title: Option<String>`
+
+### Self-Contained Block Events
+
+- `ThematicBreak`
+
+### Self-Contained Inline Events
+
+- `Text` — `content: String`, `bold: bool`, `italic: bool`, `code: bool`, `strikethrough: bool`, `underline: bool`, `subscript: bool`, `superscript: bool`, `mark: Option<Color>`
+- `Image` — `source: ImageSource`, `alt: Option<String>`, `title: Option<String>`, `decorative: bool`, `id: Option<String>`
+- `FootnoteRef` — `id: u32`
+- `LineBreak`

--- a/crates/docspec-core/README.md
+++ b/crates/docspec-core/README.md
@@ -2,48 +2,6 @@
 
 Core types and traits for the DocSpec streaming document pipeline. Documents are streams of typed events flowing from `EventSource` readers to `EventSink` writers.
 
-## Events
+## Documentation
 
-The `Event` enum defines all atomic units of document structure. Events come in three categories: Start/End pairs for containers, self-contained block events, and self-contained inline events.
-
-### Document Structure
-
-- `StartDocument` / `EndDocument` — `language: Option<String>`, `metadata: Option<DocumentMeta>`
-- `StartHeading` / `EndHeading` — `level: u8`, `id: Option<String>`
-- `StartParagraph` / `EndParagraph` — `alignment: Option<TextAlignment>`, `id: Option<String>`
-- `StartBlockQuote` / `EndBlockQuote`
-- `StartPreformatted` / `EndPreformatted` — `syntax: Option<String>`
-- `StartFootnote` / `EndFootnote` — `id: u32`
-
-### Lists
-
-- `StartListItem` / `EndListItem` — `level: u8`, `list_type: ListType`, `start: Option<u32>`, `style_type: Option<ListStyleType>`
-
-### Tables
-
-- `StartTable` / `EndTable`
-- `StartCaption` / `EndCaption`
-- `StartTableRow` / `EndTableRow`
-- `StartTableHeader` / `EndTableHeader` — `scope: Option<TableHeaderScope>`, `abbr: Option<String>`, `colspan: Option<u32>`, `rowspan: Option<u32>`
-- `StartTableCell` / `EndTableCell` — `colspan: Option<u32>`, `rowspan: Option<u32>`
-
-### Definition Lists
-
-- `StartDefinitionList` / `EndDefinitionList`
-- `StartDefinitionTerm` / `EndDefinitionTerm`
-- `StartDefinitionDetail` / `EndDefinitionDetail`
-
-### Inline Containers
-
-- `StartLink` / `EndLink` — `href: String`, `title: Option<String>`
-
-### Self-Contained Block Events
-
-- `ThematicBreak`
-
-### Self-Contained Inline Events
-
-- `Text` — `content: String`, `bold: bool`, `italic: bool`, `code: bool`, `strikethrough: bool`, `underline: bool`, `subscript: bool`, `superscript: bool`, `mark: Option<Color>`
-- `Image` — `source: ImageSource`, `alt: Option<String>`, `title: Option<String>`, `decorative: bool`, `id: Option<String>`
-- `FootnoteRef` — `id: u32`
-- `LineBreak`
+Run `just doc-open` to browse the full API documentation including all event types, traits, and field descriptions.

--- a/crates/docspec-core/src/event.rs
+++ b/crates/docspec-core/src/event.rs
@@ -87,22 +87,39 @@ pub enum Event {
     LineBreak,
 
     /// Begin a block quote.
-    StartBlockQuote,
+    StartBlockQuote {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 
     /// Begin a table caption.
-    StartCaption,
+    StartCaption {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 
     /// Begin a definition detail (description).
-    StartDefinitionDetail,
+    StartDefinitionDetail {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 
     /// Begin a definition list.
-    StartDefinitionList,
+    StartDefinitionList {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 
     /// Begin a definition term.
-    StartDefinitionTerm,
+    StartDefinitionTerm {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 
     /// Begin a document with optional language and metadata.
     StartDocument {
+        /// Optional block identifier.
+        id: Option<String>,
         /// BCP 47 language tag (e.g., "en", "en-US", "zh-Hans").
         language: Option<String>,
         /// Document metadata including title, authors, and description.
@@ -127,12 +144,16 @@ pub enum Event {
     StartLink {
         /// URL or URI target of the link.
         href: String,
+        /// Optional block identifier.
+        id: Option<String>,
         /// Optional tooltip text.
         title: Option<String>,
     },
 
     /// Begin a list item.
     StartListItem {
+        /// Optional block identifier.
+        id: Option<String>,
         /// Nesting level (1 = top-level).
         level: u8,
         /// Whether the list is ordered or unordered.
@@ -153,17 +174,24 @@ pub enum Event {
 
     /// Begin a preformatted (code) block with optional syntax highlighting.
     StartPreformatted {
+        /// Optional block identifier.
+        id: Option<String>,
         /// Language identifier for syntax highlighting (e.g., "rust", "python").
         syntax: Option<String>,
     },
 
     /// Begin a table.
-    StartTable,
+    StartTable {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 
     /// Begin a table data cell.
     StartTableCell {
         /// Number of columns this cell spans.
         colspan: Option<u32>,
+        /// Optional block identifier.
+        id: Option<String>,
         /// Number of rows this cell spans.
         rowspan: Option<u32>,
     },
@@ -174,6 +202,8 @@ pub enum Event {
         abbr: Option<String>,
         /// Number of columns this cell spans.
         colspan: Option<u32>,
+        /// Optional block identifier.
+        id: Option<String>,
         /// Number of rows this cell spans.
         rowspan: Option<u32>,
         /// Whether this header applies to a column or row.
@@ -181,7 +211,10 @@ pub enum Event {
     },
 
     /// Begin a table row.
-    StartTableRow,
+    StartTableRow {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 
     /// A text run with formatting attributes.
     Text {
@@ -415,35 +448,35 @@ mod tests {
 
     #[test]
     fn start_block_quote() {
-        let event = Event::StartBlockQuote;
+        let event = Event::StartBlockQuote { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
 
     #[test]
     fn start_caption() {
-        let event = Event::StartCaption;
+        let event = Event::StartCaption { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
 
     #[test]
     fn start_definition_detail() {
-        let event = Event::StartDefinitionDetail;
+        let event = Event::StartDefinitionDetail { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
 
     #[test]
     fn start_definition_list() {
-        let event = Event::StartDefinitionList;
+        let event = Event::StartDefinitionList { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
 
     #[test]
     fn start_definition_term() {
-        let event = Event::StartDefinitionTerm;
+        let event = Event::StartDefinitionTerm { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
@@ -451,6 +484,7 @@ mod tests {
     #[test]
     fn start_document_minimal() {
         let event = Event::StartDocument {
+            id: None,
             language: None,
             metadata: None,
         };
@@ -461,12 +495,14 @@ mod tests {
     #[test]
     fn start_document_with_language() {
         let event = Event::StartDocument {
+            id: None,
             language: Some("en-US".to_string()),
             metadata: None,
         };
         assert_eq!(
             event,
             Event::StartDocument {
+                id: None,
                 language: Some("en-US".to_string()),
                 metadata: None,
             }
@@ -484,12 +520,14 @@ mod tests {
             description: Some("A test document".to_string()),
         };
         let event = Event::StartDocument {
+            id: None,
             language: Some("en".to_string()),
             metadata: Some(meta.clone()),
         };
         assert_eq!(
             event,
             Event::StartDocument {
+                id: None,
                 language: Some("en".to_string()),
                 metadata: Some(meta),
             }
@@ -533,6 +571,7 @@ mod tests {
     fn start_link() {
         let event = Event::StartLink {
             href: "https://example.com".to_string(),
+            id: None,
             title: Some("Example Link".to_string()),
         };
         let cloned = event.clone();
@@ -543,12 +582,14 @@ mod tests {
     fn start_link_no_title() {
         let event = Event::StartLink {
             href: "https://rust-lang.org".to_string(),
+            id: None,
             title: None,
         };
         assert_eq!(
             event,
             Event::StartLink {
                 href: "https://rust-lang.org".to_string(),
+                id: None,
                 title: None,
             }
         );
@@ -557,6 +598,7 @@ mod tests {
     #[test]
     fn start_list_item_ordered() {
         let event = Event::StartListItem {
+            id: None,
             level: 1,
             list_type: ListType::Ordered,
             start: Some(1),
@@ -569,6 +611,7 @@ mod tests {
     #[test]
     fn start_list_item_unordered() {
         let event = Event::StartListItem {
+            id: None,
             level: 2,
             list_type: ListType::Unordered,
             start: None,
@@ -577,6 +620,7 @@ mod tests {
         assert_eq!(
             event,
             Event::StartListItem {
+                id: None,
                 level: 2,
                 list_type: ListType::Unordered,
                 start: None,
@@ -612,7 +656,10 @@ mod tests {
 
     #[test]
     fn start_preformatted_no_syntax() {
-        let event = Event::StartPreformatted { syntax: None };
+        let event = Event::StartPreformatted {
+            id: None,
+            syntax: None,
+        };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
@@ -620,11 +667,13 @@ mod tests {
     #[test]
     fn start_preformatted_with_syntax() {
         let event = Event::StartPreformatted {
+            id: None,
             syntax: Some("rust".to_string()),
         };
         assert_eq!(
             event,
             Event::StartPreformatted {
+                id: None,
                 syntax: Some("rust".to_string()),
             }
         );
@@ -632,7 +681,7 @@ mod tests {
 
     #[test]
     fn start_table() {
-        let event = Event::StartTable;
+        let event = Event::StartTable { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
@@ -641,6 +690,7 @@ mod tests {
     fn start_table_cell_minimal() {
         let event = Event::StartTableCell {
             colspan: None,
+            id: None,
             rowspan: None,
         };
         let cloned = event.clone();
@@ -651,12 +701,14 @@ mod tests {
     fn start_table_cell_with_spans() {
         let event = Event::StartTableCell {
             colspan: Some(3),
+            id: None,
             rowspan: Some(2),
         };
         assert_eq!(
             event,
             Event::StartTableCell {
                 colspan: Some(3),
+                id: None,
                 rowspan: Some(2),
             }
         );
@@ -665,18 +717,20 @@ mod tests {
     #[test]
     fn start_table_header_full() {
         let event = Event::StartTableHeader {
-            scope: Some(TableHeaderScope::Column),
             abbr: Some("Qty".to_string()),
             colspan: Some(2),
+            id: None,
             rowspan: Some(1),
+            scope: Some(TableHeaderScope::Column),
         };
         assert_eq!(
             event,
             Event::StartTableHeader {
-                scope: Some(TableHeaderScope::Column),
                 abbr: Some("Qty".to_string()),
                 colspan: Some(2),
+                id: None,
                 rowspan: Some(1),
+                scope: Some(TableHeaderScope::Column),
             }
         );
     }
@@ -684,10 +738,11 @@ mod tests {
     #[test]
     fn start_table_header_minimal() {
         let event = Event::StartTableHeader {
-            scope: None,
             abbr: None,
             colspan: None,
+            id: None,
             rowspan: None,
+            scope: None,
         };
         let cloned = event.clone();
         assert_eq!(event, cloned);
@@ -695,7 +750,7 @@ mod tests {
 
     #[test]
     fn start_table_row() {
-        let event = Event::StartTableRow;
+        let event = Event::StartTableRow { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }

--- a/crates/docspec-core/src/event.rs
+++ b/crates/docspec-core/src/event.rs
@@ -239,7 +239,10 @@ pub enum Event {
     },
 
     /// A horizontal rule / thematic break.
-    ThematicBreak,
+    ThematicBreak {
+        /// Optional block identifier.
+        id: Option<String>,
+    },
 }
 
 #[cfg(test)]
@@ -441,9 +444,12 @@ mod tests {
     #[test]
     fn partial_eq_unit_variants() {
         assert_eq!(Event::EndDocument, Event::EndDocument);
-        assert_eq!(Event::ThematicBreak, Event::ThematicBreak);
+        assert_eq!(
+            Event::ThematicBreak { id: None },
+            Event::ThematicBreak { id: None }
+        );
         assert_eq!(Event::LineBreak, Event::LineBreak);
-        assert_ne!(Event::EndDocument, Event::ThematicBreak);
+        assert_ne!(Event::EndDocument, Event::ThematicBreak { id: None });
     }
 
     #[test]
@@ -877,7 +883,7 @@ mod tests {
 
     #[test]
     fn thematic_break() {
-        let event = Event::ThematicBreak;
+        let event = Event::ThematicBreak { id: None };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }

--- a/crates/docspec-core/src/traits.rs
+++ b/crates/docspec-core/src/traits.rs
@@ -122,6 +122,7 @@ mod tests {
         fn event_sink_collects_events() {
             let mut sink = MockEventSink::new();
             let event1 = crate::Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             };
@@ -163,6 +164,7 @@ mod tests {
         fn event_source_emits_events() {
             let events = vec![
                 crate::Event::StartDocument {
+                    id: None,
                     language: None,
                     metadata: None,
                 },
@@ -205,6 +207,7 @@ mod tests {
         fn pipeline_source_to_sink() {
             let events = vec![
                 crate::Event::StartDocument {
+                    id: None,
                     language: None,
                     metadata: None,
                 },

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -139,7 +139,8 @@ impl<'a> MarkdownReader<'a> {
         match tag_end {
             TagEnd::Heading(_) => self.push_event_end(Event::EndHeading),
             TagEnd::Paragraph => self.push_event_end(Event::EndParagraph),
-            TagEnd::BlockQuote(_) | TagEnd::Item | TagEnd::TableCell => {
+            TagEnd::BlockQuote(_) => self.push_event_end(Event::EndBlockQuote),
+            TagEnd::Item | TagEnd::TableCell => {
                 if self.block_state == BlockState::AutoParagraph {
                     self.push_event_end(Event::EndParagraph);
                 }
@@ -209,6 +210,7 @@ impl<'a> MarkdownReader<'a> {
                 alignment: None,
                 id: None,
             }),
+            Tag::BlockQuote(_) => self.push_event_start(Event::StartBlockQuote { id: None }),
             Tag::Emphasis => {
                 self.italic_depth = self.italic_depth.saturating_add(1);
             }
@@ -228,8 +230,7 @@ impl<'a> MarkdownReader<'a> {
                     url: dest_url.into_string(),
                 });
             }
-            Tag::BlockQuote(_)
-            | Tag::CodeBlock(_)
+            Tag::CodeBlock(_)
             | Tag::DefinitionList
             | Tag::DefinitionListDefinition
             | Tag::DefinitionListTitle
@@ -331,7 +332,7 @@ impl<'a> MarkdownReader<'a> {
                 }
             }
             pulldown_cmark::Event::Rule => {
-                self.queue.push_back(Event::ThematicBreak);
+                self.queue.push_back(Event::ThematicBreak { id: None });
             }
             pulldown_cmark::Event::DisplayMath(_)
             | pulldown_cmark::Event::FootnoteReference(_)

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -137,13 +137,12 @@ impl<'a> MarkdownReader<'a> {
 
     fn handle_end_tag(&mut self, tag_end: TagEnd) {
         match tag_end {
-            TagEnd::Heading(_) => {
-                self.queue.push_back(Event::EndHeading);
-                self.block_state = BlockState::None;
-            }
-            TagEnd::Paragraph => {
-                self.queue.push_back(Event::EndParagraph);
-                self.block_state = BlockState::None;
+            TagEnd::Heading(_) => self.push_event_end(Event::EndHeading),
+            TagEnd::Paragraph => self.push_event_end(Event::EndParagraph),
+            TagEnd::BlockQuote(_) | TagEnd::Item | TagEnd::TableCell => {
+                if self.block_state == BlockState::AutoParagraph {
+                    self.push_event_end(Event::EndParagraph);
+                }
             }
             TagEnd::Emphasis => {
                 self.italic_depth = self.italic_depth.saturating_sub(1);
@@ -169,12 +168,6 @@ impl<'a> MarkdownReader<'a> {
                         decorative,
                         id: None,
                     });
-                }
-            }
-            TagEnd::BlockQuote(_) | TagEnd::Item | TagEnd::TableCell => {
-                if self.block_state == BlockState::AutoParagraph {
-                    self.queue.push_back(Event::EndParagraph);
-                    self.block_state = BlockState::None;
                 }
             }
             TagEnd::CodeBlock
@@ -206,19 +199,16 @@ impl<'a> MarkdownReader<'a> {
                     HeadingLevel::H5 => 5,
                     HeadingLevel::H6 => 6,
                 };
-                self.queue.push_back(Event::StartHeading {
+
+                self.push_event_start(Event::StartHeading {
                     level: level_u8,
                     id: None,
                 });
-                self.block_state = BlockState::Explicit;
             }
-            Tag::Paragraph => {
-                self.queue.push_back(Event::StartParagraph {
-                    alignment: None,
-                    id: None,
-                });
-                self.block_state = BlockState::Explicit;
-            }
+            Tag::Paragraph => self.push_event_start(Event::StartParagraph {
+                alignment: None,
+                id: None,
+            }),
             Tag::Emphasis => {
                 self.italic_depth = self.italic_depth.saturating_add(1);
             }
@@ -351,6 +341,19 @@ impl<'a> MarkdownReader<'a> {
             | pulldown_cmark::Event::TaskListMarker(_) => {}
         }
     }
+
+    fn push_event(&mut self, event: Event, state: BlockState) {
+        self.queue.push_back(event);
+        self.block_state = state;
+    }
+
+    fn push_event_end(&mut self, event: Event) {
+        self.push_event(event, BlockState::None);
+    }
+
+    fn push_event_start(&mut self, event: Event) {
+        self.push_event(event, BlockState::Explicit);
+    }
 }
 
 impl EventSource for MarkdownReader<'_> {
@@ -359,6 +362,7 @@ impl EventSource for MarkdownReader<'_> {
         if self.phase == Phase::NotStarted {
             self.phase = Phase::Running;
             return Ok(Some(Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None,
             }));

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -41,7 +41,7 @@ use alloc::collections::VecDeque;
 
 pub use docspec_core::EventSource;
 use docspec_core::{Event, ImageSource, Result};
-use pulldown_cmark::{HeadingLevel, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{CodeBlockKind, HeadingLevel, Options, Parser, Tag, TagEnd};
 
 /// Whether content is inside a block-level element.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -171,8 +171,8 @@ impl<'a> MarkdownReader<'a> {
                     });
                 }
             }
-            TagEnd::CodeBlock
-            | TagEnd::DefinitionList
+            TagEnd::CodeBlock => self.push_event_end(Event::EndPreformatted),
+            TagEnd::DefinitionList
             | TagEnd::DefinitionListDefinition
             | TagEnd::DefinitionListTitle
             | TagEnd::FootnoteDefinition
@@ -211,6 +211,13 @@ impl<'a> MarkdownReader<'a> {
                 id: None,
             }),
             Tag::BlockQuote(_) => self.push_event_start(Event::StartBlockQuote { id: None }),
+            Tag::CodeBlock(kind) => {
+                let syntax = match kind {
+                    CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.into_string()),
+                    CodeBlockKind::Fenced(_) | CodeBlockKind::Indented => None,
+                };
+                self.push_event_start(Event::StartPreformatted { id: None, syntax });
+            }
             Tag::Emphasis => {
                 self.italic_depth = self.italic_depth.saturating_add(1);
             }
@@ -230,8 +237,7 @@ impl<'a> MarkdownReader<'a> {
                     url: dest_url.into_string(),
                 });
             }
-            Tag::CodeBlock(_)
-            | Tag::DefinitionList
+            Tag::DefinitionList
             | Tag::DefinitionListDefinition
             | Tag::DefinitionListTitle
             | Tag::FootnoteDefinition(_)

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -24,10 +24,10 @@ mod tests {
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        assert!(!events
+        assert!(events
             .iter()
             .any(|e| matches!(e, Event::StartBlockQuote { .. })));
-        assert!(!events.iter().any(|e| matches!(e, Event::EndBlockQuote)));
+        assert!(events.iter().any(|e| matches!(e, Event::EndBlockQuote)));
 
         let has_quoted = events
             .iter()
@@ -117,7 +117,7 @@ mod tests {
                 | Event::StartTableCell { .. }
                 | Event::StartTableHeader { .. }
                 | Event::StartTableRow { .. }
-                | Event::ThematicBreak
+                | Event::ThematicBreak { .. }
                 | _ => "Other",
             })
             .collect();
@@ -414,7 +414,9 @@ mod tests {
         let mut reader = MarkdownReader::new("Before\n\n---\n\nAfter");
         let events = collect_events(&mut reader);
 
-        assert!(events.iter().any(|e| matches!(e, Event::ThematicBreak)));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::ThematicBreak { .. })));
     }
 
     #[test]

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -24,7 +24,9 @@ mod tests {
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        assert!(!events.iter().any(|e| matches!(e, Event::StartBlockQuote)));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, Event::StartBlockQuote { .. })));
         assert!(!events.iter().any(|e| matches!(e, Event::EndBlockQuote)));
 
         let has_quoted = events
@@ -101,20 +103,20 @@ mod tests {
                 | Event::FootnoteRef { .. }
                 | Event::Image { .. }
                 | Event::LineBreak
-                | Event::StartBlockQuote
-                | Event::StartCaption
-                | Event::StartDefinitionDetail
-                | Event::StartDefinitionList
-                | Event::StartDefinitionTerm
+                | Event::StartBlockQuote { .. }
+                | Event::StartCaption { .. }
+                | Event::StartDefinitionDetail { .. }
+                | Event::StartDefinitionList { .. }
+                | Event::StartDefinitionTerm { .. }
                 | Event::StartFootnote { .. }
                 | Event::StartHeading { .. }
                 | Event::StartLink { .. }
                 | Event::StartListItem { .. }
                 | Event::StartPreformatted { .. }
-                | Event::StartTable
+                | Event::StartTable { .. }
                 | Event::StartTableCell { .. }
                 | Event::StartTableHeader { .. }
-                | Event::StartTableRow
+                | Event::StartTableRow { .. }
                 | Event::ThematicBreak
                 | _ => "Other",
             })
@@ -148,6 +150,7 @@ mod tests {
         assert!(matches!(
             events.first(),
             Some(Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None
             })
@@ -171,6 +174,7 @@ mod tests {
         assert!(matches!(
             events.first(),
             Some(Event::StartDocument {
+                id: None,
                 language: None,
                 metadata: None
             })
@@ -391,7 +395,7 @@ mod tests {
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        assert!(!events.iter().any(|e| matches!(e, Event::StartTable)));
+        assert!(!events.iter().any(|e| matches!(e, Event::StartTable { .. })));
         assert!(!events.iter().any(|e| matches!(e, Event::EndTable)));
 
         let has_header = events

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -524,4 +524,54 @@ mod tests {
             .any(|e| matches!(e, Event::Text { content, .. } if content == " "));
         assert!(space);
     }
+
+    #[test]
+    fn fenced_code_block_with_language() {
+        let markdown = "```rust\nfn main() {}\n```";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert!(events.iter().any(|e| matches!(
+            e,
+            Event::StartPreformatted {
+                syntax: Some(lang),
+                ..
+            } if lang == "rust"
+        )));
+        assert!(events.iter().any(|e| matches!(e, Event::EndPreformatted)));
+
+        let has_content = events
+            .iter()
+            .any(|e| matches!(e, Event::Text { content, .. } if content.contains("fn main")));
+        assert!(has_content);
+    }
+
+    #[test]
+    fn fenced_code_block_without_language() {
+        let markdown = "```\nsome code\n```";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartPreformatted { syntax: None, .. })));
+        assert!(events.iter().any(|e| matches!(e, Event::EndPreformatted)));
+    }
+
+    #[test]
+    fn indented_code_block() {
+        let markdown = "    indented code\n";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartPreformatted { syntax: None, .. })));
+        assert!(events.iter().any(|e| matches!(e, Event::EndPreformatted)));
+
+        let has_content = events
+            .iter()
+            .any(|e| matches!(e, Event::Text { content, .. } if content.contains("indented")));
+        assert!(has_content);
+    }
 }

--- a/justfile
+++ b/justfile
@@ -1,0 +1,53 @@
+# Default recipe: run all checks (what CI does)
+default: fmt clippy test doc build
+
+# Format all Rust code
+fmt:
+    cargo fmt --all
+
+# Check formatting without modifying files
+fmt-check:
+    cargo fmt --all --check
+
+# Run clippy with workspace-wide strict lints
+clippy:
+    cargo clippy --workspace --all-targets -- -D warnings
+
+# Build the entire workspace
+build:
+    cargo build --workspace
+
+# Build in release mode
+release:
+    cargo build --workspace --release
+
+# Run all tests
+test:
+    cargo test --workspace
+
+# Check documentation builds without warnings
+# To open in browser, run `just doc -- --open`
+doc:
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps
+
+# Run coverage and enforce 99.5% floor
+coverage:
+    cargo llvm-cov --workspace --lcov --output-path lcov.info
+    cargo llvm-cov report --fail-under-lines 99.5
+
+# Run coverage and open HTML report
+coverage-html:
+    cargo llvm-cov --workspace --html
+    cargo llvm-cov report --fail-under-lines 99.5
+
+# Check spelling with typos
+typos:
+    typos
+
+# Check TOML formatting
+taplo:
+    taplo fmt --check
+
+# Clean build artifacts
+clean:
+    cargo clean


### PR DESCRIPTION
## Summary

- Add `id: Option<String>` to all `Start*` event variants (except `StartFootnote`) for block-level identification
- Add block quote support: markdown reader emits `StartBlockQuote`/`EndBlockQuote`, BlockNote writer produces `"quote"` blocks
- Add thematic break / divider support: `ThematicBreak` now carries optional `id`, BlockNote writer produces `"divider"` blocks
- Add preformatted / code block support: markdown reader emits `StartPreformatted` with syntax language, BlockNote writer produces `"codeBlock"` with optional `language` prop
- Add `docspec-core` README with event type reference
- Add justfile for common dev tasks
- Refactor BlockNote writer: extract `write_id` helper, use explicit ignore list instead of wildcard catch-all

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for code blocks (with optional language), block quotes, and thematic dividers
  * Optional ID attribute available on many document elements

* **Tests**
  * Expanded unit and integration tests to cover code blocks, block quotes, dividers, and ID-bearing events

* **Documentation**
  * Updated DocSpec core README with a brief introduction to the streaming event pipeline

* **Chores**
  * Added CI-style automation recipes for formatting, linting, testing, coverage, and docs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->