### PR TITLE
fix(markdown-reader): keep parent item open during nested list

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -14,7 +14,7 @@ DocSpec documents are streams of typed events. Readers emit events. Writers cons
 
 **No warnings.** Errors are out-of-band via `Result`. Events carry content only.
 
-**Flat list model.** `StartOrderedListItem`/`StartUnorderedListItem` carry nesting level as a field. No `StartList`/`EndList`. Maps cleanly to DOCX/RTF where list structure is implicit.
+**Nested list items with level hints.** `StartOrderedListItem`/`StartUnorderedListItem` carry nesting level as a field and may nest in the event stream. No `StartList`/`EndList` exist. `level` is the authoritative indent depth — writers that do not build a tree may rely on it alone. Nesting in events lets continuation content (e.g., CommonMark paragraphs) sit naturally inside the owning parent item.
 
 ---
 
@@ -160,7 +160,7 @@ Every `Start*` has a matching `End*`. They nest but never overlap.
 
 **Heading.** Levels 1–6 are standard (HTML). DOCX/ODT/RTF support 1–9. Writers clamp higher levels. Heading levels are 1-based (range 1–9); list item `level` is 0-indexed (0 = top-level list).
 
-**List items.** Nesting is flat — children follow parents sequentially, distinguished by `level`. No `StartList`/`EndList` exists. `StartOrderedListItem` carries `start: Option<u64>` populated only on the first item of each ordered list (subsequent items: `None`). **Boundary rules:** a new list begins when (a) a non-list block intervenes, (b) ordered vs. unordered changes at the same level, or (c) level decreases then increases without a parent.
+**List items.** Child items may nest inside their parent's `Start*`/`End*` pair. The parent's `End*ListItem` appears AFTER all child items AND any continuation content (paragraphs, line breaks) that semantically belongs to the parent. `level` is 0-indexed (0 = top-level) and is the authoritative indent depth; writers that do not build a tree may rely on `level` alone. `StartOrderedListItem` carries `start: Option<u64>` populated only on the first item of each ordered list (subsequent items: `None`). **Boundary rules** (for sibling items at the same level): a new list begins when (a) a non-list block intervenes, (b) ordered vs. unordered changes at the same level, or (c) level decreases then increases without a parent.
 
 **Table.** `StartCaption` is optional, appears before rows. Header cells carry `scope`/`abbr` for accessibility; data cells omit these. Cells may contain any block element.
 
@@ -194,7 +194,7 @@ Readers MUST produce well-formed streams. Writers MAY assume well-formedness.
 2. Exactly one root: `StartDocument`. Empty containers (`Start*` immediately followed by `End*`) are valid.
 3. `Text` appears only inside containers, never at root.
 4. `StartLink` appears inside inline-accepting blocks (paragraphs, headings, list items, cells, definition details). Links do not nest.
-5. `StartOrderedListItem` and `StartUnorderedListItem` appear inside block containers. List items are flat — distinguished by `level` field.
+5. `StartOrderedListItem` and `StartUnorderedListItem` appear inside block containers. List items may nest (child items inside parent `Start*`/`End*` pairs); the `level` field indicates indentation depth and is 0-indexed.
 6. `StartCaption` appears at most once per table, before any rows.
 7. Each footnote ID appears in exactly one `FootnoteRef` and one `StartFootnote`.
 8. Table structure: `StartTableRow` appears only inside `StartTable`. `StartTableCell`/`StartTableHeader` appear only inside `StartTableRow`.

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -39,7 +39,8 @@
 //! - Bullet lists → `StartUnorderedListItem` / `EndUnorderedListItem`
 //! - Numbered lists → `StartOrderedListItem` / `EndOrderedListItem`
 //!   (`start: Option<u64>` is `Some(n)` on the first item of each list, `None` on subsequent items;
-//!   nesting is flat-by-level; task list markers (`- [ ]`/`- [x]`) are parsed as literal text)
+//!   child items may nest inside their parent's `Start*`/`End*` pair with `level` indicating
+//!   indent depth; task list markers (`- [ ]`/`- [x]`) are parsed as literal text)
 //!
 //! # Unsupported Elements
 //!
@@ -84,6 +85,8 @@ enum Phase {
 
 /// Context for a single list level tracked by [`MarkdownReader`].
 struct ListContext {
+    /// Whether the item at this list level is currently open (start emitted, end not yet emitted).
+    item_open: bool,
     /// Whether this list is ordered (numbered) rather than unordered (bulleted).
     ordered: bool,
     /// Start number to attach to the next item emitted; `Some(n)` only before the first
@@ -125,9 +128,6 @@ pub struct MarkdownReader<'a> {
     bold_depth: usize,
     /// Buffered code block text (accumulated until `EndCodeBlock` to strip trailing newline).
     code_block_buffer: Option<String>,
-    /// Whether a list item `Start*` event has been emitted but its matching `End*` not yet
-    /// emitted. Used to avoid double-close when a nested list prematurely closes the parent item.
-    current_item_open: bool,
     /// Buffered image being processed (alt text accumulation).
     image: Option<ImageBuffer>,
     /// Whether the parser is currently inside a table header row.
@@ -149,16 +149,16 @@ pub struct MarkdownReader<'a> {
 
 impl<'a> MarkdownReader<'a> {
     fn close_current_item_if_open(&mut self) {
-        if self.current_item_open {
-            if let Some(ctx) = self.list_stack.last() {
+        if let Some(ctx) = self.list_stack.last_mut() {
+            if ctx.item_open {
                 if ctx.ordered {
                     self.queue.push_back(Event::EndOrderedListItem);
                 } else {
                     self.queue.push_back(Event::EndUnorderedListItem);
                 }
+                ctx.item_open = false;
+                self.block_state = BlockState::None;
             }
-            self.current_item_open = false;
-            self.block_state = BlockState::None;
         }
     }
 
@@ -295,14 +295,14 @@ impl<'a> MarkdownReader<'a> {
                     id: None,
                 });
             }
-            self.current_item_open = true;
+            ctx.item_open = true;
             self.block_state = BlockState::Explicit;
         }
     }
 
     fn handle_list_start(&mut self, start_opt: Option<u64>) {
-        self.close_current_item_if_open();
         self.list_stack.push(ListContext {
+            item_open: false,
             ordered: start_opt.is_some(),
             pending_start: start_opt,
         });
@@ -438,7 +438,6 @@ impl<'a> MarkdownReader<'a> {
             block_state: BlockState::None,
             bold_depth: 0,
             code_block_buffer: None,
-            current_item_open: false,
             image: None,
             in_table_head: false,
             italic_depth: 0,

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -457,6 +457,34 @@ mod tests {
     }
 
     #[test]
+    fn nested_list_with_continuation_keeps_parent_item_open() {
+        let mut reader = MarkdownReader::new(
+            "- Outer A\n  - Inner nested\n\n  Continuation paragraph for Outer A\n- Outer B\n",
+        );
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(2), Some(Event::StartParagraph { .. })));
+        assert!(matches!(events.get(4), Some(Event::EndParagraph)));
+        assert!(matches!(
+            events.get(5),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(events.get(7), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(events.get(8), Some(Event::StartParagraph { .. })));
+        assert!(matches!(events.get(10), Some(Event::EndParagraph)));
+        assert!(matches!(events.get(11), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(
+            events.get(12),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert_eq!(events.len(), 18);
+    }
+
+    #[test]
     fn next_event_returns_none_after_end_document() {
         let mut reader = MarkdownReader::new("");
         let events = collect_events(&mut reader);
@@ -1040,16 +1068,16 @@ mod tests {
             events.get(1),
             Some(Event::StartUnorderedListItem { level: 0, .. })
         ));
-        assert!(matches!(events.get(3), Some(Event::EndUnorderedListItem)));
         assert!(matches!(
-            events.get(4),
+            events.get(3),
             Some(Event::StartUnorderedListItem { level: 1, .. })
         ));
-        assert!(matches!(events.get(6), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(events.get(5), Some(Event::EndUnorderedListItem)));
         assert!(matches!(
-            events.get(7),
+            events.get(6),
             Some(Event::StartUnorderedListItem { level: 1, .. })
         ));
+        assert!(matches!(events.get(8), Some(Event::EndUnorderedListItem)));
         assert!(matches!(events.get(9), Some(Event::EndUnorderedListItem)));
         assert!(matches!(
             events.get(10),
@@ -1067,30 +1095,61 @@ mod tests {
             events.get(1),
             Some(Event::StartUnorderedListItem { level: 0, .. })
         ));
-        assert!(matches!(events.get(3), Some(Event::EndUnorderedListItem)));
         assert!(matches!(
-            events.get(4),
+            events.get(3),
             Some(Event::StartOrderedListItem {
                 start: Some(1),
                 level: 1,
                 ..
             })
         ));
-        assert!(matches!(events.get(6), Some(Event::EndOrderedListItem)));
+        assert!(matches!(events.get(5), Some(Event::EndOrderedListItem)));
         assert!(matches!(
-            events.get(7),
+            events.get(6),
             Some(Event::StartOrderedListItem {
                 start: None,
                 level: 1,
                 ..
             })
         ));
-        assert!(matches!(events.get(9), Some(Event::EndOrderedListItem)));
+        assert!(matches!(events.get(8), Some(Event::EndOrderedListItem)));
+        assert!(matches!(events.get(9), Some(Event::EndUnorderedListItem)));
         assert!(matches!(
             events.get(10),
             Some(Event::StartUnorderedListItem { level: 0, .. })
         ));
         assert!(matches!(events.get(12), Some(Event::EndUnorderedListItem)));
+    }
+
+    #[test]
+    fn list_item_containing_only_nested_list_no_text() {
+        let mut reader = MarkdownReader::new("- \n  - Nested item\n- Sibling\n");
+        let events = collect_events(&mut reader);
+
+        // Outer item opens without any text of its own
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        // Nested item opens immediately inside outer item
+        assert!(matches!(
+            events.get(2),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(
+            events.get(3),
+            Some(Event::Text { content, .. }) if content == "Nested item"
+        ));
+        assert!(matches!(events.get(4), Some(Event::EndUnorderedListItem)));
+        // Outer item closes after nested
+        assert!(matches!(events.get(5), Some(Event::EndUnorderedListItem)));
+        // Sibling item
+        assert!(matches!(
+            events.get(6),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(events.get(8), Some(Event::EndUnorderedListItem)));
+        assert_eq!(events.len(), 10);
     }
 
     #[test]
@@ -1122,5 +1181,56 @@ mod tests {
             })
         ));
         assert!(matches!(events.get(8), Some(Event::EndUnorderedListItem)));
+    }
+
+    #[test]
+    fn nested_list_with_hard_break_in_continuation() {
+        let mut reader = MarkdownReader::new("- A\n  - B\n\n  Line one  \n  Line two\n");
+        let events = collect_events(&mut reader);
+
+        // Continuation paragraph is inside parent item
+        assert!(matches!(events.get(8), Some(Event::StartParagraph { .. })));
+        assert!(matches!(
+            events.get(9),
+            Some(Event::Text { content, .. }) if content == "Line one"
+        ));
+        // Hard break is inside the continuation paragraph (not orphaned)
+        assert!(matches!(events.get(10), Some(Event::LineBreak)));
+        assert!(matches!(
+            events.get(11),
+            Some(Event::Text { content, .. }) if content == "Line two"
+        ));
+        assert!(matches!(events.get(12), Some(Event::EndParagraph)));
+        // Parent closes AFTER continuation
+        assert!(matches!(events.get(13), Some(Event::EndUnorderedListItem)));
+        assert_eq!(events.len(), 15);
+    }
+
+    #[test]
+    fn three_levels_deeply_nested_unordered_list() {
+        let mut reader = MarkdownReader::new("- A\n  - B\n    - C\n");
+        let events = collect_events(&mut reader);
+
+        assert!(matches!(
+            events.get(1),
+            Some(Event::StartUnorderedListItem { level: 0, .. })
+        ));
+        assert!(matches!(
+            events.get(3),
+            Some(Event::StartUnorderedListItem { level: 1, .. })
+        ));
+        assert!(matches!(
+            events.get(5),
+            Some(Event::StartUnorderedListItem { level: 2, .. })
+        ));
+        assert!(matches!(
+            events.get(6),
+            Some(Event::Text { content, .. }) if content == "C"
+        ));
+        // All three levels close in reverse order
+        assert!(matches!(events.get(7), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(events.get(8), Some(Event::EndUnorderedListItem)));
+        assert!(matches!(events.get(9), Some(Event::EndUnorderedListItem)));
+        assert_eq!(events.len(), 11);
     }
 }

--- a/tests/fixtures/blocknote/lists.json
+++ b/tests/fixtures/blocknote/lists.json
@@ -299,6 +299,61 @@
       }
     ],
     "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Outer A",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Inner nested",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Continuation paragraph for Outer A",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Outer B",
+        "styles": {}
+      }
+    ],
+    "children": []
   }
 ]
-

--- a/tests/fixtures/markdown/lists.md
+++ b/tests/fixtures/markdown/lists.md
@@ -29,3 +29,10 @@
 - **Bold** item
 - *Italic* item
 - `Code` item
+
+<!-- variant 7: nested list with continuation paragraph -->
+- Outer A
+  - Inner nested
+
+  Continuation paragraph for Outer A
+- Outer B


### PR DESCRIPTION
## Summary

Fixes a CommonMark conformance bug in `docspec-markdown-reader` where the parent list item was prematurely closed when a nested list began. After this fix, parent items stay open across nested lists and continuation content, matching pulldown-cmark event ordering and the CommonMark spec.

## Background

Detected by Copilot during PR #60 post-merge review on `lib.rs:307` (`handle_list_start`). The original code called `close_current_item_if_open()` whenever a `Tag::List` started, but per CommonMark, list items can contain nested lists AND continue with text/paragraphs after — the parent item must stay open.

## Changes

- Moved `current_item_open` from `MarkdownReader` to `ListContext` as per-level `item_open: bool` field
- Removed `close_current_item_if_open()` call from `handle_list_start`
- Updated `handle_item_start` and `close_current_item_if_open` to operate on top-of-stack item state
- Added fixture variant 7: nested list with continuation paragraph (4 new entries in `lists.json`)
- Added reader unit tests: continuation case, hard break in continuation, 3-level nesting, item-only-nested
- Updated existing variant 4/5 test assertions for corrected event order
- **Updated `EVENTS.md`** to reflect the new contract: list items may nest in the event stream; `level` remains the authoritative indent depth (see Design Decisions, Semantics → List items, Well-Formedness rule 5)

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: clean
- `cargo test --workspace`: all pass (12 integration + 57 reader tests)

## Scope

Reader-only fix + spec alignment. Writer changes (full BlockNote list emission) remain deferred to a follow-up PR per PR #60 Option A scope.

## Notes

- Integration test `pipeline_lists` logic is unchanged (writer falls through list events); the `lists.json` fixture grew by 4 entries to cover variant 7 continuation paragraphs
- Coverage CI is failing on this PR — verified the same failure exists on main (last 5 main runs all FAIL coverage). Pre-existing condition, not introduced here. Separate PR will address the threshold gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected list-item open/close behavior so parent items remain open until their nested items and any continuation content finish; fixed ordering for multi-level closure and hard breaks in continuation paragraphs.

* **Tests**
  * Added and updated unit tests covering nested lists, continuations, hard breaks, and three-level closure sequencing.

* **Documentation**
  * Clarified list-item nesting, level semantics, ordered-list start handling, and well-formedness rules in the events spec.

* **Chores**
  * Updated test fixtures and markdown examples to cover new cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/61?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->