### PR TITLE
chore(ci): configure release-please and renovate

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,7 @@
+{
+  "crates/docspec-core": "0.1.0",
+  "crates/docspec-markdown-reader": "0.1.0",
+  "crates/docspec-blocknote-writer": "0.1.0",
+  "crates/docspec-cli": "0.1.0",
+  "crates/docspec-wasm": "0.1.0"
+}

--- a/crates/docspec-blocknote-writer/Cargo.toml
+++ b/crates/docspec-blocknote-writer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docspec-blocknote-writer"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/docspec-cli/Cargo.toml
+++ b/crates/docspec-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docspec-cli"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/docspec-core/Cargo.toml
+++ b/crates/docspec-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docspec-core"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/docspec-markdown-reader/Cargo.toml
+++ b/crates/docspec-markdown-reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docspec-markdown-reader"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/docspec-wasm/Cargo.toml
+++ b/crates/docspec-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "docspec-wasm"
-version.workspace = true
+version = "0.1.0"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "release-type": "rust",
+  "include-component-in-tag": false,
+  "packages": {
+    "crates/docspec-core": { "component": "docspec-core" },
+    "crates/docspec-markdown-reader": { "component": "docspec-markdown-reader" },
+    "crates/docspec-blocknote-writer": { "component": "docspec-blocknote-writer" },
+    "crates/docspec-cli": { "component": "docspec-cli" },
+    "crates/docspec-wasm": { "component": "docspec-wasm" }
+  },
+  "plugins": [
+    { "type": "cargo-workspace", "merge": false },
+    {
+      "type": "linked-versions",
+      "groupName": "docspec",
+      "components": ["docspec-core", "docspec-markdown-reader", "docspec-blocknote-writer", "docspec-cli", "docspec-wasm"]
+    }
+  ]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "labels": ["dependencies"],
+  "semanticCommits": "enabled",
+  "packageRules": [
+    {
+      "description": "Automerge patch/minor updates with sufficient confidence and age",
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchConfidence": ["neutral", "high", "very high"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true
+    },
+    {
+      "description": "Require manual review for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Configure automated releases via release-please and dependency updates via Renovate.

## Changes

### Release-please
- Add `release-please-config.json` with manifest config
- Add `.release-please-manifest.json` for version tracking
- Add `.github/workflows/release-please.yml` workflow
- Configure `linked-versions` plugin to keep all 5 crates synchronized
- Configure `cargo-workspace` plugin with `merge: false`

### Renovate
- Add `renovate.json` with automerge rules:
  - Patch/minor updates: automerge after 7 days with neutral+ confidence
  - Major updates: require manual review
- Labels PRs with `dependencies`
- Uses semantic commits

### Version Migration
- Migrate all 5 sub-crates from `version.workspace = true` to explicit `version = "0.1.0"`
- Required because release-please cargo-workspace plugin cannot handle workspace version inheritance (issue googleapis/release-please#2111)

## Verification
- [x] All JSON configs validated with `jq`
- [x] `cargo check --workspace` passes
- [x] All pre-commit hooks pass

## Post-merge Steps
1. Install [Mend Renovate GitHub App](https://github.com/apps/renovate) to enable dependency updates
2. Release-please will automatically create release PRs on future commits to main

Closes #47, closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated release workflow to manage releases from the main branch.
  * Introduced release configuration and a manifest that pins package releases to v0.1.0.
  * Converted several packages to explicit crate-local versions for clearer versioning.
  * Configured dependency update automation (Renovate) with automerge rules for safe updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/49)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/49)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->