### PR TITLE
feat: add task list support with refactored list event model

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -55,15 +55,9 @@ Readers register assets as encountered. Writers call `stream_to()` on demand —
 ```rust
 enum TextAlignment { Left, Center, Right, Justify }
 
-enum ListType { Ordered, Unordered }
+enum OrderedListStyle { Decimal, LowerAlpha, UpperAlpha, LowerRoman, UpperRoman }
 
-enum ListStyleType {
-    // Ordered list styles
-    Decimal, LowerAlpha, UpperAlpha, LowerRoman, UpperRoman,
-    // Unordered list styles
-    Disc, Circle, Square,
-}
-// Writers ignore mismatched styles (e.g., Disc on an ordered list).
+enum UnorderedListStyle { Disc, Circle, Square }
 
 enum TableHeaderScope { Column, Row }  // Column: header describes cells below; Row: header describes cells to the right
 
@@ -108,9 +102,50 @@ All events in the `Event` enum, grouped by category.
 
 **Lists:**
 
-| Event            | Fields                                                                                         | Pair           |
-| ---------------- | ---------------------------------------------------------------------------------------------- | -------------- |
-| `StartListItem`  | `level: u8`, `list_type: ListType`, `start: Option<u32>`, `style_type: Option<ListStyleType>` | `EndListItem`  |
+| Event                     | Fields                                                                          | Pair                   |
+| ------------------------- | ------------------------------------------------------------------------------- | ---------------------- |
+| `StartOrderedListItem`    | `id: Option<String>`, `level: u8`, `start: Option<u32>`, `style: Option<OrderedListStyle>` | `EndOrderedListItem`   |
+| `StartUnorderedListItem`  | `id: Option<String>`, `level: u8`, `style: Option<UnorderedListStyle>`          | `EndUnorderedListItem` |
+| `StartCheckListItem`      | `id: Option<String>`, `level: u8`, `checked: bool`                              | `EndCheckListItem`     |
+
+**List Examples:**
+
+```
+Simple ordered list (1. First, 2. Second):
+  StartOrderedListItem { id: None, level: 1, start: Some(1), style: None }
+    Text { content: "First", ... }
+  EndOrderedListItem
+  StartOrderedListItem { id: None, level: 1, start: None, style: None }
+    Text { content: "Second", ... }
+  EndOrderedListItem
+
+Simple unordered list (- Item, - Item):
+  StartUnorderedListItem { id: None, level: 1, style: None }
+    Text { content: "Item", ... }
+  EndUnorderedListItem
+  StartUnorderedListItem { id: None, level: 1, style: None }
+    Text { content: "Item", ... }
+  EndUnorderedListItem
+
+Task/check list (- [x] Done, - [ ] Todo):
+  StartCheckListItem { id: None, level: 1, checked: true }
+    Text { content: "Done", ... }
+  EndCheckListItem
+  StartCheckListItem { id: None, level: 1, checked: false }
+    Text { content: "Todo", ... }
+  EndCheckListItem
+
+Nested list (level 1, level 2):
+  StartUnorderedListItem { id: None, level: 1, style: None }
+    Text { content: "Parent", ... }
+    StartOrderedListItem { id: None, level: 2, start: Some(1), style: None }
+      Text { content: "Child 1", ... }
+    EndOrderedListItem
+    StartOrderedListItem { id: None, level: 2, start: None, style: None }
+      Text { content: "Child 2", ... }
+    EndOrderedListItem
+  EndUnorderedListItem
+```
 
 **Tables:**
 
@@ -161,7 +196,13 @@ Every `Start*` has a matching `End*`. They nest but never overlap.
 
 **Heading.** Levels 1–6 are standard (HTML). DOCX/ODT/RTF support 1–9. Writers clamp higher levels. Both heading and list levels are 1-based (range 1–255); no format exceeds 9.
 
-**List items.** Nesting is flat — children follow parents sequentially, distinguished by `level`. No `StartList`/`EndList` exists. The `start` field sets numbering base until another `start` appears. **Boundary rules:** a new list begins when (a) a non-list block intervenes, (b) `list_type` changes at the same level, or (c) level decreases then increases without a parent.
+**List items.** Three distinct list item types: ordered, unordered, and check lists. Each has its own start/end event pair with fields relevant to that type only.
+
+- **Ordered lists:** Numbered items (1, 2, 3 or a, b, c). Carry optional `start` for numbering offset and `style` for marker appearance.
+- **Unordered lists:** Bulleted items. Carry optional `style` for bullet appearance (disc, circle, square).
+- **Check lists:** Task items with checkboxes. Carry required `checked` boolean. No style field (checkboxes are checkboxes).
+
+All list items have `id` for optional block identifiers and `level` for nesting (1 = top-level). Nesting is flat — children follow parents sequentially, distinguished by `level`. No `StartList`/`EndList` exists. **Boundary rules:** a new list begins when (a) a non-list block intervenes, (b) list type changes at the same level, or (c) level decreases then increases without a parent.
 
 **Table.** `StartCaption` is optional, appears before rows. Header cells carry `scope`/`abbr` for accessibility; data cells omit these. Cells may contain any block element.
 
@@ -195,7 +236,7 @@ Readers MUST produce well-formed streams. Writers MAY assume well-formedness.
 2. Exactly one root: `StartDocument`. Empty containers (`Start*` immediately followed by `End*`) are valid.
 3. `Text` appears only inside containers, never at root.
 4. `StartLink` appears inside inline-accepting blocks (paragraphs, headings, list items, cells, definition details). Links do not nest.
-5. `StartListItem` appears inside block containers. List items are flat — distinguished by `level` field.
+5. List item events (`StartOrderedListItem`, `StartUnorderedListItem`, `StartCheckListItem`) appear inside block containers. List items are flat — distinguished by `level` field.
 6. `StartCaption` appears at most once per table, before any rows.
 7. Each footnote ID appears in exactly one `FootnoteRef` and one `StartFootnote`.
 8. Table structure: `StartTableRow` appears only inside `StartTable`. `StartTableCell`/`StartTableHeader` appear only inside `StartTableRow`.

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -18,14 +18,15 @@
 //! - `StartParagraph` / `EndParagraph` — paragraph blocks
 //! - `StartBlockQuote` / `EndBlockQuote` — quote blocks
 //! - `StartPreformatted` / `EndPreformatted` — code blocks
+//! - `StartOrderedListItem` / `EndOrderedListItem` — numbered list items
+//! - `StartUnorderedListItem` / `EndUnorderedListItem` — bullet list items
+//! - `StartCheckListItem` / `EndCheckListItem` — check list items with checked state
 //! - `Text` — inline text content with bold/italic/code/strikethrough/underline styles
 //! - `Image` — image blocks
 //! - `LineBreak` — line breaks within content blocks
 //! - `ThematicBreak` — divider blocks
 //!
-//! List and table structure events (`StartListItem`, `StartTable*`, etc.) are silently ignored
-//! by this writer. Use `StackTrackingSink` from `docspec_core` to wrap the writer for automatic
-//! paragraph insertion within list items and table cells.
+//! Table structure events (`StartTable*`, etc.) are silently ignored by this writer.
 //!
 //! # Example
 //!
@@ -62,6 +63,15 @@ use base64::write::EncoderWriter as Base64Encoder;
 use docspec_core::{AssetProvider, Error, Event, EventSink, ImageSource, Result};
 use struson::writer::{JsonStreamWriter, JsonWriter as _};
 
+/// Tracks a list item's state for nesting support.
+#[derive(Debug, Clone)]
+struct ListItemState {
+    /// Whether the content array has been closed (ready for children).
+    content_closed: bool,
+    /// The nesting level of this list item (1 = top-level).
+    level: u8,
+}
+
 /// A streaming `BlockNote` JSON writer.
 ///
 /// Writes JSON tokens directly to the underlying `Write` as events arrive using `struson`.
@@ -84,6 +94,8 @@ pub struct BlockNoteWriter<'a, W: Write> {
     blockquote_has_content: bool,
     /// Whether we are inside a text-bearing content block (heading, paragraph, preformatted, or blockquote).
     in_text_block: bool,
+    /// Stack of list item states for nesting support.
+    list_item_stack: Vec<ListItemState>,
     /// The underlying JSON stream writer.
     writer: JsonStreamWriter<W>,
 }
@@ -117,6 +129,28 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         Ok(())
     }
 
+    fn close_list_items_to_level(&mut self, target_level: u8) -> Result<()> {
+        while let Some(item_state) = self.list_item_stack.last() {
+            if item_state.level < target_level {
+                break;
+            }
+
+            let Some(popped_state) = self.list_item_stack.pop() else {
+                break;
+            };
+
+            if !popped_state.content_closed {
+                self.writer.end_array().map_err(io_err)?;
+                self.writer.name("children").map_err(io_err)?;
+                self.writer.begin_array().map_err(io_err)?;
+            }
+            self.writer.end_array().map_err(io_err)?;
+            self.writer.end_object().map_err(io_err)?;
+        }
+        self.in_text_block = !self.list_item_stack.is_empty();
+        Ok(())
+    }
+
     fn handle_blockquote(&mut self, id: Option<&String>) -> Result<()> {
         self.writer.begin_object().map_err(io_err)?;
         self.writer.name("type").map_err(io_err)?;
@@ -136,6 +170,48 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         self.writer.string_value("divider").map_err(io_err)?;
         self.write_id(id)?;
         self.writer.end_object().map_err(io_err)?;
+        Ok(())
+    }
+
+    fn handle_end_blockquote(&mut self) -> Result<()> {
+        if self.blockquote_force_closed_count > 0 {
+            self.blockquote_force_closed_count =
+                self.blockquote_force_closed_count.saturating_sub(1);
+            return Ok(());
+        }
+        self.close_content_block()?;
+        self.blockquote_depth = self.blockquote_depth.saturating_sub(1);
+        self.in_text_block = self.blockquote_depth > 0;
+        Ok(())
+    }
+
+    fn handle_end_list_item(&mut self) -> Result<()> {
+        if let Some(state) = self.list_item_stack.pop() {
+            if !state.content_closed {
+                self.writer.end_array().map_err(io_err)?;
+                self.writer.name("children").map_err(io_err)?;
+                self.writer.begin_array().map_err(io_err)?;
+            }
+            self.writer.end_array().map_err(io_err)?;
+            self.writer.end_object().map_err(io_err)?;
+        }
+        self.in_text_block = self
+            .list_item_stack
+            .last()
+            .is_some_and(|parent| !parent.content_closed);
+        Ok(())
+    }
+
+    fn handle_end_paragraph(&mut self) -> Result<()> {
+        let in_list_content = self
+            .list_item_stack
+            .last()
+            .is_some_and(|item| !item.content_closed);
+        if self.blockquote_depth > 0 || !self.in_text_block || in_list_content {
+            return Ok(());
+        }
+        self.close_content_block()?;
+        self.in_text_block = false;
         Ok(())
     }
 
@@ -163,7 +239,17 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         alt: Option<String>,
         id: Option<&String>,
     ) -> Result<()> {
-        self.close_for_block_sibling()?;
+        if let Some(parent) = self.list_item_stack.last_mut() {
+            if !parent.content_closed {
+                self.writer.end_array().map_err(io_err)?;
+                self.writer.name("children").map_err(io_err)?;
+                self.writer.begin_array().map_err(io_err)?;
+                parent.content_closed = true;
+                self.in_text_block = false;
+            }
+        } else {
+            self.close_for_block_sibling()?;
+        }
         let url = match source {
             ImageSource::Uri { uri } => uri,
             ImageSource::Asset { asset_id } => {
@@ -217,11 +303,69 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         Ok(())
     }
 
+    fn handle_list_item(
+        &mut self,
+        block_type: &str,
+        level: u8,
+        id: Option<&String>,
+        checked: Option<bool>,
+    ) -> Result<()> {
+        self.close_list_items_to_level(level)?;
+
+        let is_nested_child = self
+            .list_item_stack
+            .last()
+            .is_some_and(|parent| level > parent.level);
+
+        if !is_nested_child {
+            self.close_for_block_sibling()?;
+        }
+
+        if let Some(parent) = self.list_item_stack.last_mut() {
+            if level > parent.level && !parent.content_closed {
+                self.writer.end_array().map_err(io_err)?;
+                self.writer.name("children").map_err(io_err)?;
+                self.writer.begin_array().map_err(io_err)?;
+                parent.content_closed = true;
+            }
+        }
+
+        self.writer.begin_object().map_err(io_err)?;
+        self.writer.name("type").map_err(io_err)?;
+        self.writer.string_value(block_type).map_err(io_err)?;
+        self.write_id(id)?;
+        self.writer.name("props").map_err(io_err)?;
+        self.writer.begin_object().map_err(io_err)?;
+        self.writer.name("textAlignment").map_err(io_err)?;
+        self.writer.string_value("left").map_err(io_err)?;
+        if let Some(is_checked) = checked {
+            self.writer.name("checked").map_err(io_err)?;
+            self.writer.bool_value(is_checked).map_err(io_err)?;
+        }
+        self.writer.end_object().map_err(io_err)?;
+        self.writer.name("content").map_err(io_err)?;
+        self.writer.begin_array().map_err(io_err)?;
+
+        self.list_item_stack.push(ListItemState {
+            content_closed: false,
+            level,
+        });
+        self.in_text_block = true;
+        Ok(())
+    }
+
     fn handle_paragraph(&mut self, id: Option<&String>) -> Result<()> {
         if self.blockquote_depth > 0 {
             if self.blockquote_has_content {
                 self.handle_text("\n\n", false, false, false, false, false)?;
             }
+            return Ok(());
+        }
+        if self
+            .list_item_stack
+            .last()
+            .is_some_and(|item| !item.content_closed)
+        {
             return Ok(());
         }
         self.writer.begin_object().map_err(io_err)?;
@@ -318,6 +462,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             blockquote_force_closed_count: 0,
             blockquote_has_content: false,
             in_text_block: false,
+            list_item_stack: Vec::new(),
             writer: JsonStreamWriter::new(writer),
         }
     }
@@ -341,6 +486,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             blockquote_force_closed_count: 0,
             blockquote_has_content: false,
             in_text_block: false,
+            list_item_stack: Vec::new(),
             writer: JsonStreamWriter::new(writer),
         }
     }
@@ -379,29 +525,12 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
                 Ok(())
             }
             Event::StartParagraph { id, .. } => self.handle_paragraph(id.as_ref()),
-            Event::EndParagraph => {
-                if self.blockquote_depth > 0 || !self.in_text_block {
-                    return Ok(());
-                }
-                self.close_content_block()?;
-                self.in_text_block = false;
-                Ok(())
-            }
+            Event::EndParagraph => self.handle_end_paragraph(),
             Event::StartBlockQuote { id, .. } => {
                 self.close_for_block_sibling()?;
                 self.handle_blockquote(id.as_ref())
             }
-            Event::EndBlockQuote => {
-                if self.blockquote_force_closed_count > 0 {
-                    self.blockquote_force_closed_count =
-                        self.blockquote_force_closed_count.saturating_sub(1);
-                    return Ok(());
-                }
-                self.close_content_block()?;
-                self.blockquote_depth = self.blockquote_depth.saturating_sub(1);
-                self.in_text_block = self.blockquote_depth > 0;
-                Ok(())
-            }
+            Event::EndBlockQuote => self.handle_end_blockquote(),
             Event::StartPreformatted { id, syntax, .. } => {
                 self.close_for_block_sibling()?;
                 self.handle_preformatted(id.as_ref(), syntax.as_ref())
@@ -435,13 +564,24 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
                     Ok(())
                 }
             }
+            Event::StartOrderedListItem { id, level, .. } => {
+                self.handle_list_item("numberedListItem", level, id.as_ref(), None)
+            }
+            Event::StartUnorderedListItem { id, level, .. } => {
+                self.handle_list_item("bulletListItem", level, id.as_ref(), None)
+            }
+            Event::StartCheckListItem { id, level, checked } => {
+                self.handle_list_item("checkListItem", level, id.as_ref(), Some(checked))
+            }
+            Event::EndOrderedListItem | Event::EndUnorderedListItem | Event::EndCheckListItem => {
+                self.handle_end_list_item()
+            }
             Event::EndCaption
             | Event::EndDefinitionTerm
             | Event::EndLink
             | Event::EndDefinitionDetail
             | Event::EndDefinitionList
             | Event::EndFootnote
-            | Event::EndListItem
             | Event::EndTable
             | Event::EndTableCell
             | Event::EndTableHeader
@@ -453,7 +593,6 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             | Event::StartDefinitionTerm { .. }
             | Event::StartFootnote { .. }
             | Event::StartLink { .. }
-            | Event::StartListItem { .. }
             | Event::StartTable { .. }
             | Event::StartTableCell { .. }
             | Event::StartTableHeader { .. }

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -856,12 +856,10 @@ mod tests {
                 language: None,
                 metadata: None,
             },
-            Event::StartListItem {
+            Event::StartUnorderedListItem {
                 id: None,
                 level: 1,
-                list_type: docspec_core::ListType::Unordered,
-                start: None,
-                style_type: None,
+                style: None,
             },
             Event::Text {
                 content: "Item".to_string(),
@@ -874,12 +872,12 @@ mod tests {
                 superscript: false,
                 mark: None,
             },
-            Event::EndListItem,
+            Event::EndUnorderedListItem,
             Event::EndDocument,
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Item","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Item","styles":{}}],"children":[]}]"#
         );
     }
 
@@ -2252,6 +2250,626 @@ mod tests {
         assert_eq!(
             json,
             r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"combined","styles":{"bold":true,"code":true,"strike":true}}],"children":[]}]"#
+        );
+    }
+
+    // ============================================================================
+    // LIST TESTS
+    // ============================================================================
+
+    #[test]
+    fn ordered_list_outputs_numbered_list_item() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartOrderedListItem {
+                id: None,
+                level: 1,
+                start: Some(1),
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "First".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndOrderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"numberedListItem""#),
+            "Expected numberedListItem type"
+        );
+        assert!(json.contains("First"), "Expected text content");
+    }
+
+    #[test]
+    fn unordered_list_outputs_bullet_list_item() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Bullet".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"bulletListItem""#),
+            "Expected bulletListItem type"
+        );
+    }
+
+    #[test]
+    fn check_list_outputs_check_list_item_checked() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartCheckListItem {
+                id: None,
+                level: 1,
+                checked: true,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Done".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndCheckListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"checkListItem""#),
+            "Expected checkListItem type"
+        );
+        assert!(
+            json.contains(r#""checked":true"#),
+            "Expected checked:true prop"
+        );
+    }
+
+    #[test]
+    fn check_list_outputs_check_list_item_unchecked() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartCheckListItem {
+                id: None,
+                level: 1,
+                checked: false,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Todo".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndCheckListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"checkListItem""#),
+            "Expected checkListItem type"
+        );
+        assert!(
+            json.contains(r#""checked":false"#),
+            "Expected checked:false prop"
+        );
+    }
+
+    #[test]
+    fn nested_list_uses_children_array() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Parent".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 2,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Child".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"bulletListItem""#),
+            "Expected parent to be bulletListItem type"
+        );
+        assert!(
+            json.contains(r#""children":["#),
+            "Expected children array for nesting"
+        );
+        assert!(json.contains("Parent"), "Expected parent text");
+        assert!(json.contains("Child"), "Expected child text");
+    }
+
+    #[test]
+    fn list_level_transition_deep_to_shallow() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Parent".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 2,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Child".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Sibling".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains("Parent"), "Expected parent text");
+        assert!(json.contains("Child"), "Expected child text");
+        assert!(json.contains("Sibling"), "Expected sibling text");
+        assert!(
+            json.contains(r#""type":"bulletListItem""#),
+            "Expected bulletListItem type"
+        );
+    }
+
+    #[test]
+    fn list_level_transition_skip_levels_deep() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Level1".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 2,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Level2".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 3,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Level3".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains("Level1"), "Expected Level1 text");
+        assert!(json.contains("Level2"), "Expected Level2 text");
+        assert!(json.contains("Level3"), "Expected Level3 text");
+    }
+
+    #[test]
+    fn list_level_transition_skip_levels_return() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Level1Again".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains("Level1Again"), "Expected Level1Again text");
+        assert!(
+            json.contains(r#""type":"bulletListItem""#),
+            "Expected bulletListItem type"
+        );
+    }
+
+    #[test]
+    fn list_same_level_siblings() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Parent".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 2,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "FirstChild".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 2,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "SecondChild".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains("Parent"), "Expected parent text");
+        assert!(json.contains("FirstChild"), "Expected first child text");
+        assert!(json.contains("SecondChild"), "Expected second child text");
+        assert!(
+            json.contains(r#""children":["#),
+            "Expected children array for nesting"
+        );
+    }
+
+    #[test]
+    fn image_inside_list_item_produces_valid_json() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "http://example.com/img.png".to_string(),
+                },
+                alt: Some("alt text".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"bulletListItem""#),
+            "Expected bulletListItem block"
+        );
+        assert!(
+            json.contains(r#""type":"image""#),
+            "Expected image block inside list item"
+        );
+        assert!(
+            json.contains("http://example.com/img.png"),
+            "Expected image URL"
+        );
+    }
+
+    #[test]
+    fn nested_list_with_image_in_parent_produces_valid_json() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style: None,
+            },
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "http://example.com/parent.png".to_string(),
+                },
+                alt: Some("parent image".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 2,
+                style: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Child text".to_string(),
+                bold: false,
+                italic: false,
+                code: false,
+                strikethrough: false,
+                underline: false,
+                subscript: false,
+                superscript: false,
+                mark: None,
+            },
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"bulletListItem""#),
+            "Expected bulletListItem blocks"
+        );
+        assert!(json.contains("parent.png"), "Expected parent image URL");
+        assert!(json.contains("Child text"), "Expected child text content");
+        assert!(
+            json.contains(r#""children":["#),
+            "Expected children array for nested structure"
         );
     }
 }

--- a/crates/docspec-core/src/event.rs
+++ b/crates/docspec-core/src/event.rs
@@ -21,6 +21,9 @@ pub enum Event {
     /// End a table caption.
     EndCaption,
 
+    /// End a check list item.
+    EndCheckListItem,
+
     /// End a definition detail.
     EndDefinitionDetail,
 
@@ -42,8 +45,8 @@ pub enum Event {
     /// End a hyperlink.
     EndLink,
 
-    /// End a list item.
-    EndListItem,
+    /// End an ordered list item.
+    EndOrderedListItem,
 
     /// End a paragraph.
     EndParagraph,
@@ -62,6 +65,9 @@ pub enum Event {
 
     /// End a table row.
     EndTableRow,
+
+    /// End an unordered list item.
+    EndUnorderedListItem,
 
     /// A reference to a footnote.
     FootnoteRef {
@@ -96,6 +102,16 @@ pub enum Event {
     StartCaption {
         /// Optional block identifier.
         id: Option<String>,
+    },
+
+    /// Begin a check list item.
+    StartCheckListItem {
+        /// Whether the checkbox is checked.
+        checked: bool,
+        /// Optional block identifier.
+        id: Option<String>,
+        /// Nesting level (1 = top-level).
+        level: u8,
     },
 
     /// Begin a definition detail (description).
@@ -150,18 +166,16 @@ pub enum Event {
         title: Option<String>,
     },
 
-    /// Begin a list item.
-    StartListItem {
+    /// Begin an ordered list item.
+    StartOrderedListItem {
         /// Optional block identifier.
         id: Option<String>,
         /// Nesting level (1 = top-level).
         level: u8,
-        /// Whether the list is ordered or unordered.
-        list_type: crate::ListType,
-        /// Starting number for ordered lists (None = continue from previous).
+        /// Starting number (None = continue from previous).
         start: Option<u32>,
         /// Visual style for the list marker.
-        style_type: Option<crate::ListStyleType>,
+        style: Option<crate::OrderedListStyle>,
     },
 
     /// Begin a paragraph with optional alignment.
@@ -214,6 +228,16 @@ pub enum Event {
     StartTableRow {
         /// Optional block identifier.
         id: Option<String>,
+    },
+
+    /// Begin an unordered list item.
+    StartUnorderedListItem {
+        /// Optional block identifier.
+        id: Option<String>,
+        /// Nesting level (1 = top-level).
+        level: u8,
+        /// Visual style for the list marker.
+        style: Option<crate::UnorderedListStyle>,
     },
 
     /// A text run with formatting attributes.

--- a/crates/docspec-core/src/lib.rs
+++ b/crates/docspec-core/src/lib.rs
@@ -28,6 +28,6 @@ pub use event::Event;
 pub use stack::{block_kind_for_end, block_kind_for_start, BlockKind, StackTrackingSink};
 pub use traits::{AssetProvider, EventSink, EventSource};
 pub use types::{
-    Author, Color, DocumentMeta, ImageSource, ListStyleType, ListType, TableHeaderScope,
-    TextAlignment,
+    Author, Color, DocumentMeta, ImageSource, OrderedListStyle, TableHeaderScope, TextAlignment,
+    UnorderedListStyle,
 };

--- a/crates/docspec-core/src/stack.rs
+++ b/crates/docspec-core/src/stack.rs
@@ -18,6 +18,8 @@ pub enum BlockKind {
     Blockquote,
     /// A table caption container.
     Caption,
+    /// A check list item container.
+    CheckListItem,
     /// A definition detail (description) container.
     DefinitionDetail,
     /// A definition list container.
@@ -32,8 +34,8 @@ pub enum BlockKind {
     Heading,
     /// A hyperlink container.
     Link,
-    /// A list item container.
-    ListItem,
+    /// An ordered list item container.
+    OrderedListItem,
     /// A paragraph container.
     Paragraph,
     /// A preformatted (code) block container.
@@ -46,6 +48,8 @@ pub enum BlockKind {
     TableHeader,
     /// A table row container.
     TableRow,
+    /// An unordered list item container.
+    UnorderedListItem,
 }
 
 /// A wrapper around any [`EventSink`] that tracks the nesting stack of open block-level containers
@@ -79,7 +83,8 @@ impl<S: EventSink> StackTrackingSink<S> {
     /// block elements (paragraphs, headings, etc.), not inline text directly. Text inside
     /// a block quote without an explicit paragraph triggers auto-paragraph insertion.
     ///
-    /// Note: [`BlockKind::ListItem`], [`BlockKind::TableCell`], [`BlockKind::TableHeader`],
+    /// Note: List item variants ([`BlockKind::OrderedListItem`], [`BlockKind::UnorderedListItem`],
+    /// [`BlockKind::CheckListItem`]), [`BlockKind::TableCell`], [`BlockKind::TableHeader`],
     /// and [`BlockKind::DefinitionDetail`] are NOT content-bearing despite being able to
     /// contain inline content per `EVENTS.md`. This is because downstream writers like
     /// `BlockNoteWriter` rely on auto-paragraph insertion for these container types.
@@ -259,40 +264,48 @@ impl<S: EventSink> EventSink for StackTrackingSink<S> {
 #[inline]
 #[must_use]
 pub fn block_kind_for_start(event: &Event) -> Option<BlockKind> {
-    if let Event::StartBlockQuote { .. } = event {
-        Some(BlockKind::Blockquote)
-    } else if let Event::StartCaption { .. } = event {
-        Some(BlockKind::Caption)
-    } else if let Event::StartDefinitionDetail { .. } = event {
-        Some(BlockKind::DefinitionDetail)
-    } else if let Event::StartDefinitionList { .. } = event {
-        Some(BlockKind::DefinitionList)
-    } else if let Event::StartDefinitionTerm { .. } = event {
-        Some(BlockKind::DefinitionTerm)
-    } else if let Event::StartDocument { .. } = event {
-        Some(BlockKind::Document)
-    } else if let Event::StartFootnote { .. } = event {
-        Some(BlockKind::Footnote)
-    } else if let Event::StartHeading { .. } = event {
-        Some(BlockKind::Heading)
-    } else if let Event::StartLink { .. } = event {
-        Some(BlockKind::Link)
-    } else if let Event::StartListItem { .. } = event {
-        Some(BlockKind::ListItem)
-    } else if let Event::StartParagraph { .. } = event {
-        Some(BlockKind::Paragraph)
-    } else if let Event::StartPreformatted { .. } = event {
-        Some(BlockKind::Preformatted)
-    } else if let Event::StartTable { .. } = event {
-        Some(BlockKind::Table)
-    } else if let Event::StartTableCell { .. } = event {
-        Some(BlockKind::TableCell)
-    } else if let Event::StartTableHeader { .. } = event {
-        Some(BlockKind::TableHeader)
-    } else if let Event::StartTableRow { .. } = event {
-        Some(BlockKind::TableRow)
-    } else {
-        None
+    match event {
+        Event::StartBlockQuote { .. } => Some(BlockKind::Blockquote),
+        Event::StartCaption { .. } => Some(BlockKind::Caption),
+        Event::StartCheckListItem { .. } => Some(BlockKind::CheckListItem),
+        Event::StartDefinitionDetail { .. } => Some(BlockKind::DefinitionDetail),
+        Event::StartDefinitionList { .. } => Some(BlockKind::DefinitionList),
+        Event::StartDefinitionTerm { .. } => Some(BlockKind::DefinitionTerm),
+        Event::StartDocument { .. } => Some(BlockKind::Document),
+        Event::StartFootnote { .. } => Some(BlockKind::Footnote),
+        Event::StartHeading { .. } => Some(BlockKind::Heading),
+        Event::StartLink { .. } => Some(BlockKind::Link),
+        Event::StartOrderedListItem { .. } => Some(BlockKind::OrderedListItem),
+        Event::StartParagraph { .. } => Some(BlockKind::Paragraph),
+        Event::StartPreformatted { .. } => Some(BlockKind::Preformatted),
+        Event::StartTable { .. } => Some(BlockKind::Table),
+        Event::StartTableCell { .. } => Some(BlockKind::TableCell),
+        Event::StartTableHeader { .. } => Some(BlockKind::TableHeader),
+        Event::StartTableRow { .. } => Some(BlockKind::TableRow),
+        Event::StartUnorderedListItem { .. } => Some(BlockKind::UnorderedListItem),
+        Event::EndBlockQuote
+        | Event::EndCaption
+        | Event::EndCheckListItem
+        | Event::EndDefinitionDetail
+        | Event::EndDefinitionList
+        | Event::EndDefinitionTerm
+        | Event::EndDocument
+        | Event::EndFootnote
+        | Event::EndHeading
+        | Event::EndLink
+        | Event::EndOrderedListItem
+        | Event::EndParagraph
+        | Event::EndPreformatted
+        | Event::EndTable
+        | Event::EndTableCell
+        | Event::EndTableHeader
+        | Event::EndTableRow
+        | Event::EndUnorderedListItem
+        | Event::FootnoteRef { .. }
+        | Event::Image { .. }
+        | Event::LineBreak
+        | Event::Text { .. }
+        | Event::ThematicBreak { .. } => None,
     }
 }
 
@@ -302,40 +315,48 @@ pub fn block_kind_for_start(event: &Event) -> Option<BlockKind> {
 #[inline]
 #[must_use]
 pub fn block_kind_for_end(event: &Event) -> Option<BlockKind> {
-    if let Event::EndBlockQuote = event {
-        Some(BlockKind::Blockquote)
-    } else if let Event::EndCaption = event {
-        Some(BlockKind::Caption)
-    } else if let Event::EndDefinitionDetail = event {
-        Some(BlockKind::DefinitionDetail)
-    } else if let Event::EndDefinitionList = event {
-        Some(BlockKind::DefinitionList)
-    } else if let Event::EndDefinitionTerm = event {
-        Some(BlockKind::DefinitionTerm)
-    } else if let Event::EndDocument = event {
-        Some(BlockKind::Document)
-    } else if let Event::EndFootnote = event {
-        Some(BlockKind::Footnote)
-    } else if let Event::EndHeading = event {
-        Some(BlockKind::Heading)
-    } else if let Event::EndLink = event {
-        Some(BlockKind::Link)
-    } else if let Event::EndListItem = event {
-        Some(BlockKind::ListItem)
-    } else if let Event::EndParagraph = event {
-        Some(BlockKind::Paragraph)
-    } else if let Event::EndPreformatted = event {
-        Some(BlockKind::Preformatted)
-    } else if let Event::EndTable = event {
-        Some(BlockKind::Table)
-    } else if let Event::EndTableCell = event {
-        Some(BlockKind::TableCell)
-    } else if let Event::EndTableHeader = event {
-        Some(BlockKind::TableHeader)
-    } else if let Event::EndTableRow = event {
-        Some(BlockKind::TableRow)
-    } else {
-        None
+    match event {
+        Event::EndBlockQuote => Some(BlockKind::Blockquote),
+        Event::EndCaption => Some(BlockKind::Caption),
+        Event::EndCheckListItem => Some(BlockKind::CheckListItem),
+        Event::EndDefinitionDetail => Some(BlockKind::DefinitionDetail),
+        Event::EndDefinitionList => Some(BlockKind::DefinitionList),
+        Event::EndDefinitionTerm => Some(BlockKind::DefinitionTerm),
+        Event::EndDocument => Some(BlockKind::Document),
+        Event::EndFootnote => Some(BlockKind::Footnote),
+        Event::EndHeading => Some(BlockKind::Heading),
+        Event::EndLink => Some(BlockKind::Link),
+        Event::EndOrderedListItem => Some(BlockKind::OrderedListItem),
+        Event::EndUnorderedListItem => Some(BlockKind::UnorderedListItem),
+        Event::EndParagraph => Some(BlockKind::Paragraph),
+        Event::EndPreformatted => Some(BlockKind::Preformatted),
+        Event::EndTable => Some(BlockKind::Table),
+        Event::EndTableCell => Some(BlockKind::TableCell),
+        Event::EndTableHeader => Some(BlockKind::TableHeader),
+        Event::EndTableRow => Some(BlockKind::TableRow),
+        Event::FootnoteRef { .. }
+        | Event::Image { .. }
+        | Event::LineBreak
+        | Event::StartBlockQuote { .. }
+        | Event::StartCaption { .. }
+        | Event::StartCheckListItem { .. }
+        | Event::StartDefinitionDetail { .. }
+        | Event::StartDefinitionList { .. }
+        | Event::StartDefinitionTerm { .. }
+        | Event::StartDocument { .. }
+        | Event::StartFootnote { .. }
+        | Event::StartHeading { .. }
+        | Event::StartLink { .. }
+        | Event::StartOrderedListItem { .. }
+        | Event::StartParagraph { .. }
+        | Event::StartPreformatted { .. }
+        | Event::StartTable { .. }
+        | Event::StartTableCell { .. }
+        | Event::StartTableHeader { .. }
+        | Event::StartTableRow { .. }
+        | Event::StartUnorderedListItem { .. }
+        | Event::Text { .. }
+        | Event::ThematicBreak { .. } => None,
     }
 }
 
@@ -356,7 +377,9 @@ pub fn end_event_for(kind: BlockKind) -> Event {
         BlockKind::Footnote => Event::EndFootnote,
         BlockKind::Heading => Event::EndHeading,
         BlockKind::Link => Event::EndLink,
-        BlockKind::ListItem => Event::EndListItem,
+        BlockKind::CheckListItem => Event::EndCheckListItem,
+        BlockKind::OrderedListItem => Event::EndOrderedListItem,
+        BlockKind::UnorderedListItem => Event::EndUnorderedListItem,
         BlockKind::Paragraph => Event::EndParagraph,
         BlockKind::Preformatted => Event::EndPreformatted,
         BlockKind::Table => Event::EndTable,
@@ -904,7 +927,18 @@ mod tests {
         assert_eq!(end_event_for(BlockKind::Footnote), Event::EndFootnote);
         assert_eq!(end_event_for(BlockKind::Heading), Event::EndHeading);
         assert_eq!(end_event_for(BlockKind::Link), Event::EndLink);
-        assert_eq!(end_event_for(BlockKind::ListItem), Event::EndListItem);
+        assert_eq!(
+            end_event_for(BlockKind::CheckListItem),
+            Event::EndCheckListItem
+        );
+        assert_eq!(
+            end_event_for(BlockKind::OrderedListItem),
+            Event::EndOrderedListItem
+        );
+        assert_eq!(
+            end_event_for(BlockKind::UnorderedListItem),
+            Event::EndUnorderedListItem
+        );
         assert_eq!(end_event_for(BlockKind::Paragraph), Event::EndParagraph);
         assert_eq!(
             end_event_for(BlockKind::Preformatted),

--- a/crates/docspec-core/src/types.rs
+++ b/crates/docspec-core/src/types.rs
@@ -13,36 +13,30 @@ pub enum TextAlignment {
     Right,
 }
 
-/// Whether a list is ordered (numbered) or unordered (bulleted).
+/// Visual style for ordered list markers.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ListType {
-    /// Numbered list.
-    Ordered,
-    /// Bulleted list.
-    Unordered,
-}
-
-/// The specific visual style for a list.
-///
-/// Writers ignore mismatched styles (e.g., Disc on an ordered list).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ListStyleType {
-    /// Hollow circle bullet.
-    Circle,
+pub enum OrderedListStyle {
     /// Decimal numbering (1, 2, 3, ...).
     Decimal,
-    /// Filled circle bullet.
-    Disc,
     /// Lowercase alphabetic (a, b, c, ...).
     LowerAlpha,
     /// Lowercase Roman numerals (i, ii, iii, ...).
     LowerRoman,
-    /// Square bullet.
-    Square,
     /// Uppercase alphabetic (A, B, C, ...).
     UpperAlpha,
     /// Uppercase Roman numerals (I, II, III, ...).
     UpperRoman,
+}
+
+/// Visual style for unordered list markers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UnorderedListStyle {
+    /// Hollow circle bullet.
+    Circle,
+    /// Filled circle bullet (default).
+    Disc,
+    /// Square bullet.
+    Square,
 }
 
 /// Scope of a table header cell.

--- a/crates/docspec-core/tests/event.rs
+++ b/crates/docspec-core/tests/event.rs
@@ -4,8 +4,8 @@
 mod tests {
     use docspec_core::*;
     use docspec_core::{
-        Author, Color, DocumentMeta, ImageSource, ListStyleType, ListType, TableHeaderScope,
-        TextAlignment,
+        Author, Color, DocumentMeta, ImageSource, OrderedListStyle, TableHeaderScope,
+        TextAlignment, UnorderedListStyle,
     };
 
     #[test]
@@ -72,8 +72,22 @@ mod tests {
     }
 
     #[test]
-    fn end_list_item() {
-        let event = Event::EndListItem;
+    fn end_check_list_item() {
+        let event = Event::EndCheckListItem;
+        let cloned = event.clone();
+        assert_eq!(event, cloned);
+    }
+
+    #[test]
+    fn end_ordered_list_item() {
+        let event = Event::EndOrderedListItem;
+        let cloned = event.clone();
+        assert_eq!(event, cloned);
+    }
+
+    #[test]
+    fn end_unordered_list_item() {
+        let event = Event::EndUnorderedListItem;
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
@@ -357,37 +371,43 @@ mod tests {
     }
 
     #[test]
-    fn start_list_item_ordered() {
-        let event = Event::StartListItem {
+    fn start_ordered_list_item() {
+        let event = Event::StartOrderedListItem {
             id: None,
             level: 1,
-            list_type: ListType::Ordered,
             start: Some(1),
-            style_type: Some(ListStyleType::Decimal),
+            style: Some(OrderedListStyle::Decimal),
         };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
 
     #[test]
-    fn start_list_item_unordered() {
-        let event = Event::StartListItem {
+    fn start_unordered_list_item() {
+        let event = Event::StartUnorderedListItem {
             id: None,
             level: 2,
-            list_type: ListType::Unordered,
-            start: None,
-            style_type: Some(ListStyleType::Disc),
+            style: Some(UnorderedListStyle::Disc),
         };
         assert_eq!(
             event,
-            Event::StartListItem {
+            Event::StartUnorderedListItem {
                 id: None,
                 level: 2,
-                list_type: ListType::Unordered,
-                start: None,
-                style_type: Some(ListStyleType::Disc),
+                style: Some(UnorderedListStyle::Disc),
             }
         );
+    }
+
+    #[test]
+    fn start_check_list_item() {
+        let event = Event::StartCheckListItem {
+            checked: true,
+            id: None,
+            level: 1,
+        };
+        let cloned = event.clone();
+        assert_eq!(event, cloned);
     }
 
     #[test]

--- a/crates/docspec-core/tests/stack.rs
+++ b/crates/docspec-core/tests/stack.rs
@@ -115,9 +115,24 @@ mod tests {
     }
 
     #[test]
-    fn block_kind_for_end_list_item() {
-        let event = Event::EndListItem;
-        assert_eq!(block_kind_for_end(&event), Some(BlockKind::ListItem));
+    fn block_kind_for_end_ordered_list_item() {
+        let event = Event::EndOrderedListItem;
+        assert_eq!(block_kind_for_end(&event), Some(BlockKind::OrderedListItem));
+    }
+
+    #[test]
+    fn block_kind_for_end_unordered_list_item() {
+        let event = Event::EndUnorderedListItem;
+        assert_eq!(
+            block_kind_for_end(&event),
+            Some(BlockKind::UnorderedListItem)
+        );
+    }
+
+    #[test]
+    fn block_kind_for_end_check_list_item() {
+        let event = Event::EndCheckListItem;
+        assert_eq!(block_kind_for_end(&event), Some(BlockKind::CheckListItem));
     }
 
     #[test]
@@ -244,15 +259,40 @@ mod tests {
     }
 
     #[test]
-    fn block_kind_for_start_list_item() {
-        let event = Event::StartListItem {
+    fn block_kind_for_start_ordered_list_item() {
+        let event = Event::StartOrderedListItem {
             id: None,
             level: 1,
-            list_type: docspec_core::ListType::Unordered,
             start: None,
-            style_type: None,
+            style: None,
         };
-        assert_eq!(block_kind_for_start(&event), Some(BlockKind::ListItem));
+        assert_eq!(
+            block_kind_for_start(&event),
+            Some(BlockKind::OrderedListItem)
+        );
+    }
+
+    #[test]
+    fn block_kind_for_start_unordered_list_item() {
+        let event = Event::StartUnorderedListItem {
+            id: None,
+            level: 1,
+            style: None,
+        };
+        assert_eq!(
+            block_kind_for_start(&event),
+            Some(BlockKind::UnorderedListItem)
+        );
+    }
+
+    #[test]
+    fn block_kind_for_start_check_list_item() {
+        let event = Event::StartCheckListItem {
+            checked: false,
+            id: None,
+            level: 1,
+        };
+        assert_eq!(block_kind_for_start(&event), Some(BlockKind::CheckListItem));
     }
 
     #[test]

--- a/crates/docspec-core/tests/types.rs
+++ b/crates/docspec-core/tests/types.rs
@@ -164,31 +164,32 @@ mod tests {
     }
 
     #[test]
-    fn list_style_type_clone() {
-        let style = ListStyleType::Decimal;
+    fn ordered_list_style_clone() {
+        let style = OrderedListStyle::Decimal;
         let cloned = style.clone();
         assert_eq!(style, cloned);
     }
 
     #[test]
-    fn list_style_type_variants() {
-        assert_eq!(ListStyleType::Decimal, ListStyleType::Decimal);
-        assert_ne!(ListStyleType::Decimal, ListStyleType::LowerAlpha);
-        assert_eq!(ListStyleType::Disc, ListStyleType::Disc);
-        assert_ne!(ListStyleType::Disc, ListStyleType::Circle);
+    fn ordered_list_style_variants() {
+        assert_eq!(OrderedListStyle::Decimal, OrderedListStyle::Decimal);
+        assert_ne!(OrderedListStyle::Decimal, OrderedListStyle::LowerAlpha);
+        assert_eq!(OrderedListStyle::LowerRoman, OrderedListStyle::LowerRoman);
+        assert_ne!(OrderedListStyle::UpperAlpha, OrderedListStyle::UpperRoman);
     }
 
     #[test]
-    fn list_type_clone() {
-        let list_type = ListType::Ordered;
-        let cloned = list_type.clone();
-        assert_eq!(list_type, cloned);
+    fn unordered_list_style_clone() {
+        let style = UnorderedListStyle::Disc;
+        let cloned = style.clone();
+        assert_eq!(style, cloned);
     }
 
     #[test]
-    fn list_type_variants() {
-        assert_eq!(ListType::Ordered, ListType::Ordered);
-        assert_ne!(ListType::Ordered, ListType::Unordered);
+    fn unordered_list_style_variants() {
+        assert_eq!(UnorderedListStyle::Disc, UnorderedListStyle::Disc);
+        assert_ne!(UnorderedListStyle::Disc, UnorderedListStyle::Circle);
+        assert_ne!(UnorderedListStyle::Circle, UnorderedListStyle::Square);
     }
 
     #[test]

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -25,6 +25,9 @@
 //! - Paragraphs → `StartParagraph` / `EndParagraph`
 //! - Block quotes → `StartBlockQuote` / `EndBlockQuote`
 //! - Code blocks → `StartPreformatted` / `EndPreformatted`
+//! - Ordered lists → `StartOrderedListItem` / `EndOrderedListItem`
+//! - Unordered lists → `StartUnorderedListItem` / `EndUnorderedListItem`
+//! - Task lists → `StartCheckListItem` / `EndCheckListItem`
 //! - Bold text → `Text { bold: true, ... }`
 //! - Italic text → `Text { italic: true, ... }`
 //! - Inline code → `Text { code: true, ... }`
@@ -39,7 +42,7 @@
 //! The following elements are not emitted as structured events. Text content is
 //! recursively extracted where applicable; structure is silently dropped:
 //!
-//! - Tables, lists, and links (text extracted, structure dropped)
+//! - Tables and links (text extracted, structure dropped)
 //! - Definition lists and footnotes
 //! - HTML blocks and inline HTML
 //! - Math blocks and inline math
@@ -85,6 +88,20 @@ struct ImageBuffer {
     url: String,
 }
 
+struct ListContext {
+    is_first_item: bool,
+    is_ordered: bool,
+    level: u8,
+    start: Option<u32>,
+}
+
+enum ItemState {
+    EmittedCheckList,
+    EmittedOrdered,
+    EmittedUnordered,
+    Pending { task_marker: Option<bool> },
+}
+
 /// A streaming Markdown reader that implements [`EventSource`].
 ///
 /// `MarkdownReader` parses Markdown using `pulldown-cmark` and emits `DocSpec` events
@@ -113,6 +130,10 @@ pub struct MarkdownReader<'a> {
     image: Option<ImageBuffer>,
     /// Nesting depth for italic (emphasis) formatting.
     italic_depth: usize,
+    /// Stack of item states for nested list items.
+    item_state_stack: Vec<ItemState>,
+    /// Stack of list contexts for nested lists.
+    list_stack: Vec<ListContext>,
     /// The pulldown-cmark parser.
     parser: Parser<'a>,
     /// Document processing phase.
@@ -124,10 +145,80 @@ pub struct MarkdownReader<'a> {
 }
 
 impl<'a> MarkdownReader<'a> {
+    fn emit_list_item_end(&mut self) {
+        if self.list_stack.is_empty() {
+            self.item_state_stack.clear();
+            return;
+        }
+
+        if matches!(
+            self.item_state_stack.last(),
+            Some(ItemState::Pending { .. })
+        ) {
+            self.emit_list_item_start();
+        }
+
+        match self.item_state_stack.pop() {
+            Some(ItemState::EmittedCheckList) => {
+                self.queue.push_back(Event::EndCheckListItem);
+            }
+            Some(ItemState::EmittedOrdered) => {
+                self.queue.push_back(Event::EndOrderedListItem);
+            }
+            Some(ItemState::EmittedUnordered) => {
+                self.queue.push_back(Event::EndUnorderedListItem);
+            }
+            Some(ItemState::Pending { .. }) | None => {}
+        }
+    }
+
+    fn emit_list_item_start(&mut self) {
+        let task_marker = match self.item_state_stack.last() {
+            Some(ItemState::Pending { task_marker }) => *task_marker,
+            _ => return,
+        };
+
+        let Some(ctx) = self.list_stack.last_mut() else {
+            return;
+        };
+
+        let new_state = if let Some(checked) = task_marker {
+            ctx.is_first_item = false;
+            self.queue.push_back(Event::StartCheckListItem {
+                id: None,
+                level: ctx.level,
+                checked,
+            });
+            ItemState::EmittedCheckList
+        } else if ctx.is_ordered {
+            let start = if ctx.is_first_item { ctx.start } else { None };
+            ctx.is_first_item = false;
+            self.queue.push_back(Event::StartOrderedListItem {
+                id: None,
+                level: ctx.level,
+                start,
+                style: None,
+            });
+            ItemState::EmittedOrdered
+        } else {
+            self.queue.push_back(Event::StartUnorderedListItem {
+                id: None,
+                level: ctx.level,
+                style: None,
+            });
+            ItemState::EmittedUnordered
+        };
+
+        if let Some(last) = self.item_state_stack.last_mut() {
+            *last = new_state;
+        }
+    }
+
     fn handle_code(&mut self, content: String) {
         if let Some(img) = &mut self.image {
             img.alt_buf.push_str(&content);
         } else {
+            self.emit_list_item_start();
             if self.block_state == BlockState::None {
                 self.queue.push_back(Event::StartParagraph {
                     alignment: None,
@@ -154,10 +245,19 @@ impl<'a> MarkdownReader<'a> {
             TagEnd::Heading(_) => self.push_event_end(Event::EndHeading),
             TagEnd::Paragraph => self.push_event_end(Event::EndParagraph),
             TagEnd::BlockQuote(_) => self.push_event_end(Event::EndBlockQuote),
-            TagEnd::Item | TagEnd::TableCell => {
+            TagEnd::Item => {
                 if self.block_state == BlockState::AutoParagraph {
                     self.push_event_end(Event::EndParagraph);
                 }
+                self.emit_list_item_end();
+            }
+            TagEnd::TableCell => {
+                if self.block_state == BlockState::AutoParagraph {
+                    self.push_event_end(Event::EndParagraph);
+                }
+            }
+            TagEnd::List(_) => {
+                self.list_stack.pop();
             }
             TagEnd::Emphasis => {
                 self.italic_depth = self.italic_depth.saturating_sub(1);
@@ -170,6 +270,7 @@ impl<'a> MarkdownReader<'a> {
             }
             TagEnd::Image => {
                 if let Some(img) = self.image.take() {
+                    self.emit_list_item_start();
                     let alt = {
                         let trimmed = img.alt_buf.trim();
                         if trimmed.is_empty() {
@@ -213,7 +314,6 @@ impl<'a> MarkdownReader<'a> {
             | TagEnd::FootnoteDefinition
             | TagEnd::HtmlBlock
             | TagEnd::Link
-            | TagEnd::List(_)
             | TagEnd::MetadataBlock(_)
             | TagEnd::Subscript
             | TagEnd::Superscript
@@ -275,14 +375,28 @@ impl<'a> MarkdownReader<'a> {
                     url: dest_url.into_string(),
                 });
             }
+            Tag::List(first_item_number) => {
+                self.emit_list_item_start();
+                let is_ordered = first_item_number.is_some();
+                let level =
+                    u8::try_from(self.list_stack.len().saturating_add(1)).unwrap_or(u8::MAX);
+                self.list_stack.push(ListContext {
+                    is_first_item: true,
+                    is_ordered,
+                    level,
+                    start: first_item_number.and_then(|n| u32::try_from(n).ok()),
+                });
+            }
+            Tag::Item => {
+                self.item_state_stack
+                    .push(ItemState::Pending { task_marker: None });
+            }
             Tag::DefinitionList
             | Tag::DefinitionListDefinition
             | Tag::DefinitionListTitle
             | Tag::FootnoteDefinition(_)
             | Tag::HtmlBlock
-            | Tag::Item
             | Tag::Link { .. }
-            | Tag::List(_)
             | Tag::MetadataBlock(_)
             | Tag::Subscript
             | Tag::Superscript
@@ -299,6 +413,7 @@ impl<'a> MarkdownReader<'a> {
         } else if let Some(buf) = &mut self.code_block_buffer {
             buf.push_str(&content);
         } else {
+            self.emit_list_item_start();
             if self.block_state == BlockState::None {
                 self.queue.push_back(Event::StartParagraph {
                     alignment: None,
@@ -335,7 +450,8 @@ impl<'a> MarkdownReader<'a> {
     #[inline]
     #[must_use]
     pub fn new(markdown: &'a str) -> Self {
-        let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
+        let options =
+            Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_TASKLISTS;
         let parser = Parser::new_ext(markdown, options);
         Self {
             block_state: BlockState::None,
@@ -343,6 +459,8 @@ impl<'a> MarkdownReader<'a> {
             code_block_buffer: None,
             image: None,
             italic_depth: 0,
+            item_state_stack: Vec::new(),
+            list_stack: Vec::new(),
             parser,
             phase: Phase::NotStarted,
             queue: VecDeque::new(),
@@ -391,12 +509,16 @@ impl<'a> MarkdownReader<'a> {
             pulldown_cmark::Event::Rule => {
                 self.queue.push_back(Event::ThematicBreak { id: None });
             }
+            pulldown_cmark::Event::TaskListMarker(checked) => {
+                if let Some(ItemState::Pending { task_marker }) = self.item_state_stack.last_mut() {
+                    *task_marker = Some(checked);
+                }
+            }
             pulldown_cmark::Event::DisplayMath(_)
             | pulldown_cmark::Event::FootnoteReference(_)
             | pulldown_cmark::Event::Html(_)
             | pulldown_cmark::Event::InlineHtml(_)
-            | pulldown_cmark::Event::InlineMath(_)
-            | pulldown_cmark::Event::TaskListMarker(_) => {}
+            | pulldown_cmark::Event::InlineMath(_) => {}
         }
     }
 

--- a/crates/docspec-markdown-reader/tests/integration.rs
+++ b/crates/docspec-markdown-reader/tests/integration.rs
@@ -131,4 +131,36 @@ mod tests {
         let actual = run_pipeline(markdown);
         assert_json_eq(&actual, expected);
     }
+
+    #[test]
+    fn pipeline_nested_lists() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/nested_lists.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/nested_lists.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
+
+    #[test]
+    fn pipeline_ordered_list() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/ordered_list.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/ordered_list.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
+
+    #[test]
+    fn pipeline_task_list() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/task_list.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/task_list.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
+
+    #[test]
+    fn pipeline_unordered_list() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/unordered_list.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/unordered_list.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
 }

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -89,34 +89,38 @@ mod tests {
                 Event::Text { .. } => "Text",
                 Event::EndBlockQuote
                 | Event::EndCaption
+                | Event::EndCheckListItem
                 | Event::EndDefinitionDetail
                 | Event::EndDefinitionList
                 | Event::EndDefinitionTerm
                 | Event::EndFootnote
                 | Event::EndLink
-                | Event::EndListItem
+                | Event::EndOrderedListItem
                 | Event::EndPreformatted
                 | Event::EndTable
                 | Event::EndTableCell
                 | Event::EndTableHeader
                 | Event::EndTableRow
+                | Event::EndUnorderedListItem
                 | Event::FootnoteRef { .. }
                 | Event::Image { .. }
                 | Event::LineBreak
                 | Event::StartBlockQuote { .. }
                 | Event::StartCaption { .. }
+                | Event::StartCheckListItem { .. }
                 | Event::StartDefinitionDetail { .. }
                 | Event::StartDefinitionList { .. }
                 | Event::StartDefinitionTerm { .. }
                 | Event::StartFootnote { .. }
                 | Event::StartHeading { .. }
                 | Event::StartLink { .. }
-                | Event::StartListItem { .. }
+                | Event::StartOrderedListItem { .. }
                 | Event::StartPreformatted { .. }
                 | Event::StartTable { .. }
                 | Event::StartTableCell { .. }
                 | Event::StartTableHeader { .. }
                 | Event::StartTableRow { .. }
+                | Event::StartUnorderedListItem { .. }
                 | Event::ThematicBreak { .. }
                 | _ => "Other",
             })
@@ -320,10 +324,12 @@ mod tests {
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        assert!(!events
+        assert!(events
             .iter()
-            .any(|e| matches!(e, Event::StartListItem { .. })));
-        assert!(!events.iter().any(|e| matches!(e, Event::EndListItem)));
+            .any(|e| matches!(e, Event::StartUnorderedListItem { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::EndUnorderedListItem)));
 
         let has_item_one = events
             .iter()
@@ -581,14 +587,10 @@ mod tests {
 
     #[test]
     fn code_block_preserves_trailing_blank_lines() {
-        // Code block with intentional trailing blank lines
-        // The parser adds a newline terminator, but we should only remove that one,
-        // not all trailing newlines
         let markdown = "```\ncode\n\n\n```";
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        // Find the text event inside the code block
         let text_event = events.iter().find(|e| {
             matches!(
                 e,
@@ -600,9 +602,6 @@ mod tests {
             )
         });
 
-        // The content should preserve the blank lines (two newlines after "code")
-        // Only the parser-added terminator should be removed
-        // Use exact equality to catch regressions
         assert!(matches!(
             text_event,
             Some(Event::Text { content, .. }) if content == "code\n\n"
@@ -716,6 +715,454 @@ mod tests {
         assert!(matches!(
             text_event,
             Some(Event::Text { content, bold: true, italic: true, strikethrough: true, .. }) if content == "bold italic struck"
+        ));
+    }
+
+    #[test]
+    fn ordered_list_emits_events() {
+        let markdown = "1. First\n2. Second\n3. Third";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let ordered_starts: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::StartOrderedListItem { .. }))
+            .collect();
+        assert_eq!(ordered_starts.len(), 3, "Expected 3 ordered list items");
+
+        assert!(matches!(
+            ordered_starts.first(),
+            Some(Event::StartOrderedListItem {
+                level: 1,
+                start: Some(1),
+                ..
+            })
+        ));
+
+        assert!(matches!(
+            ordered_starts.get(1),
+            Some(Event::StartOrderedListItem {
+                level: 1,
+                start: None,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn unordered_list_emits_events() {
+        let markdown = "- Item one\n- Item two";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let unordered_starts: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::StartUnorderedListItem { .. }))
+            .collect();
+        assert_eq!(unordered_starts.len(), 2, "Expected 2 unordered list items");
+    }
+
+    #[test]
+    fn task_list_emits_events() {
+        let markdown = "- [x] Done\n- [ ] Todo";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let check_starts: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::StartCheckListItem { .. }))
+            .collect();
+        assert_eq!(check_starts.len(), 2, "Expected 2 check list items");
+
+        assert!(matches!(
+            check_starts.first(),
+            Some(Event::StartCheckListItem { checked: true, .. })
+        ));
+
+        assert!(matches!(
+            check_starts.get(1),
+            Some(Event::StartCheckListItem { checked: false, .. })
+        ));
+    }
+
+    #[test]
+    fn nested_list_levels() {
+        let markdown = "- Level 1\n  - Level 2\n    - Level 3";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let items: Vec<_> = events
+            .iter()
+            .filter_map(|e| {
+                if let Event::StartUnorderedListItem { level, .. } = e {
+                    Some(*level)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert_eq!(items, vec![1, 2, 3], "Expected levels 1, 2, 3");
+    }
+
+    #[test]
+    fn mixed_list_types() {
+        let markdown = "1. Ordered\n- Unordered";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartOrderedListItem { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartUnorderedListItem { .. })));
+    }
+
+    #[test]
+    fn ordered_list_with_custom_start_number() {
+        let markdown = "5. First\n6. Second";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let ordered_starts: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::StartOrderedListItem { .. }))
+            .collect();
+        assert_eq!(ordered_starts.len(), 2, "Expected 2 ordered list items");
+
+        assert!(matches!(
+            ordered_starts.first(),
+            Some(Event::StartOrderedListItem {
+                level: 1,
+                start: Some(5),
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn nested_task_list() {
+        let markdown = "- [x] Parent\n  - [ ] Child";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let check_starts: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::StartCheckListItem { .. }))
+            .collect();
+        assert_eq!(check_starts.len(), 2, "Expected 2 check list items");
+
+        assert!(matches!(
+            check_starts.first(),
+            Some(Event::StartCheckListItem { level: 1, .. })
+        ));
+        assert!(matches!(
+            check_starts.get(1),
+            Some(Event::StartCheckListItem { level: 2, .. })
+        ));
+    }
+
+    #[test]
+    fn list_items_have_end_events() {
+        let markdown = "- Item one\n- Item two";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let end_unordered: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::EndUnorderedListItem))
+            .collect();
+        assert_eq!(
+            end_unordered.len(),
+            2,
+            "Expected 2 EndUnorderedListItem events"
+        );
+    }
+
+    #[test]
+    fn ordered_list_items_have_end_events() {
+        let markdown = "1. First\n2. Second";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let end_ordered: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::EndOrderedListItem))
+            .collect();
+        assert_eq!(end_ordered.len(), 2, "Expected 2 EndOrderedListItem events");
+    }
+
+    #[test]
+    fn task_list_items_have_end_events() {
+        let markdown = "- [x] Done\n- [ ] Todo";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let end_check: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::EndCheckListItem))
+            .collect();
+        assert_eq!(end_check.len(), 2, "Expected 2 EndCheckListItem events");
+    }
+
+    #[test]
+    fn empty_list_item() {
+        let markdown = "- \n- Item";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let unordered_starts: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::StartUnorderedListItem { .. }))
+            .collect();
+        assert_eq!(
+            unordered_starts.len(),
+            2,
+            "Expected 2 list items including empty"
+        );
+    }
+
+    /// Regression test: ordered parent with unordered child must emit correct End events.
+    /// Bug: single `item_state` field gets overwritten by child, causing parent to emit wrong End.
+    #[test]
+    fn nested_mixed_list_types_correct_end_events() {
+        let markdown = "1. Parent\n   - Child";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let list_events: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::StartOrderedListItem { .. }
+                        | Event::EndOrderedListItem
+                        | Event::StartUnorderedListItem { .. }
+                        | Event::EndUnorderedListItem
+                )
+            })
+            .collect();
+
+        assert_eq!(list_events.len(), 4, "Expected 4 list events");
+        assert!(matches!(
+            list_events.first(),
+            Some(Event::StartOrderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(
+            list_events.get(1),
+            Some(Event::StartUnorderedListItem { level: 2, .. })
+        ));
+        assert!(matches!(
+            list_events.get(2),
+            Some(Event::EndUnorderedListItem)
+        ));
+        assert!(matches!(
+            list_events.get(3),
+            Some(Event::EndOrderedListItem)
+        ));
+    }
+
+    /// Regression test: deeply nested lists maintain correct Start/End pairing.
+    /// Bug: `item_state` stack corruption causes wrong End events at depth > 2.
+    #[test]
+    fn deeply_nested_lists_correct_pairing() {
+        let markdown = "- L1\n  - L2\n    - L3";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let list_events: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::StartUnorderedListItem { .. } | Event::EndUnorderedListItem
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            list_events.len(),
+            6,
+            "Expected 6 list events (3 starts, 3 ends)"
+        );
+        assert!(matches!(
+            list_events.first(),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(
+            list_events.get(1),
+            Some(Event::StartUnorderedListItem { level: 2, .. })
+        ));
+        assert!(matches!(
+            list_events.get(2),
+            Some(Event::StartUnorderedListItem { level: 3, .. })
+        ));
+        assert!(matches!(
+            list_events.get(3),
+            Some(Event::EndUnorderedListItem)
+        ));
+        assert!(matches!(
+            list_events.get(4),
+            Some(Event::EndUnorderedListItem)
+        ));
+        assert!(matches!(
+            list_events.get(5),
+            Some(Event::EndUnorderedListItem)
+        ));
+    }
+
+    /// Regression test: task list parent with regular child.
+    /// Bug: task marker could be consumed by wrong item.
+    #[test]
+    fn nested_task_list_marker_applies_to_correct_item() {
+        let markdown = "- [x] Parent\n  - Child";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let check_events: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::StartCheckListItem { .. } | Event::EndCheckListItem
+                )
+            })
+            .collect();
+
+        let unordered_events: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::StartUnorderedListItem { .. } | Event::EndUnorderedListItem
+                )
+            })
+            .collect();
+
+        assert_eq!(check_events.len(), 2, "Parent should be check list item");
+        assert_eq!(
+            unordered_events.len(),
+            2,
+            "Child should be unordered list item"
+        );
+
+        assert!(matches!(
+            check_events.first(),
+            Some(Event::StartCheckListItem {
+                level: 1,
+                checked: true,
+                ..
+            })
+        ));
+        assert!(matches!(
+            unordered_events.first(),
+            Some(Event::StartUnorderedListItem { level: 2, .. })
+        ));
+    }
+
+    /// Regression test: image inside list item should emit proper Start/End events.
+    /// Bug: image as first content in list item may not trigger `StartUnorderedListItem` emission.
+    #[test]
+    fn image_inside_list_item_emits_correct_events() {
+        let markdown = "- ![alt text](http://example.com/img.png)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let list_events: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::StartUnorderedListItem { .. } | Event::EndUnorderedListItem
+                )
+            })
+            .collect();
+
+        let image_events: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e, Event::Image { .. }))
+            .collect();
+
+        assert_eq!(
+            list_events.len(),
+            2,
+            "Expected Start and End list item events"
+        );
+        assert_eq!(image_events.len(), 1, "Expected one image event");
+
+        assert!(matches!(
+            list_events.first(),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(
+            list_events.get(1),
+            Some(Event::EndUnorderedListItem)
+        ));
+
+        assert!(matches!(
+            image_events.first(),
+            Some(Event::Image { alt: Some(alt), .. }) if alt == "alt text"
+        ));
+    }
+
+    /// Regression test: list item with only an image (no text) should still emit events.
+    #[test]
+    fn list_item_with_image_only_no_text() {
+        let markdown = "1. ![](http://example.com/img.png)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let list_events: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::StartOrderedListItem { .. } | Event::EndOrderedListItem
+                )
+            })
+            .collect();
+
+        assert_eq!(
+            list_events.len(),
+            2,
+            "Expected Start and End ordered list item events"
+        );
+        assert!(matches!(
+            list_events.first(),
+            Some(Event::StartOrderedListItem {
+                level: 1,
+                start: Some(1),
+                ..
+            })
+        ));
+    }
+
+    /// Regression test: nested list with image in parent.
+    #[test]
+    fn nested_list_with_image_in_parent() {
+        let markdown = "- ![img](http://example.com/img.png)\n  - Child text";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        let list_events: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    Event::StartUnorderedListItem { .. } | Event::EndUnorderedListItem
+                )
+            })
+            .collect();
+
+        assert_eq!(list_events.len(), 4, "Expected 2 starts and 2 ends");
+        assert!(matches!(
+            list_events.first(),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(
+            list_events.get(1),
+            Some(Event::StartUnorderedListItem { level: 2, .. })
         ));
     }
 }

--- a/tests/fixtures/blocknote/nested_lists.json
+++ b/tests/fixtures/blocknote/nested_lists.json
@@ -1,0 +1,45 @@
+[
+  {
+    "type": "bulletListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Level 1 first",
+        "styles": {}
+      }
+    ],
+    "children": [
+      {
+        "type": "bulletListItem",
+        "props": {
+          "textAlignment": "left"
+        },
+        "content": [
+          {
+            "type": "text",
+            "text": "Level 2 child",
+            "styles": {}
+          }
+        ],
+        "children": []
+      }
+    ]
+  },
+  {
+    "type": "bulletListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Level 1 second",
+        "styles": {}
+      }
+    ],
+    "children": []
+  }
+]

--- a/tests/fixtures/blocknote/ordered_list.json
+++ b/tests/fixtures/blocknote/ordered_list.json
@@ -1,0 +1,72 @@
+[
+  {
+    "type": "numberedListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "First item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "numberedListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Second item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "numberedListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Third item with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "bold text",
+        "styles": {
+          "bold": true
+        }
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "numberedListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Fourth item with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "italic text",
+        "styles": {
+          "italic": true
+        }
+      }
+    ],
+    "children": []
+  }
+]

--- a/tests/fixtures/blocknote/task_list.json
+++ b/tests/fixtures/blocknote/task_list.json
@@ -1,0 +1,76 @@
+[
+  {
+    "type": "checkListItem",
+    "props": {
+      "checked": true,
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Completed task",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "checkListItem",
+    "props": {
+      "checked": false,
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Pending task",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "checkListItem",
+    "props": {
+      "checked": true,
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Another done item with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "bold",
+        "styles": {
+          "bold": true
+        }
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "checkListItem",
+    "props": {
+      "checked": false,
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Todo with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "emphasis",
+        "styles": {
+          "italic": true
+        }
+      }
+    ],
+    "children": []
+  }
+]

--- a/tests/fixtures/blocknote/unordered_list.json
+++ b/tests/fixtures/blocknote/unordered_list.json
@@ -1,0 +1,77 @@
+[
+  {
+    "type": "bulletListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Apple",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "bulletListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Banana",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "bulletListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Cherry with ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "bold",
+        "styles": {
+          "bold": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " and ",
+        "styles": {}
+      },
+      {
+        "type": "text",
+        "text": "italic",
+        "styles": {
+          "italic": true
+        }
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "bulletListItem",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Date",
+        "styles": {}
+      }
+    ],
+    "children": []
+  }
+]

--- a/tests/fixtures/markdown/nested_lists.md
+++ b/tests/fixtures/markdown/nested_lists.md
@@ -1,0 +1,3 @@
+- Level 1 first
+  - Level 2 child
+- Level 1 second

--- a/tests/fixtures/markdown/ordered_list.md
+++ b/tests/fixtures/markdown/ordered_list.md
@@ -1,0 +1,4 @@
+1. First item
+2. Second item
+3. Third item with **bold text**
+4. Fourth item with *italic text*

--- a/tests/fixtures/markdown/task_list.md
+++ b/tests/fixtures/markdown/task_list.md
@@ -1,0 +1,4 @@
+- [x] Completed task
+- [ ] Pending task
+- [x] Another done item with **bold**
+- [ ] Todo with *emphasis*

--- a/tests/fixtures/markdown/unordered_list.md
+++ b/tests/fixtures/markdown/unordered_list.md
@@ -1,0 +1,4 @@
+- Apple
+- Banana
+- Cherry with **bold** and *italic*
+- Date


### PR DESCRIPTION
## Summary

- Add task list (checkbox) support for Markdown → BlockNote conversion
- Refactor list event model from single `StartListItem` into three distinct event types
- Full streaming implementation with no document buffering
- Fix list level transition bug when going from deeper to shallower nesting

## Changes

### Core (`docspec-core`)
- 6 new events: `Start/EndOrderedListItem`, `Start/EndUnorderedListItem`, `Start/EndCheckListItem`
- `OrderedListStyle` enum (Decimal, LowerAlpha, UpperAlpha, LowerRoman, UpperRoman)
- `UnorderedListStyle` enum (Disc, Circle, Square)
- 3 new `BlockKind` variants for stack tracking
- Removed old `ListType`, `ListStyleType`, `StartListItem`, `EndListItem`

### Markdown Reader
- Parse ordered lists with start numbers and styles
- Parse unordered lists with bullet styles
- Parse task lists with checked/unchecked state
- Support nested lists up to arbitrary depth

### BlockNote Writer
- Output `numberedListItem` for ordered lists
- Output `bulletListItem` for unordered lists
- Output `checkListItem` with `checked` prop for task lists
- Handle nesting via `children` arrays
- **Fixed:** Level transition bug when going from deeper to shallower nesting (e.g., level 2 → level 1)

## Level Transition Fix

The markdown reader doesn't emit explicit `EndListItem` events for parent items when transitioning to children. When a new list item at a shallower level arrives, the writer must close deeper items first.

**Solution:** Added `close_list_items_to_level()` helper that pops and closes stack items where `level >= target_level` before processing new items.

**Test case:**
```markdown
- Level 1
  - Level 2
- Level 1 again
```

Now correctly produces valid BlockNote JSON with proper nesting structure.

## Testing
- 17 integration tests covering all list types and level transitions
- Fixtures for ordered, unordered, task, and nested lists
- All existing tests pass
- Coverage: 95-97% for modified crates

Refs: #12, #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated ordered, unordered, and checklist list items with per-type style options, nesting, and checked/unchecked checklist states.
  * Markdown reader now emits typed list events (including task lists) and preserves images inside list items.
* **Documentation**
  * Streaming events specification and writer docs updated to list the new list-item event types and styles; new BlockNote JSON fixtures included.
* **Tests**
  * Expanded integration and unit tests covering list types, nesting, transitions, images, and task lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->