### PR TITLE
chore(cargo): mark workspace as unpublishable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/docspec/docspec"
+publish = false
 
 [workspace.lints.rust]
 unsafe_code = "forbid"


### PR DESCRIPTION
## Summary

Set `publish = false` at workspace level to prevent accidental crates.io publishing until proper publishing infrastructure is ready.

## Changes

- Added `publish = false` to `[workspace.package]` in root `Cargo.toml`

All sub-crates inherit this setting, preventing `cargo publish` from succeeding.

## Related

Relates to #51 (does not close — that issue tracks the full publishing setup)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated workspace configuration settings.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/52)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->