### PR TITLE
feat(wasm): minimal docspec-wasm crate with basic WebAssembly support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -225,6 +231,16 @@ dependencies = [
  "docspec-core",
  "pulldown-cmark",
  "serde_json",
+]
+
+[[package]]
+name = "docspec-wasm"
+version = "0.1.0"
+dependencies = [
+ "docspec-blocknote-writer",
+ "docspec-core",
+ "docspec-markdown-reader",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -549,6 +565,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -745,6 +767,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.120"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/docspec-markdown-reader",
   "crates/docspec-blocknote-writer",
   "crates/docspec-cli",
+  "crates/docspec-wasm",
 ]
 
 [workspace.package]

--- a/crates/docspec-wasm/Cargo.toml
+++ b/crates/docspec-wasm/Cargo.toml
@@ -1,0 +1,75 @@
+[package]
+name = "docspec-wasm"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "WebAssembly bindings for the DocSpec document conversion library."
+readme = "README.md"
+keywords = ["document", "conversion", "streaming", "wasm"]
+categories = ["encoding", "wasm"]
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+docspec-core = { path = "../docspec-core" }
+docspec-markdown-reader = { path = "../docspec-markdown-reader" }
+docspec-blocknote-writer = { path = "../docspec-blocknote-writer" }
+
+[lints.rust]
+unsafe_code = "forbid"
+missing_docs = "deny"
+
+[lints.clippy]
+# Reason: wasm-bindgen exported functions cannot be inlined
+missing_inline_in_public_items = "allow"
+# Inherit all other workspace clippy lints
+unwrap_used = "deny"
+expect_used = "deny"
+allow_attributes = "deny"
+suspicious = { level = "deny", priority = -1 }
+style = { level = "deny", priority = -1 }
+complexity = { level = "deny", priority = -1 }
+perf = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+restriction = { level = "deny", priority = -1 }
+cargo = { level = "deny", priority = -1 }
+cognitive_complexity = "deny"
+option_if_let_else = "deny"
+redundant_pub_crate = "deny"
+use_self = "deny"
+blanket_clippy_restriction_lints = "allow"
+implicit_return = "allow"
+question_mark_used = "allow"
+single_char_lifetime_names = "allow"
+min_ident_chars = "allow"
+absolute_paths = "allow"
+mod_module_files = "allow"
+missing_trait_methods = "allow"
+pattern_type_mismatch = "allow"
+multiple_inherent_impl = "allow"
+allow_attributes_without_reason = "allow"
+shadow_same = "allow"
+default_numeric_fallback = "allow"
+std_instead_of_core = "warn"
+alloc_instead_of_core = "warn"
+std_instead_of_alloc = "warn"
+missing_docs_in_private_items = "allow"
+partial_pub_fields = "allow"
+let_underscore_untyped = "allow"
+str_to_string = "allow"
+semicolon_inside_block = "allow"
+integer_division_remainder_used = "allow"
+big_endian_bytes = "allow"
+little_endian_bytes = "allow"
+host_endian_bytes = "allow"
+cfg_not_test = "allow"
+decimal_literal_representation = "allow"
+pub_use = "allow"
+exhaustive_enums = "allow"
+exhaustive_structs = "allow"
+module_name_repetitions = "allow"
+error_impl_error = "allow"
+multiple_crate_versions = "allow"

--- a/crates/docspec-wasm/README.md
+++ b/crates/docspec-wasm/README.md
@@ -1,0 +1,5 @@
+# docspec-wasm
+
+WebAssembly bindings for the DocSpec document conversion library.
+
+See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation.

--- a/crates/docspec-wasm/src/lib.rs
+++ b/crates/docspec-wasm/src/lib.rs
@@ -1,0 +1,82 @@
+//! WebAssembly bindings for the `DocSpec` document conversion library.
+//!
+//! Exposes the markdown-to-`BlockNote` conversion pipeline for use in browser
+//! environments via wasm-bindgen.
+
+use docspec_blocknote_writer::BlockNoteWriter;
+use docspec_core::{Error, EventSink as _, EventSource as _};
+use docspec_markdown_reader::MarkdownReader;
+use wasm_bindgen::prelude::*;
+
+/// Converts a Markdown string to `BlockNote` JSON format.
+///
+/// # Errors
+///
+/// Returns a JavaScript error string if the conversion fails due to a
+/// parse error, invalid event sequence, or JSON serialization error.
+#[wasm_bindgen]
+pub fn convert_markdown_to_blocknote(markdown: &str) -> core::result::Result<String, JsValue> {
+    let mut reader = MarkdownReader::new(markdown);
+    let mut output = Vec::new();
+    let mut writer = BlockNoteWriter::new(&mut output);
+
+    let mut next = reader.next_event();
+    while let Ok(Some(event)) = next {
+        writer
+            .handle_event(event)
+            .map_err(|e| JsValue::from_str(&e.to_string()))?;
+        next = reader.next_event();
+    }
+    next.map_err(|e| JsValue::from_str(&e.to_string()))?;
+    writer
+        .finish()
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    String::from_utf8(output)
+        .map_err(|e| Error::Other {
+            message: e.to_string(),
+        })
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::convert_markdown_to_blocknote;
+
+    #[test]
+    fn heading_and_paragraph() {
+        let result = convert_markdown_to_blocknote("# Hello\n\nWorld");
+        assert!(result.is_ok(), "conversion failed: {result:?}");
+        assert_eq!(
+            result.unwrap_or_default(),
+            r#"[{"type":"heading","props":{"level":1,"textAlignment":"left"},"content":[{"type":"text","text":"Hello","styles":{}}],"children":[]},{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"World","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn empty_input() {
+        let result = convert_markdown_to_blocknote("");
+        assert!(result.is_ok(), "empty input should succeed: {result:?}");
+        assert_eq!(result.unwrap_or_default(), "[]");
+    }
+
+    #[test]
+    fn plain_paragraph() {
+        let result = convert_markdown_to_blocknote("Just a paragraph");
+        assert!(result.is_ok(), "conversion failed: {result:?}");
+        assert_eq!(
+            result.unwrap_or_default(),
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Just a paragraph","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn bold_and_italic_formatting() {
+        let result = convert_markdown_to_blocknote("**bold** and *italic*");
+        assert!(result.is_ok(), "conversion failed: {result:?}");
+        assert_eq!(
+            result.unwrap_or_default(),
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"bold","styles":{"bold":true}},{"type":"text","text":" and ","styles":{}},{"type":"text","text":"italic","styles":{"italic":true}}],"children":[]}]"#
+        );
+    }
+}

--- a/justfile
+++ b/justfile
@@ -48,6 +48,14 @@ typos:
 taplo:
     taplo fmt --check
 
+# Build the WASM artifact for browser use (debug)
+wasm:
+    wasm-pack build --dev --target web crates/docspec-wasm
+
+# Build the WASM artifact for browser use (release)
+wasm-release:
+    wasm-pack build --release --target web crates/docspec-wasm
+
 # Clean build artifacts
 clean:
     cargo clean


### PR DESCRIPTION
## Summary

- Add `docspec-wasm` workspace member wrapping the markdown→BlockNote streaming pipeline with `wasm-bindgen` bindings
- Single exported function: `convert_markdown_to_blocknote(markdown) → JSON string`
- Buildable WASM artifact via `wasm-pack build --target web crates/docspec-wasm`

## What changed

| File | Change |
|------|--------|
| `Cargo.toml` | Add `crates/docspec-wasm` to workspace members |
| `crates/docspec-wasm/Cargo.toml` | New crate: `cdylib` + `rlib`, `wasm-bindgen` dep, workspace lint inheritance |
| `crates/docspec-wasm/src/lib.rs` | One `#[wasm_bindgen]` export + 4 tests with exact JSON assertions |
| `justfile` | Add `just wasm` recipe |

## Design

Thin wrapper crate — existing crates (`docspec-core`, `docspec-markdown-reader`, `docspec-blocknote-writer`) are untouched. The wrapper replicates the CLI pipeline pattern (`MarkdownReader` → event loop → `BlockNoteWriter`) writing to a borrowed `Vec<u8>`, then returns the JSON string across the WASM boundary. Errors convert via `Display` → `JsValue::from_str()`.

## Verification

- `cargo test --workspace` — 226 tests pass (4 new in docspec-wasm)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo check --target wasm32-unknown-unknown -p docspec-wasm` — compiles
- `wasm-pack build --target web crates/docspec-wasm` — produces `pkg/` with `.js`, `.wasm`, `.d.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebAssembly bindings enabling markdown → BlockNote conversion in web browsers.

* **Documentation**
  * Added a short README describing the wasm bindings and linking to main docs.

* **Chores**
  * Project workspace updated to include the new wasm crate.
  * Added build recipes to produce debug and release WebAssembly artifacts.

* **Tests**
  * Added unit tests covering headings, paragraphs, empty input, and inline formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->