### PR TITLE
feat(markdown-reader): emit ordered and unordered list events

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -14,7 +14,7 @@ DocSpec documents are streams of typed events. Readers emit events. Writers cons
 
 **No warnings.** Errors are out-of-band via `Result`. Events carry content only.
 
-**Flat list model.** List items carry nesting level as a field. No `StartList`/`EndList`. Maps cleanly to DOCX/RTF where list structure is implicit.
+**Flat list model.** `StartOrderedListItem`/`StartUnorderedListItem` carry nesting level as a field. No `StartList`/`EndList`. Maps cleanly to DOCX/RTF where list structure is implicit.
 
 ---
 
@@ -54,8 +54,6 @@ Readers register assets as encountered. Writers call `stream_to()` on demand —
 
 ```rust
 enum TextAlignment { Left, Center, Right, Justify }
-
-enum ListType { Ordered, Unordered }
 
 enum ListStyleType {
     // Ordered list styles
@@ -108,9 +106,10 @@ All events in the `Event` enum, grouped by category.
 
 **Lists:**
 
-| Event            | Fields                                                                                         | Pair           |
-| ---------------- | ---------------------------------------------------------------------------------------------- | -------------- |
-| `StartListItem`  | `level: u8`, `list_type: ListType`, `start: Option<u32>`, `style_type: Option<ListStyleType>` | `EndListItem`  |
+| Event                  | Fields                                                                 | Pair                   |
+| ---------------------- | ---------------------------------------------------------------------- | ---------------------- |
+| `StartOrderedListItem` | `start: Option<u64>`, `style_type: ListStyleType`, `level: u32`, `id: Option<String>` | `EndOrderedListItem`   |
+| `StartUnorderedListItem` | `style_type: ListStyleType`, `level: u32`, `id: Option<String>`                       | `EndUnorderedListItem` |
 
 **Tables:**
 
@@ -159,9 +158,9 @@ Every `Start*` has a matching `End*`. They nest but never overlap.
 
 **Document.** The root container. `language` is a BCP 47 tag.
 
-**Heading.** Levels 1–6 are standard (HTML). DOCX/ODT/RTF support 1–9. Writers clamp higher levels. Both heading and list levels are 1-based (range 1–255); no format exceeds 9.
+**Heading.** Levels 1–6 are standard (HTML). DOCX/ODT/RTF support 1–9. Writers clamp higher levels. Heading levels are 1-based (range 1–9); list item `level` is 0-indexed (0 = top-level list).
 
-**List items.** Nesting is flat — children follow parents sequentially, distinguished by `level`. No `StartList`/`EndList` exists. The `start` field sets numbering base until another `start` appears. **Boundary rules:** a new list begins when (a) a non-list block intervenes, (b) `list_type` changes at the same level, or (c) level decreases then increases without a parent.
+**List items.** Nesting is flat — children follow parents sequentially, distinguished by `level`. No `StartList`/`EndList` exists. `StartOrderedListItem` carries `start: Option<u64>` populated only on the first item of each ordered list (subsequent items: `None`). **Boundary rules:** a new list begins when (a) a non-list block intervenes, (b) ordered vs. unordered changes at the same level, or (c) level decreases then increases without a parent.
 
 **Table.** `StartCaption` is optional, appears before rows. Header cells carry `scope`/`abbr` for accessibility; data cells omit these. Cells may contain any block element.
 
@@ -195,7 +194,7 @@ Readers MUST produce well-formed streams. Writers MAY assume well-formedness.
 2. Exactly one root: `StartDocument`. Empty containers (`Start*` immediately followed by `End*`) are valid.
 3. `Text` appears only inside containers, never at root.
 4. `StartLink` appears inside inline-accepting blocks (paragraphs, headings, list items, cells, definition details). Links do not nest.
-5. `StartListItem` appears inside block containers. List items are flat — distinguished by `level` field.
+5. `StartOrderedListItem` and `StartUnorderedListItem` appear inside block containers. List items are flat — distinguished by `level` field.
 6. `StartCaption` appears at most once per table, before any rows.
 7. Each footnote ID appears in exactly one `FootnoteRef` and one `StartFootnote`.
 8. Table structure: `StartTableRow` appears only inside `StartTable`. `StartTableCell`/`StartTableHeader` appear only inside `StartTableRow`.

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -23,7 +23,7 @@
 //! - `LineBreak` — line breaks within content blocks
 //! - `ThematicBreak` — divider blocks
 //!
-//! List and table structure events (`StartListItem`, `StartTable*`, etc.) are silently ignored
+//! List and table structure events (`StartOrderedListItem`, `StartUnorderedListItem`, `StartTable*`, etc.) are silently ignored
 //! by this writer. Use `StackTrackingSink` from `docspec_core` to wrap the writer for automatic
 //! paragraph insertion within list items and table cells.
 //!
@@ -463,7 +463,6 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             | Event::EndDefinitionDetail
             | Event::EndDefinitionList
             | Event::EndFootnote
-            | Event::EndListItem
             | Event::EndTable
             | Event::EndTableCell
             | Event::EndTableHeader
@@ -475,7 +474,6 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             | Event::StartDefinitionTerm { .. }
             | Event::StartFootnote { .. }
             | Event::StartLink { .. }
-            | Event::StartListItem { .. }
             | Event::StartTable { .. }
             | Event::StartTableCell { .. }
             | Event::StartTableHeader { .. }

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -690,18 +690,16 @@ mod tests {
                 language: None,
                 metadata: None,
             },
-            Event::StartListItem {
+            Event::StartUnorderedListItem {
                 id: None,
-                level: 1,
-                list_type: docspec_core::ListType::Unordered,
-                start: None,
-                style_type: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
             },
             Event::Text {
                 content: "Item".to_string(),
                 style: TextStyle::default(),
             },
-            Event::EndListItem,
+            Event::EndUnorderedListItem,
             Event::EndDocument,
         ]);
         assert_eq!(

--- a/crates/docspec-core/src/event.rs
+++ b/crates/docspec-core/src/event.rs
@@ -133,8 +133,8 @@ pub enum Event {
     /// End a hyperlink.
     EndLink,
 
-    /// End a list item.
-    EndListItem,
+    /// End an ordered (numbered) list item.
+    EndOrderedListItem,
 
     /// End a paragraph.
     EndParagraph,
@@ -153,6 +153,9 @@ pub enum Event {
 
     /// End a table row.
     EndTableRow,
+
+    /// End an unordered (bulleted) list item.
+    EndUnorderedListItem,
 
     /// A reference to a footnote.
     FootnoteRef {
@@ -241,18 +244,17 @@ pub enum Event {
         title: Option<String>,
     },
 
-    /// Begin a list item.
-    StartListItem {
+    /// Begin an ordered (numbered) list item.
+    StartOrderedListItem {
         /// Optional block identifier.
         id: Option<String>,
-        /// Nesting level (1 = top-level).
-        level: u8,
-        /// Whether the list is ordered or unordered.
-        list_type: crate::ListType,
-        /// Starting number for ordered lists (None = continue from previous).
-        start: Option<u32>,
-        /// Visual style for the list marker.
-        style_type: Option<crate::ListStyleType>,
+        /// Zero-indexed nesting depth (0 = top-level list).
+        level: u32,
+        /// Starting number for the list, populated only on the first item of an ordered list
+        /// (subsequent items in the same list: `None`).
+        start: Option<u64>,
+        /// Visual style of the list marker. Writers tolerate mismatches per `ListStyleType` convention.
+        style_type: crate::ListStyleType,
     },
 
     /// Begin a paragraph with optional alignment.
@@ -305,6 +307,16 @@ pub enum Event {
     StartTableRow {
         /// Optional block identifier.
         id: Option<String>,
+    },
+
+    /// Begin an unordered (bulleted) list item.
+    StartUnorderedListItem {
+        /// Optional block identifier.
+        id: Option<String>,
+        /// Zero-indexed nesting depth (0 = top-level list).
+        level: u32,
+        /// Visual style of the list marker. Writers tolerate mismatches per `ListStyleType` convention.
+        style_type: crate::ListStyleType,
     },
 
     /// A text run with formatting attributes.

--- a/crates/docspec-core/src/lib.rs
+++ b/crates/docspec-core/src/lib.rs
@@ -12,8 +12,8 @@
 //!
 //! # Event Types
 //!
-//! The [`Event`] enum has 37 variants covering all document structures defined in
-//! the `DocSpec` specification.
+//! The [`Event`] enum covers all document structures defined in the `DocSpec`
+//! specification. See `EVENTS.md` for the authoritative variant list and semantics.
 
 extern crate alloc;
 
@@ -28,6 +28,5 @@ pub use event::{Event, TextStyle};
 pub use stack::{block_kind_for_end, block_kind_for_start, BlockKind, StackTrackingSink};
 pub use traits::{AssetProvider, EventSink, EventSource};
 pub use types::{
-    Author, Color, DocumentMeta, ImageSource, ListStyleType, ListType, TableHeaderScope,
-    TextAlignment,
+    Author, Color, DocumentMeta, ImageSource, ListStyleType, TableHeaderScope, TextAlignment,
 };

--- a/crates/docspec-core/src/stack.rs
+++ b/crates/docspec-core/src/stack.rs
@@ -32,8 +32,8 @@ pub enum BlockKind {
     Heading,
     /// A hyperlink container.
     Link,
-    /// A list item container.
-    ListItem,
+    /// An ordered (numbered) list item container.
+    OrderedListItem,
     /// A paragraph container.
     Paragraph,
     /// A preformatted (code) block container.
@@ -46,6 +46,8 @@ pub enum BlockKind {
     TableHeader,
     /// A table row container.
     TableRow,
+    /// An unordered (bulleted) list item container.
+    UnorderedListItem,
 }
 
 /// A wrapper around any [`EventSink`] that tracks the nesting stack of open block-level containers
@@ -79,7 +81,7 @@ impl<S: EventSink> StackTrackingSink<S> {
     /// block elements (paragraphs, headings, etc.), not inline text directly. Text inside
     /// a block quote without an explicit paragraph triggers auto-paragraph insertion.
     ///
-    /// Note: [`BlockKind::ListItem`], [`BlockKind::TableCell`], [`BlockKind::TableHeader`],
+    /// Note: [`BlockKind::OrderedListItem`], [`BlockKind::UnorderedListItem`], [`BlockKind::TableCell`], [`BlockKind::TableHeader`],
     /// and [`BlockKind::DefinitionDetail`] are NOT content-bearing despite being able to
     /// contain inline content per `EVENTS.md`. This is because downstream writers like
     /// `BlockNoteWriter` rely on auto-paragraph insertion for these container types.
@@ -277,8 +279,10 @@ pub fn block_kind_for_start(event: &Event) -> Option<BlockKind> {
         Some(BlockKind::Heading)
     } else if let Event::StartLink { .. } = event {
         Some(BlockKind::Link)
-    } else if let Event::StartListItem { .. } = event {
-        Some(BlockKind::ListItem)
+    } else if let Event::StartOrderedListItem { .. } = event {
+        Some(BlockKind::OrderedListItem)
+    } else if let Event::StartUnorderedListItem { .. } = event {
+        Some(BlockKind::UnorderedListItem)
     } else if let Event::StartParagraph { .. } = event {
         Some(BlockKind::Paragraph)
     } else if let Event::StartPreformatted { .. } = event {
@@ -320,8 +324,10 @@ pub fn block_kind_for_end(event: &Event) -> Option<BlockKind> {
         Some(BlockKind::Heading)
     } else if let Event::EndLink = event {
         Some(BlockKind::Link)
-    } else if let Event::EndListItem = event {
-        Some(BlockKind::ListItem)
+    } else if let Event::EndOrderedListItem = event {
+        Some(BlockKind::OrderedListItem)
+    } else if let Event::EndUnorderedListItem = event {
+        Some(BlockKind::UnorderedListItem)
     } else if let Event::EndParagraph = event {
         Some(BlockKind::Paragraph)
     } else if let Event::EndPreformatted = event {
@@ -356,8 +362,9 @@ pub fn end_event_for(kind: BlockKind) -> Event {
         BlockKind::Footnote => Event::EndFootnote,
         BlockKind::Heading => Event::EndHeading,
         BlockKind::Link => Event::EndLink,
-        BlockKind::ListItem => Event::EndListItem,
+        BlockKind::OrderedListItem => Event::EndOrderedListItem,
         BlockKind::Paragraph => Event::EndParagraph,
+        BlockKind::UnorderedListItem => Event::EndUnorderedListItem,
         BlockKind::Preformatted => Event::EndPreformatted,
         BlockKind::Table => Event::EndTable,
         BlockKind::TableCell => Event::EndTableCell,
@@ -849,7 +856,14 @@ mod tests {
         assert_eq!(end_event_for(BlockKind::Footnote), Event::EndFootnote);
         assert_eq!(end_event_for(BlockKind::Heading), Event::EndHeading);
         assert_eq!(end_event_for(BlockKind::Link), Event::EndLink);
-        assert_eq!(end_event_for(BlockKind::ListItem), Event::EndListItem);
+        assert_eq!(
+            end_event_for(BlockKind::OrderedListItem),
+            Event::EndOrderedListItem
+        );
+        assert_eq!(
+            end_event_for(BlockKind::UnorderedListItem),
+            Event::EndUnorderedListItem
+        );
         assert_eq!(end_event_for(BlockKind::Paragraph), Event::EndParagraph);
         assert_eq!(
             end_event_for(BlockKind::Preformatted),

--- a/crates/docspec-core/src/types.rs
+++ b/crates/docspec-core/src/types.rs
@@ -13,15 +13,6 @@ pub enum TextAlignment {
     Right,
 }
 
-/// Whether a list is ordered (numbered) or unordered (bulleted).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ListType {
-    /// Numbered list.
-    Ordered,
-    /// Bulleted list.
-    Unordered,
-}
-
 /// The specific visual style for a list.
 ///
 /// Writers ignore mismatched styles (e.g., Disc on an ordered list).

--- a/crates/docspec-core/tests/event.rs
+++ b/crates/docspec-core/tests/event.rs
@@ -4,8 +4,7 @@
 mod tests {
     use docspec_core::*;
     use docspec_core::{
-        Author, Color, DocumentMeta, ImageSource, ListStyleType, ListType, TableHeaderScope,
-        TextAlignment,
+        Author, Color, DocumentMeta, ImageSource, ListStyleType, TableHeaderScope, TextAlignment,
     };
 
     #[test]
@@ -72,8 +71,15 @@ mod tests {
     }
 
     #[test]
-    fn end_list_item() {
-        let event = Event::EndListItem;
+    fn end_ordered_list_item() {
+        let event = Event::EndOrderedListItem;
+        let cloned = event.clone();
+        assert_eq!(event, cloned);
+    }
+
+    #[test]
+    fn end_unordered_list_item() {
+        let event = Event::EndUnorderedListItem;
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
@@ -357,35 +363,30 @@ mod tests {
     }
 
     #[test]
-    fn start_list_item_ordered() {
-        let event = Event::StartListItem {
+    fn start_ordered_list_item() {
+        let event = Event::StartOrderedListItem {
             id: None,
-            level: 1,
-            list_type: ListType::Ordered,
+            level: 0,
             start: Some(1),
-            style_type: Some(ListStyleType::Decimal),
+            style_type: ListStyleType::Decimal,
         };
         let cloned = event.clone();
         assert_eq!(event, cloned);
     }
 
     #[test]
-    fn start_list_item_unordered() {
-        let event = Event::StartListItem {
+    fn start_unordered_list_item() {
+        let event = Event::StartUnorderedListItem {
             id: None,
-            level: 2,
-            list_type: ListType::Unordered,
-            start: None,
-            style_type: Some(ListStyleType::Disc),
+            level: 1,
+            style_type: ListStyleType::Disc,
         };
         assert_eq!(
             event,
-            Event::StartListItem {
+            Event::StartUnorderedListItem {
                 id: None,
-                level: 2,
-                list_type: ListType::Unordered,
-                start: None,
-                style_type: Some(ListStyleType::Disc),
+                level: 1,
+                style_type: ListStyleType::Disc,
             }
         );
     }

--- a/crates/docspec-core/tests/stack.rs
+++ b/crates/docspec-core/tests/stack.rs
@@ -115,9 +115,18 @@ mod tests {
     }
 
     #[test]
-    fn block_kind_for_end_list_item() {
-        let event = Event::EndListItem;
-        assert_eq!(block_kind_for_end(&event), Some(BlockKind::ListItem));
+    fn block_kind_for_end_ordered_list_item() {
+        let event = Event::EndOrderedListItem;
+        assert_eq!(block_kind_for_end(&event), Some(BlockKind::OrderedListItem));
+    }
+
+    #[test]
+    fn block_kind_for_end_unordered_list_item() {
+        let event = Event::EndUnorderedListItem;
+        assert_eq!(
+            block_kind_for_end(&event),
+            Some(BlockKind::UnorderedListItem)
+        );
     }
 
     #[test]
@@ -237,15 +246,30 @@ mod tests {
     }
 
     #[test]
-    fn block_kind_for_start_list_item() {
-        let event = Event::StartListItem {
+    fn block_kind_for_start_ordered_list_item() {
+        let event = Event::StartOrderedListItem {
             id: None,
-            level: 1,
-            list_type: docspec_core::ListType::Unordered,
-            start: None,
-            style_type: None,
+            level: 0,
+            start: Some(1),
+            style_type: docspec_core::ListStyleType::Decimal,
         };
-        assert_eq!(block_kind_for_start(&event), Some(BlockKind::ListItem));
+        assert_eq!(
+            block_kind_for_start(&event),
+            Some(BlockKind::OrderedListItem)
+        );
+    }
+
+    #[test]
+    fn block_kind_for_start_unordered_list_item() {
+        let event = Event::StartUnorderedListItem {
+            id: None,
+            level: 0,
+            style_type: docspec_core::ListStyleType::Disc,
+        };
+        assert_eq!(
+            block_kind_for_start(&event),
+            Some(BlockKind::UnorderedListItem)
+        );
     }
 
     #[test]

--- a/crates/docspec-core/tests/types.rs
+++ b/crates/docspec-core/tests/types.rs
@@ -179,19 +179,6 @@ mod tests {
     }
 
     #[test]
-    fn list_type_clone() {
-        let list_type = ListType::Ordered;
-        let cloned = list_type.clone();
-        assert_eq!(list_type, cloned);
-    }
-
-    #[test]
-    fn list_type_variants() {
-        assert_eq!(ListType::Ordered, ListType::Ordered);
-        assert_ne!(ListType::Ordered, ListType::Unordered);
-    }
-
-    #[test]
     fn table_header_scope_clone() {
         let scope = TableHeaderScope::Column;
         let cloned = scope.clone();

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -36,13 +36,17 @@
 //! - Tables → `StartTable` / `EndTable`, `StartTableRow` / `EndTableRow`,
 //!   `StartTableHeader` / `EndTableHeader`, `StartTableCell` / `EndTableCell`
 //!   (GFM column alignment syntax is parsed, but alignment data is discarded)
+//! - Bullet lists → `StartUnorderedListItem` / `EndUnorderedListItem`
+//! - Numbered lists → `StartOrderedListItem` / `EndOrderedListItem`
+//!   (`start: Option<u64>` is `Some(n)` on the first item of each list, `None` on subsequent items;
+//!   nesting is flat-by-level; task list markers (`- [ ]`/`- [x]`) are parsed as literal text)
 //!
 //! # Unsupported Elements
 //!
 //! The following elements are not emitted as structured events. Text content is
 //! recursively extracted where applicable; structure is silently dropped:
 //!
-//! - Lists and links (text extracted, structure dropped)
+//! - Links (text extracted, structure dropped)
 //! - Definition lists and footnotes
 //! - HTML blocks and inline HTML
 //! - Math blocks and inline math
@@ -53,7 +57,7 @@ extern crate alloc;
 use alloc::collections::VecDeque;
 
 pub use docspec_core::EventSource;
-use docspec_core::{Event, ImageSource, Result, TableHeaderScope, TextStyle};
+use docspec_core::{Event, ImageSource, ListStyleType, Result, TableHeaderScope, TextStyle};
 use pulldown_cmark::{CodeBlockKind, HeadingLevel, Options, Parser, Tag, TagEnd};
 
 /// Whether content is inside a block-level element.
@@ -76,6 +80,15 @@ enum Phase {
     NotStarted,
     /// Processing events between `StartDocument` and `EndDocument`.
     Running,
+}
+
+/// Context for a single list level tracked by [`MarkdownReader`].
+struct ListContext {
+    /// Whether this list is ordered (numbered) rather than unordered (bulleted).
+    ordered: bool,
+    /// Start number to attach to the next item emitted; `Some(n)` only before the first
+    /// item is emitted, then `None` for all subsequent items in the same list.
+    pending_start: Option<u64>,
 }
 
 /// Buffered image state during image alt text collection.
@@ -112,12 +125,18 @@ pub struct MarkdownReader<'a> {
     bold_depth: usize,
     /// Buffered code block text (accumulated until `EndCodeBlock` to strip trailing newline).
     code_block_buffer: Option<String>,
+    /// Whether a list item `Start*` event has been emitted but its matching `End*` not yet
+    /// emitted. Used to avoid double-close when a nested list prematurely closes the parent item.
+    current_item_open: bool,
     /// Buffered image being processed (alt text accumulation).
     image: Option<ImageBuffer>,
     /// Whether the parser is currently inside a table header row.
     in_table_head: bool,
     /// Nesting depth for italic (emphasis) formatting.
     italic_depth: usize,
+    /// LIFO stack of list contexts. `len()` gives the current nesting depth;
+    /// `level = list_stack.len().saturating_sub(1)` at item-emit time.
+    list_stack: alloc::vec::Vec<ListContext>,
     /// The pulldown-cmark parser.
     parser: Parser<'a>,
     /// Document processing phase.
@@ -129,6 +148,20 @@ pub struct MarkdownReader<'a> {
 }
 
 impl<'a> MarkdownReader<'a> {
+    fn close_current_item_if_open(&mut self) {
+        if self.current_item_open {
+            if let Some(ctx) = self.list_stack.last() {
+                if ctx.ordered {
+                    self.queue.push_back(Event::EndOrderedListItem);
+                } else {
+                    self.queue.push_back(Event::EndUnorderedListItem);
+                }
+            }
+            self.current_item_open = false;
+            self.block_state = BlockState::None;
+        }
+    }
+
     fn current_text_style(&self) -> TextStyle {
         let mut style = TextStyle::default();
         if self.bold_depth > 0 {
@@ -168,8 +201,10 @@ impl<'a> MarkdownReader<'a> {
             TagEnd::BlockQuote(_) => self.push_event_end(Event::EndBlockQuote),
             TagEnd::Item => {
                 if self.block_state == BlockState::AutoParagraph {
-                    self.push_event_end(Event::EndParagraph);
+                    self.queue.push_back(Event::EndParagraph);
                 }
+                self.close_current_item_if_open();
+                self.block_state = BlockState::None;
             }
             TagEnd::Emphasis => {
                 self.italic_depth = self.italic_depth.saturating_sub(1);
@@ -212,13 +247,17 @@ impl<'a> MarkdownReader<'a> {
                 }
                 self.push_event_end(Event::EndPreformatted);
             }
+            TagEnd::List(_) => {
+                self.close_current_item_if_open();
+                self.list_stack.pop();
+                self.block_state = BlockState::None;
+            }
             TagEnd::DefinitionList
             | TagEnd::DefinitionListDefinition
             | TagEnd::DefinitionListTitle
             | TagEnd::FootnoteDefinition
             | TagEnd::HtmlBlock
             | TagEnd::Link
-            | TagEnd::List(_)
             | TagEnd::MetadataBlock(_)
             | TagEnd::Subscript
             | TagEnd::Superscript => {}
@@ -236,6 +275,37 @@ impl<'a> MarkdownReader<'a> {
                 }
             }
         }
+    }
+
+    fn handle_item_start(&mut self) {
+        let depth = self.list_stack.len().saturating_sub(1);
+        let level = u32::try_from(depth).map_or(u32::MAX, |v| v);
+        if let Some(ctx) = self.list_stack.last_mut() {
+            if ctx.ordered {
+                self.queue.push_back(Event::StartOrderedListItem {
+                    start: ctx.pending_start.take(),
+                    style_type: ListStyleType::Decimal,
+                    level,
+                    id: None,
+                });
+            } else {
+                self.queue.push_back(Event::StartUnorderedListItem {
+                    style_type: ListStyleType::Disc,
+                    level,
+                    id: None,
+                });
+            }
+            self.current_item_open = true;
+            self.block_state = BlockState::Explicit;
+        }
+    }
+
+    fn handle_list_start(&mut self, start_opt: Option<u64>) {
+        self.close_current_item_if_open();
+        self.list_stack.push(ListContext {
+            ordered: start_opt.is_some(),
+            pending_start: start_opt,
+        });
     }
 
     fn handle_start_tag(&mut self, tag: Tag<'a>) {
@@ -290,14 +360,14 @@ impl<'a> MarkdownReader<'a> {
                     url: dest_url.into_string(),
                 });
             }
+            Tag::List(start_opt) => self.handle_list_start(start_opt),
+            Tag::Item => self.handle_item_start(),
             Tag::DefinitionList
             | Tag::DefinitionListDefinition
             | Tag::DefinitionListTitle
             | Tag::FootnoteDefinition(_)
             | Tag::HtmlBlock
-            | Tag::Item
             | Tag::Link { .. }
-            | Tag::List(_)
             | Tag::MetadataBlock(_)
             | Tag::Subscript
             | Tag::Superscript => {}
@@ -368,9 +438,11 @@ impl<'a> MarkdownReader<'a> {
             block_state: BlockState::None,
             bold_depth: 0,
             code_block_buffer: None,
-            in_table_head: false,
+            current_item_open: false,
             image: None,
+            in_table_head: false,
             italic_depth: 0,
+            list_stack: Vec::new(),
             parser,
             phase: Phase::NotStarted,
             queue: VecDeque::new(),

--- a/crates/docspec-markdown-reader/tests/integration.rs
+++ b/crates/docspec-markdown-reader/tests/integration.rs
@@ -139,4 +139,12 @@ mod tests {
         let actual = run_pipeline(markdown);
         assert_json_eq(&actual, expected);
     }
+
+    #[test]
+    fn pipeline_lists() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/lists.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/lists.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
 }

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -2,7 +2,9 @@
 
 #[cfg(test)]
 mod tests {
-    use docspec_core::{Event, EventSource as _, ImageSource, TableHeaderScope, TextStyle};
+    use docspec_core::{
+        Event, EventSource as _, ImageSource, ListStyleType, TableHeaderScope, TextStyle,
+    };
     use docspec_markdown_reader::MarkdownReader;
 
     fn collect_events(reader: &mut MarkdownReader<'_>) -> Vec<Event> {
@@ -103,7 +105,8 @@ mod tests {
                 | Event::EndDefinitionTerm
                 | Event::EndFootnote
                 | Event::EndLink
-                | Event::EndListItem
+                | Event::EndOrderedListItem
+                | Event::EndUnorderedListItem
                 | Event::EndPreformatted
                 | Event::EndTable
                 | Event::EndTableCell
@@ -120,7 +123,8 @@ mod tests {
                 | Event::StartFootnote { .. }
                 | Event::StartHeading { .. }
                 | Event::StartLink { .. }
-                | Event::StartListItem { .. }
+                | Event::StartOrderedListItem { .. }
+                | Event::StartUnorderedListItem { .. }
                 | Event::StartPreformatted { .. }
                 | Event::StartTable { .. }
                 | Event::StartTableCell { .. }
@@ -422,10 +426,12 @@ mod tests {
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        assert!(!events
+        assert!(events
             .iter()
-            .any(|e| matches!(e, Event::StartListItem { .. })));
-        assert!(!events.iter().any(|e| matches!(e, Event::EndListItem)));
+            .any(|e| matches!(e, Event::StartUnorderedListItem { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::EndUnorderedListItem)));
 
         let has_item_one = events
             .iter()
@@ -549,15 +555,20 @@ mod tests {
     }
 
     #[test]
-    fn list_item_text_wrapped_in_auto_paragraph() {
+    fn list_item_emits_start_text_end_directly() {
         let markdown = "- Item";
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        assert!(events
-            .iter()
-            .any(|e| matches!(e, Event::StartParagraph { .. })));
-        assert!(events.iter().any(|e| matches!(e, Event::EndParagraph)));
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(
+            events.get(2),
+            Some(Event::Text { content, .. }) if content == "Item"
+        ));
+        assert!(matches!(events.get(3), Some(Event::EndUnorderedListItem)));
     }
 
     #[test]
@@ -900,5 +911,216 @@ mod tests {
         assert!(matches!(events.get(12), Some(Event::EndTable)));
         assert!(matches!(events.get(13), Some(Event::StartTable { .. })));
         assert!(matches!(events.get(24), Some(Event::EndTable)));
+    }
+
+    #[test]
+    fn simple_bullet_list_emits_unordered_items() {
+        let mut reader = MarkdownReader::new("- a\n- b\n- c");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem {
+                style_type: ListStyleType::Disc,
+                level: 0,
+                id: None,
+            })
+        ));
+        assert!(matches!(events.get(2), Some(Event::Text { .. })));
+        assert!(matches!(events.get(3), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(4),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(6), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(7),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(9), Some(Event::EndUnorderedListItem)));
+    }
+
+    #[test]
+    fn simple_numbered_list_emits_ordered_items() {
+        let mut reader = MarkdownReader::new("1. a\n2. b\n3. c");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartOrderedListItem {
+                start: Some(1),
+                level: 0,
+                ..
+            })
+        ));
+        assert!(matches!(events.get(3), Some(Event::EndOrderedListItem)));
+        assert!(matches!(
+            events.get(4),
+            Some(Event::StartOrderedListItem {
+                start: None,
+                level: 0,
+                ..
+            })
+        ));
+        assert!(matches!(
+            events.get(7),
+            Some(Event::StartOrderedListItem {
+                start: None,
+                level: 0,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn numbered_list_with_explicit_start() {
+        let mut reader = MarkdownReader::new("5. a\n6. b\n7. c");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartOrderedListItem {
+                start: Some(5),
+                level: 0,
+                ..
+            })
+        ));
+        assert!(matches!(
+            events.get(4),
+            Some(Event::StartOrderedListItem {
+                start: None,
+                level: 0,
+                ..
+            })
+        ));
+        assert!(matches!(
+            events.get(7),
+            Some(Event::StartOrderedListItem {
+                start: None,
+                level: 0,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn bullet_list_emits_disc_style() {
+        let mut reader = MarkdownReader::new("- a");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem {
+                style_type: ListStyleType::Disc,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn ordered_list_emits_decimal_style() {
+        let mut reader = MarkdownReader::new("1. a");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartOrderedListItem {
+                style_type: ListStyleType::Decimal,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn nested_bullet_lists_emit_increasing_level() {
+        let mut reader = MarkdownReader::new("- A\n  - B\n  - C\n- D");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(3), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(4),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(events.get(6), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(7),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(events.get(9), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(10),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(12), Some(Event::EndUnorderedListItem)));
+    }
+
+    #[test]
+    fn mixed_nested_lists() {
+        let mut reader = MarkdownReader::new("- A\n  1. B\n  2. C\n- D");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(3), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(4),
+            Some(Event::StartOrderedListItem {
+                start: Some(1),
+                level: 1,
+                ..
+            })
+        ));
+        assert!(matches!(events.get(6), Some(Event::EndOrderedListItem)));
+        assert!(matches!(
+            events.get(7),
+            Some(Event::StartOrderedListItem {
+                start: None,
+                level: 1,
+                ..
+            })
+        ));
+        assert!(matches!(events.get(9), Some(Event::EndOrderedListItem)));
+        assert!(matches!(
+            events.get(10),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(12), Some(Event::EndUnorderedListItem)));
+    }
+
+    #[test]
+    fn list_items_with_inline_formatting() {
+        let mut reader = MarkdownReader::new("- **bold** item\n- *italic* item");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(
+            events.get(2),
+            Some(Event::Text {
+                style: TextStyle { bold: true, .. },
+                ..
+            })
+        ));
+        assert!(matches!(events.get(4), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(5),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(
+            events.get(6),
+            Some(Event::Text {
+                style: TextStyle { italic: true, .. },
+                ..
+            })
+        ));
+        assert!(matches!(events.get(8), Some(Event::EndUnorderedListItem)));
     }
 }

--- a/tests/fixtures/blocknote/lists.json
+++ b/tests/fixtures/blocknote/lists.json
@@ -1,0 +1,304 @@
+[
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "First item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Second item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Third item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "First item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Second item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Third item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Fifth item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Sixth item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Seventh item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Outer A",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Inner A1",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Inner A2",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Outer B",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Bullet outer",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Numbered inner one",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Numbered inner two",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Bullet outer continued",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Bold",
+        "styles": {
+          "bold": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Italic",
+        "styles": {
+          "italic": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Code",
+        "styles": {
+          "code": true
+        }
+      },
+      {
+        "type": "text",
+        "text": " item",
+        "styles": {}
+      }
+    ],
+    "children": []
+  }
+]
+

--- a/tests/fixtures/markdown/lists.md
+++ b/tests/fixtures/markdown/lists.md
@@ -1,0 +1,31 @@
+<!-- variant 1: simple bullet list -->
+- First item
+- Second item
+- Third item
+
+<!-- variant 2: simple numbered list -->
+1. First item
+2. Second item
+3. Third item
+
+<!-- variant 3: numbered list with explicit start -->
+5. Fifth item
+6. Sixth item
+7. Seventh item
+
+<!-- variant 4: nested bullet list -->
+- Outer A
+  - Inner A1
+  - Inner A2
+- Outer B
+
+<!-- variant 5: nested mixed list -->
+- Bullet outer
+  1. Numbered inner one
+  2. Numbered inner two
+- Bullet outer continued
+
+<!-- variant 6: list items with inline formatting -->
+- **Bold** item
+- *Italic* item
+- `Code` item


### PR DESCRIPTION
Adds list support to the markdown reader, with a breaking change to the core event spec.

## Spec change (breaking)

- Removed: `Event::StartListItem`, `Event::EndListItem`, `enum ListType`
- Added: `Event::StartOrderedListItem`, `Event::EndOrderedListItem`, `Event::StartUnorderedListItem`, `Event::EndUnorderedListItem`
- `StackTrackingSink` updated: `BlockKind::ListItem` split into `BlockKind::OrderedListItem` and `BlockKind::UnorderedListItem`
- `EVENTS.md` updated with new variant table entries + well-formedness rules

## Reader implementation

- List-context stack tracks pulldown-cmark's nested `Tag::List` / `Tag::Item` events
- Emits flat-by-level event stream — nested items close their parent before opening
- `start` populated only on the first item of an ordered list (carries the start number from pulldown-cmark)
- Reader emits `style_type: Decimal` for ordered and `style_type: Disc` for unordered (markdown can't express other styles)
- Task list markers (`- [ ]`/`- [x]`) are parsed as literal text — `ENABLE_TASKLISTS` option NOT enabled. `CheckListItem` variant deferred to a follow-up PR.

## Writer scope

- `docspec-blocknote-writer` touched only to keep compiling — explicit silent-drop arm updated to remove the obsolete variant names; new variants fall through to the existing `_ => Ok(())` catch-all
- Full BlockNote `bulletListItem`/`numberedListItem` JSON emission is intentionally deferred to a separate PR (writer is being developed elsewhere)

## Testing

- 8 new reader unit tests covering simple/nested/mixed/start≠1/inline-formatting scenarios
- `pipeline_lists` integration test with `tests/fixtures/markdown/lists.md` and `tests/fixtures/blocknote/lists.json` fixtures
- All existing tests pass (no regression)

Refs #37
Refs #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved list handling: explicit ordered vs. unordered list items, correct nesting levels, preserved ordered start numbers, optional per-item ids, and richer list style semantics.
  * Markdown import/export now emits structured list events and includes fixtures covering nested, mixed, started, and inline-styled list items.

* **Refactor**
  * Internal list tracking streamlined to reliably manage list boundaries and nesting.

* **Documentation**
  * Updated docs to describe supported list behaviors, nesting, and ordered-start semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->