### PR TITLE
feat: add code, strikethrough, underline text formatting support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,3 +118,7 @@ assertions_on_result_states = "allow"
 # --- Selective allows: cargo group ---
 # Reason: Transitive dependency version conflicts are not directly controllable
 multiple_crate_versions = "allow"
+
+# --- Selective allows: pedantic group (continued) ---
+# Reason: BlockNote text styling requires 5 bool parameters (bold, italic, code, strike, underline) that directly map to JSON fields. Refactoring into a struct would add complexity without improving clarity.
+fn_params_excessive_bools = "allow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/docspec/docspec"
+publish = false
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -18,7 +18,7 @@
 //! - `StartParagraph` / `EndParagraph` — paragraph blocks
 //! - `StartBlockQuote` / `EndBlockQuote` — quote blocks
 //! - `StartPreformatted` / `EndPreformatted` — code blocks
-//! - `Text` — inline text content with bold/italic styles
+//! - `Text` — inline text content with bold/italic/code/strikethrough/underline styles
 //! - `Image` — image blocks
 //! - `LineBreak` — line breaks within content blocks
 //! - `ThematicBreak` — divider blocks
@@ -220,7 +220,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
     fn handle_paragraph(&mut self, id: Option<&String>) -> Result<()> {
         if self.blockquote_depth > 0 {
             if self.blockquote_has_content {
-                self.handle_text("\n\n", false, false)?;
+                self.handle_text("\n\n", false, false, false, false, false)?;
             }
             return Ok(());
         }
@@ -257,7 +257,15 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         Ok(())
     }
 
-    fn handle_text(&mut self, content: &str, bold: bool, italic: bool) -> Result<()> {
+    fn handle_text(
+        &mut self,
+        content: &str,
+        bold: bool,
+        italic: bool,
+        code: bool,
+        strikethrough: bool,
+        underline: bool,
+    ) -> Result<()> {
         if !self.in_text_block {
             return Ok(());
         }
@@ -277,6 +285,18 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         }
         if italic {
             self.writer.name("italic").map_err(io_err)?;
+            self.writer.bool_value(true).map_err(io_err)?;
+        }
+        if code {
+            self.writer.name("code").map_err(io_err)?;
+            self.writer.bool_value(true).map_err(io_err)?;
+        }
+        if strikethrough {
+            self.writer.name("strike").map_err(io_err)?;
+            self.writer.bool_value(true).map_err(io_err)?;
+        }
+        if underline {
+            self.writer.name("underline").map_err(io_err)?;
             self.writer.bool_value(true).map_err(io_err)?;
         }
         self.writer.end_object().map_err(io_err)?;
@@ -394,20 +414,23 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
                 content,
                 bold,
                 italic,
+                code,
+                strikethrough,
+                underline,
                 ..
             } => {
                 // Auto-open paragraph for orphan text (e.g., text after image closed paragraph)
                 if !self.in_text_block && self.blockquote_depth == 0 {
                     self.handle_paragraph(None)?;
                 }
-                self.handle_text(&content, bold, italic)
+                self.handle_text(&content, bold, italic, code, strikethrough, underline)
             }
             Event::Image {
                 source, alt, id, ..
             } => self.handle_image(source, alt, id.as_ref()),
             Event::LineBreak => {
                 if self.in_text_block {
-                    self.handle_text("\n", false, false)
+                    self.handle_text("\n", false, false, false, false, false)
                 } else {
                     Ok(())
                 }

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -2122,4 +2122,136 @@ mod tests {
             r#"[{"type":"quote","content":[],"children":[]},{"type":"divider"}]"#
         );
     }
+
+    // ============================================================================
+    // CODE/STRIKE/UNDERLINE STYLE TESTS
+    // ============================================================================
+
+    #[test]
+    fn code_text() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "code".to_string(),
+                bold: false,
+                italic: false,
+                code: true,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"code","styles":{"code":true}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn strikethrough_text() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "struck".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: true,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"struck","styles":{"strike":true}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn underline_text() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "underlined".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: true,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"underlined","styles":{"underline":true}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn combined_styles_bold_code_strikethrough() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "combined".to_string(),
+                bold: true,
+                italic: false,
+                code: true,
+                strikethrough: true,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"combined","styles":{"bold":true,"code":true,"strike":true}}],"children":[]}]"#
+        );
+    }
 }

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -28,6 +28,7 @@
 //! - Bold text → `Text { bold: true, ... }`
 //! - Italic text → `Text { italic: true, ... }`
 //! - Inline code → `Text { code: true, ... }`
+//! - Strikethrough → `Text { strikethrough: true, ... }`
 //! - Images → `Image { source: Uri, alt, title, decorative }`
 //! - Hard line breaks → `LineBreak`
 //! - Soft line breaks → space `Text`
@@ -42,7 +43,7 @@
 //! - Definition lists and footnotes
 //! - HTML blocks and inline HTML
 //! - Math blocks and inline math
-//! - Strikethrough, subscript, and superscript formatting
+//! - Subscript and superscript formatting
 
 extern crate alloc;
 
@@ -118,6 +119,8 @@ pub struct MarkdownReader<'a> {
     phase: Phase,
     /// Queue of `DocSpec` events to emit.
     queue: VecDeque<Event>,
+    /// Nesting depth for strikethrough formatting.
+    strikethrough_depth: usize,
 }
 
 impl<'a> MarkdownReader<'a> {
@@ -137,7 +140,7 @@ impl<'a> MarkdownReader<'a> {
                 bold: self.bold_depth > 0,
                 italic: self.italic_depth > 0,
                 code: true,
-                strikethrough: false,
+                strikethrough: self.strikethrough_depth > 0,
                 underline: false,
                 subscript: false,
                 superscript: false,
@@ -161,6 +164,9 @@ impl<'a> MarkdownReader<'a> {
             }
             TagEnd::Strong => {
                 self.bold_depth = self.bold_depth.saturating_sub(1);
+            }
+            TagEnd::Strikethrough => {
+                self.strikethrough_depth = self.strikethrough_depth.saturating_sub(1);
             }
             TagEnd::Image => {
                 if let Some(img) = self.image.take() {
@@ -191,7 +197,7 @@ impl<'a> MarkdownReader<'a> {
                             bold: false,
                             italic: false,
                             code: true,
-                            strikethrough: false,
+                            strikethrough: self.strikethrough_depth > 0,
                             underline: false,
                             subscript: false,
                             superscript: false,
@@ -209,7 +215,6 @@ impl<'a> MarkdownReader<'a> {
             | TagEnd::Link
             | TagEnd::List(_)
             | TagEnd::MetadataBlock(_)
-            | TagEnd::Strikethrough
             | TagEnd::Subscript
             | TagEnd::Superscript
             | TagEnd::Table
@@ -254,6 +259,9 @@ impl<'a> MarkdownReader<'a> {
             Tag::Strong => {
                 self.bold_depth = self.bold_depth.saturating_add(1);
             }
+            Tag::Strikethrough => {
+                self.strikethrough_depth = self.strikethrough_depth.saturating_add(1);
+            }
             Tag::Image {
                 dest_url, title, ..
             } => {
@@ -276,7 +284,6 @@ impl<'a> MarkdownReader<'a> {
             | Tag::Link { .. }
             | Tag::List(_)
             | Tag::MetadataBlock(_)
-            | Tag::Strikethrough
             | Tag::Subscript
             | Tag::Superscript
             | Tag::Table(_)
@@ -304,7 +311,7 @@ impl<'a> MarkdownReader<'a> {
                 bold: self.bold_depth > 0,
                 italic: self.italic_depth > 0,
                 code: false,
-                strikethrough: false,
+                strikethrough: self.strikethrough_depth > 0,
                 underline: false,
                 subscript: false,
                 superscript: false,
@@ -328,7 +335,7 @@ impl<'a> MarkdownReader<'a> {
     #[inline]
     #[must_use]
     pub fn new(markdown: &'a str) -> Self {
-        let options = Options::ENABLE_TABLES;
+        let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
         let parser = Parser::new_ext(markdown, options);
         Self {
             block_state: BlockState::None,
@@ -339,6 +346,7 @@ impl<'a> MarkdownReader<'a> {
             parser,
             phase: Phase::NotStarted,
             queue: VecDeque::new(),
+            strikethrough_depth: 0,
         }
     }
 
@@ -372,7 +380,7 @@ impl<'a> MarkdownReader<'a> {
                         bold: self.bold_depth > 0,
                         italic: self.italic_depth > 0,
                         code: false,
-                        strikethrough: false,
+                        strikethrough: self.strikethrough_depth > 0,
                         underline: false,
                         subscript: false,
                         superscript: false,

--- a/crates/docspec-markdown-reader/tests/integration.rs
+++ b/crates/docspec-markdown-reader/tests/integration.rs
@@ -123,4 +123,12 @@ mod tests {
         let actual = run_pipeline(markdown);
         assert_json_eq(&actual, expected);
     }
+
+    #[test]
+    fn pipeline_text_formatting() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/text_formatting.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/text_formatting.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
 }

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -608,4 +608,114 @@ mod tests {
             Some(Event::Text { content, .. }) if content == "code\n\n"
         ));
     }
+
+    #[test]
+    fn strikethrough_basic() {
+        let mut reader = MarkdownReader::new("~~struck~~");
+        let events = collect_events(&mut reader);
+
+        let text_event = events.iter().find(|e| {
+            matches!(
+                e,
+                Event::Text {
+                    strikethrough: true,
+                    ..
+                }
+            )
+        });
+        assert!(matches!(
+            text_event,
+            Some(Event::Text { content, strikethrough: true, .. }) if content == "struck"
+        ));
+    }
+
+    #[test]
+    fn strikethrough_with_bold() {
+        let mut reader = MarkdownReader::new("~~**bold struck**~~");
+        let events = collect_events(&mut reader);
+
+        let text_event = events.iter().find(|e| {
+            matches!(
+                e,
+                Event::Text {
+                    bold: true,
+                    strikethrough: true,
+                    ..
+                }
+            )
+        });
+        assert!(matches!(
+            text_event,
+            Some(Event::Text { content, bold: true, strikethrough: true, .. }) if content == "bold struck"
+        ));
+    }
+
+    #[test]
+    fn strikethrough_with_italic() {
+        let mut reader = MarkdownReader::new("~~*italic struck*~~");
+        let events = collect_events(&mut reader);
+
+        let text_event = events.iter().find(|e| {
+            matches!(
+                e,
+                Event::Text {
+                    italic: true,
+                    strikethrough: true,
+                    ..
+                }
+            )
+        });
+        assert!(matches!(
+            text_event,
+            Some(Event::Text { content, italic: true, strikethrough: true, .. }) if content == "italic struck"
+        ));
+    }
+
+    #[test]
+    fn strikethrough_in_paragraph() {
+        let markdown = "This is ~~struck~~ text in a paragraph.";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartParagraph { .. })));
+
+        let struck_text = events.iter().find(|e| {
+            matches!(
+                e,
+                Event::Text {
+                    content,
+                    strikethrough: true,
+                    ..
+                } if content == "struck"
+            )
+        });
+        assert!(
+            struck_text.is_some(),
+            "Should find strikethrough text in paragraph"
+        );
+    }
+
+    #[test]
+    fn strikethrough_with_bold_and_italic() {
+        let mut reader = MarkdownReader::new("~~***bold italic struck***~~");
+        let events = collect_events(&mut reader);
+
+        let text_event = events.iter().find(|e| {
+            matches!(
+                e,
+                Event::Text {
+                    bold: true,
+                    italic: true,
+                    strikethrough: true,
+                    ..
+                }
+            )
+        });
+        assert!(matches!(
+            text_event,
+            Some(Event::Text { content, bold: true, italic: true, strikethrough: true, .. }) if content == "bold italic struck"
+        ));
+    }
 }

--- a/tests/fixtures/blocknote/text_formatting.json
+++ b/tests/fixtures/blocknote/text_formatting.json
@@ -1,0 +1,175 @@
+[
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "This is a paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "strikethrough",
+        "styles": {
+          "strike": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " text.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "This is a paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "code",
+        "styles": {
+          "code": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " text.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "This is a paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "bold struck",
+        "styles": {
+          "bold": true,
+          "strike": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " text.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "This is a paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "**bold code**",
+        "styles": {
+          "code": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " text.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "This is a paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "italic struck",
+        "styles": {
+          "italic": true,
+          "strike": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " text.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "This is a paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "bold italic struck",
+        "styles": {
+          "bold": true,
+          "italic": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " and ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "combined",
+        "styles": {
+          "bold": true,
+          "italic": true,
+          "strike": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " text.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  }
+]

--- a/tests/fixtures/markdown/text_formatting.md
+++ b/tests/fixtures/markdown/text_formatting.md
@@ -1,0 +1,11 @@
+This is a paragraph with ~~strikethrough~~ text.
+
+This is a paragraph with `code` text.
+
+This is a paragraph with ~~**bold struck**~~ text.
+
+This is a paragraph with `**bold code**` text.
+
+This is a paragraph with ~~*italic struck*~~ text.
+
+This is a paragraph with ***bold italic struck*** and ~~***combined***~~ text.


### PR DESCRIPTION
## Summary

- Enable strikethrough parsing in markdown reader via `ENABLE_STRIKETHROUGH`
- Add `strikethrough_depth` counter following bold/italic pattern
- Emit `code`, `strike`, `underline` styles in BlockNote writer JSON output

## Changes

### Markdown Reader
- Added `strikethrough_depth` field to track nesting
- Enabled `Options::ENABLE_STRIKETHROUGH` in pulldown-cmark
- All text emission sites now include strikethrough flag

### BlockNote Writer
- Extended `handle_text()` to accept code, strikethrough, underline params
- Emits `"code": true`, `"strike": true`, `"underline": true` in JSON styles
- Note: Uses `strike` (not `strikethrough`) per BlockNote convention

## Test Coverage

- 5 new strikethrough tests for markdown reader
- 4 new style tests for BlockNote writer  
- 1 new integration test for full pipeline

## References

- #12 (BlockNote writer)
- #37 (Markdown reader)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for strikethrough, inline code, and underline text formatting in BlockNote output; Markdown conversion now preserves strikethrough.

* **Tests**
  * Added comprehensive unit/integration tests and fixtures covering inline text styling and multi-style combinations.

* **Chores**
  * Disabled workspace package publishing and updated linter configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/53)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->