### PR TITLE
Readability refactors across crates

### DIFF
--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -145,6 +145,39 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         Ok(())
     }
 
+    /// Resolves `asset_id` through the configured provider and encodes the asset bytes
+    /// as a `data:<content-type>;base64,…` URI.
+    ///
+    /// Returns `Err` if no `AssetProvider` is configured, the asset cannot be found,
+    /// or the underlying I/O fails while streaming the asset bytes through the
+    /// base64 encoder.
+    fn encode_asset_as_data_uri(&self, asset_id: &str) -> Result<String> {
+        let provider = self.assets.ok_or_else(|| Error::Other {
+            message: "no AssetProvider configured".to_string(),
+        })?;
+        let content_type = provider
+            .content_type(asset_id)
+            .ok_or_else(|| Error::Other {
+                message: format!("asset not found: {asset_id}"),
+            })?;
+        let prefix = format!("data:{content_type};base64,");
+        let mut data_uri = Vec::with_capacity(prefix.len());
+        data_uri.extend_from_slice(prefix.as_bytes());
+        {
+            let mut enc = Base64Encoder::new(&mut data_uri, &BASE64_STANDARD);
+            provider
+                .stream_to(asset_id, &mut enc)
+                .ok_or_else(|| Error::Other {
+                    message: format!("asset not found: {asset_id}"),
+                })?
+                .map_err(io_err)?;
+            enc.finish().map_err(io_err)?
+        };
+        String::from_utf8(data_uri).map_err(|e| Error::Other {
+            message: format!("base64 encoding produced invalid UTF-8: {e}"),
+        })
+    }
+
     fn handle_blockquote(&mut self, id: Option<&String>) -> Result<()> {
         self.json.open_object()?;
         self.json.key("type").value("quote")?;
@@ -225,33 +258,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         self.close_for_block_sibling()?;
         let url = match source {
             ImageSource::Uri { uri } => uri,
-            ImageSource::Asset { asset_id } => {
-                let provider = self.assets.ok_or_else(|| Error::Other {
-                    message: "no AssetProvider configured".to_string(),
-                })?;
-                let content_type =
-                    provider
-                        .content_type(&asset_id)
-                        .ok_or_else(|| Error::Other {
-                            message: format!("asset not found: {asset_id}"),
-                        })?;
-                let prefix = format!("data:{content_type};base64,");
-                let mut data_uri = Vec::with_capacity(prefix.len());
-                data_uri.extend_from_slice(prefix.as_bytes());
-                {
-                    let mut enc = Base64Encoder::new(&mut data_uri, &BASE64_STANDARD);
-                    provider
-                        .stream_to(&asset_id, &mut enc)
-                        .ok_or_else(|| Error::Other {
-                            message: format!("asset not found: {asset_id}"),
-                        })?
-                        .map_err(io_err)?;
-                    enc.finish().map_err(io_err)?
-                };
-                String::from_utf8(data_uri).map_err(|e| Error::Other {
-                    message: format!("base64 encoding produced invalid UTF-8: {e}"),
-                })?
-            }
+            ImageSource::Asset { asset_id } => self.encode_asset_as_data_uri(&asset_id)?,
         };
         let caption = alt.unwrap_or_default();
 

--- a/crates/docspec-core/src/stack.rs
+++ b/crates/docspec-core/src/stack.rs
@@ -72,6 +72,121 @@ pub struct StackTrackingSink<S: EventSink> {
 }
 
 impl<S: EventSink> StackTrackingSink<S> {
+    /// Handles an `EndDocument` event: drains all remaining open blocks in reverse order,
+    /// emits their close events, sets `document_finished`, then forwards `EndDocument`.
+    fn handle_end_document(&mut self) -> Result<()> {
+        if !self.stack.contains(&BlockKind::Document) {
+            return Err(Error::InvalidSequence {
+                expected: "open Document".to_string(),
+                found: "EndDocument".to_string(),
+                message: "EndDocument received without StartDocument".to_string(),
+            });
+        }
+        while let Some(kind) = self.stack.pop() {
+            if kind != BlockKind::Document {
+                self.sink.handle_event(end_event_for(kind))?;
+            }
+        }
+        self.document_finished = true;
+        self.sink.handle_event(Event::EndDocument)
+    }
+
+    /// Handles any intermediate End event (not `EndDocument`): validates the stack,
+    /// auto-closes intervening blocks, pops the target frame, and forwards the event.
+    fn handle_end_event(&mut self, event: Event) -> Result<()> {
+        let Some(target_kind) = block_kind_for_end(&event) else {
+            return Err(Error::InvalidSequence {
+                expected: "valid End event".to_string(),
+                found: format!("{event:?}"),
+                message: "handle_end_event called with non-End event".to_string(),
+            });
+        };
+        if self.stack.is_empty() {
+            return Err(Error::InvalidSequence {
+                expected: "open block".to_string(),
+                found: format!("{target_kind:?}"),
+                message: "received End event with empty stack".to_string(),
+            });
+        }
+        if self.stack.contains(&target_kind) {
+            while self.stack.last() != Some(&target_kind) {
+                if let Some(popped_kind) = self.stack.pop() {
+                    self.sink.handle_event(end_event_for(popped_kind))?;
+                }
+            }
+            self.stack.pop();
+            return self.sink.handle_event(event);
+        }
+        Err(Error::InvalidSequence {
+            expected: self
+                .stack
+                .last()
+                .map_or("empty".to_string(), |k| format!("{k:?}")),
+            found: format!("{target_kind:?}"),
+            message: format!("End event for {target_kind:?} does not match any open block"),
+        })
+    }
+
+    /// Handles `ThematicBreak` and `Text` events (all non-block, non-End events).
+    ///
+    /// `ThematicBreak`: auto-closes an open `Paragraph` if present.
+    /// `Text`: auto-inserts a `StartParagraph` when no content-bearing block is open.
+    /// All other leaf events are forwarded directly.
+    fn handle_other_event(&mut self, event: Event) -> Result<()> {
+        if matches!(event, Event::ThematicBreak { .. })
+            && self.stack.last() == Some(&BlockKind::Paragraph)
+        {
+            self.stack.pop();
+            self.sink.handle_event(Event::EndParagraph)?;
+        }
+
+        if matches!(event, Event::Text { .. }) && !self.has_open_content() {
+            let para = Event::StartParagraph {
+                alignment: None,
+                id: None,
+            };
+            self.stack.push(BlockKind::Paragraph);
+            self.sink.handle_event(para)?;
+        }
+
+        self.sink.handle_event(event)
+    }
+
+    /// Handles any Start event: validates Document/Link nesting constraints,
+    /// auto-closes an open Paragraph when needed, pushes the new block, and forwards the event.
+    fn handle_start_event(&mut self, kind: BlockKind, event: Event) -> Result<()> {
+        if kind == BlockKind::Document {
+            if self.stack.contains(&BlockKind::Document) {
+                return Err(Error::InvalidSequence {
+                    expected: "single Document".to_string(),
+                    found: "StartDocument".to_string(),
+                    message: "StartDocument received while Document already open".to_string(),
+                });
+            }
+            if self.document_finished {
+                return Err(Error::InvalidSequence {
+                    expected: "end of stream".to_string(),
+                    found: "StartDocument".to_string(),
+                    message: "StartDocument received after document already finished".to_string(),
+                });
+            }
+        }
+        // Links cannot nest per EVENTS.md
+        if kind == BlockKind::Link && self.stack.contains(&BlockKind::Link) {
+            return Err(Error::InvalidSequence {
+                expected: "no nested links".to_string(),
+                found: "StartLink".to_string(),
+                message: "StartLink received while another link is already open".to_string(),
+            });
+        }
+        if kind != BlockKind::Link && self.stack.last() == Some(&BlockKind::Paragraph) {
+            self.stack.pop();
+            self.sink.handle_event(Event::EndParagraph)?;
+        }
+        self.stack.push(kind);
+        self.sink.handle_event(event)
+    }
+
     /// Returns `true` if the stack contains any content-bearing block.
     ///
     /// Content-bearing blocks are: [`BlockKind::Heading`], [`BlockKind::Paragraph`],
@@ -145,8 +260,8 @@ impl<S: EventSink> EventSink for StackTrackingSink<S> {
 
     #[inline]
     fn handle_event(&mut self, event: Event) -> Result<()> {
-        // Reject all events after document has finished (except we already handle StartDocument
-        // specially below for a clearer error message)
+        // Reject all events after document has finished (except StartDocument gets a
+        // clearer error message from handle_start_event)
         if self.document_finished && !matches!(event, Event::StartDocument { .. }) {
             return Err(Error::InvalidSequence {
                 expected: "end of stream".to_string(),
@@ -156,102 +271,18 @@ impl<S: EventSink> EventSink for StackTrackingSink<S> {
         }
 
         if let Some(kind) = block_kind_for_start(&event) {
-            if kind == BlockKind::Document {
-                if self.stack.contains(&BlockKind::Document) {
-                    return Err(Error::InvalidSequence {
-                        expected: "single Document".to_string(),
-                        found: "StartDocument".to_string(),
-                        message: "StartDocument received while Document already open".to_string(),
-                    });
-                }
-                if self.document_finished {
-                    return Err(Error::InvalidSequence {
-                        expected: "end of stream".to_string(),
-                        found: "StartDocument".to_string(),
-                        message: "StartDocument received after document already finished"
-                            .to_string(),
-                    });
-                }
-            }
-            // Links cannot nest per EVENTS.md
-            if kind == BlockKind::Link && self.stack.contains(&BlockKind::Link) {
-                return Err(Error::InvalidSequence {
-                    expected: "no nested links".to_string(),
-                    found: "StartLink".to_string(),
-                    message: "StartLink received while another link is already open".to_string(),
-                });
-            }
-            if kind != BlockKind::Link && self.stack.last() == Some(&BlockKind::Paragraph) {
-                self.stack.pop();
-                self.sink.handle_event(Event::EndParagraph)?;
-            }
-            self.stack.push(kind);
-            return self.sink.handle_event(event);
+            return self.handle_start_event(kind, event);
         }
 
         if matches!(event, Event::EndDocument) {
-            if !self.stack.contains(&BlockKind::Document) {
-                return Err(Error::InvalidSequence {
-                    expected: "open Document".to_string(),
-                    found: "EndDocument".to_string(),
-                    message: "EndDocument received without StartDocument".to_string(),
-                });
-            }
-            while let Some(kind) = self.stack.pop() {
-                if kind != BlockKind::Document {
-                    self.sink.handle_event(end_event_for(kind))?;
-                }
-            }
-            self.document_finished = true;
-            return self.sink.handle_event(event);
+            return self.handle_end_document();
         }
 
-        if let Some(target_kind) = block_kind_for_end(&event) {
-            if self.stack.is_empty() {
-                return Err(Error::InvalidSequence {
-                    expected: "open block".to_string(),
-                    found: format!("{target_kind:?}"),
-                    message: "received End event with empty stack".to_string(),
-                });
-            }
-
-            if self.stack.contains(&target_kind) {
-                while self.stack.last() != Some(&target_kind) {
-                    if let Some(popped_kind) = self.stack.pop() {
-                        self.sink.handle_event(end_event_for(popped_kind))?;
-                    }
-                }
-                self.stack.pop();
-                return self.sink.handle_event(event);
-            }
-
-            return Err(Error::InvalidSequence {
-                expected: self
-                    .stack
-                    .last()
-                    .map_or("empty".to_string(), |k| format!("{k:?}")),
-                found: format!("{target_kind:?}"),
-                message: format!("End event for {target_kind:?} does not match any open block"),
-            });
+        if block_kind_for_end(&event).is_some() {
+            return self.handle_end_event(event);
         }
 
-        if matches!(event, Event::ThematicBreak { .. })
-            && self.stack.last() == Some(&BlockKind::Paragraph)
-        {
-            self.stack.pop();
-            self.sink.handle_event(Event::EndParagraph)?;
-        }
-
-        if matches!(event, Event::Text { .. }) && !self.has_open_content() {
-            let para = Event::StartParagraph {
-                alignment: None,
-                id: None,
-            };
-            self.stack.push(BlockKind::Paragraph);
-            self.sink.handle_event(para)?;
-        }
-
-        self.sink.handle_event(event)
+        self.handle_other_event(event)
     }
 }
 
@@ -261,42 +292,46 @@ impl<S: EventSink> EventSink for StackTrackingSink<S> {
 #[inline]
 #[must_use]
 pub fn block_kind_for_start(event: &Event) -> Option<BlockKind> {
-    if let Event::StartBlockQuote { .. } = event {
-        Some(BlockKind::Blockquote)
-    } else if let Event::StartCaption { .. } = event {
-        Some(BlockKind::Caption)
-    } else if let Event::StartDefinitionDetail { .. } = event {
-        Some(BlockKind::DefinitionDetail)
-    } else if let Event::StartDefinitionList { .. } = event {
-        Some(BlockKind::DefinitionList)
-    } else if let Event::StartDefinitionTerm { .. } = event {
-        Some(BlockKind::DefinitionTerm)
-    } else if let Event::StartDocument { .. } = event {
-        Some(BlockKind::Document)
-    } else if let Event::StartFootnote { .. } = event {
-        Some(BlockKind::Footnote)
-    } else if let Event::StartHeading { .. } = event {
-        Some(BlockKind::Heading)
-    } else if let Event::StartLink { .. } = event {
-        Some(BlockKind::Link)
-    } else if let Event::StartOrderedListItem { .. } = event {
-        Some(BlockKind::OrderedListItem)
-    } else if let Event::StartUnorderedListItem { .. } = event {
-        Some(BlockKind::UnorderedListItem)
-    } else if let Event::StartParagraph { .. } = event {
-        Some(BlockKind::Paragraph)
-    } else if let Event::StartPreformatted { .. } = event {
-        Some(BlockKind::Preformatted)
-    } else if let Event::StartTable { .. } = event {
-        Some(BlockKind::Table)
-    } else if let Event::StartTableCell { .. } = event {
-        Some(BlockKind::TableCell)
-    } else if let Event::StartTableHeader { .. } = event {
-        Some(BlockKind::TableHeader)
-    } else if let Event::StartTableRow { .. } = event {
-        Some(BlockKind::TableRow)
-    } else {
-        None
+    match event {
+        Event::StartBlockQuote { .. } => Some(BlockKind::Blockquote),
+        Event::StartCaption { .. } => Some(BlockKind::Caption),
+        Event::StartDefinitionDetail { .. } => Some(BlockKind::DefinitionDetail),
+        Event::StartDefinitionList { .. } => Some(BlockKind::DefinitionList),
+        Event::StartDefinitionTerm { .. } => Some(BlockKind::DefinitionTerm),
+        Event::StartDocument { .. } => Some(BlockKind::Document),
+        Event::StartFootnote { .. } => Some(BlockKind::Footnote),
+        Event::StartHeading { .. } => Some(BlockKind::Heading),
+        Event::StartLink { .. } => Some(BlockKind::Link),
+        Event::StartOrderedListItem { .. } => Some(BlockKind::OrderedListItem),
+        Event::StartParagraph { .. } => Some(BlockKind::Paragraph),
+        Event::StartPreformatted { .. } => Some(BlockKind::Preformatted),
+        Event::StartTable { .. } => Some(BlockKind::Table),
+        Event::StartTableCell { .. } => Some(BlockKind::TableCell),
+        Event::StartTableHeader { .. } => Some(BlockKind::TableHeader),
+        Event::StartTableRow { .. } => Some(BlockKind::TableRow),
+        Event::StartUnorderedListItem { .. } => Some(BlockKind::UnorderedListItem),
+        Event::EndBlockQuote
+        | Event::EndCaption
+        | Event::EndDefinitionDetail
+        | Event::EndDefinitionList
+        | Event::EndDefinitionTerm
+        | Event::EndDocument
+        | Event::EndFootnote
+        | Event::EndHeading
+        | Event::EndLink
+        | Event::EndOrderedListItem
+        | Event::EndParagraph
+        | Event::EndPreformatted
+        | Event::EndTable
+        | Event::EndTableCell
+        | Event::EndTableHeader
+        | Event::EndTableRow
+        | Event::EndUnorderedListItem
+        | Event::FootnoteRef { .. }
+        | Event::Image { .. }
+        | Event::LineBreak
+        | Event::Text { .. }
+        | Event::ThematicBreak { .. } => None,
     }
 }
 
@@ -306,42 +341,46 @@ pub fn block_kind_for_start(event: &Event) -> Option<BlockKind> {
 #[inline]
 #[must_use]
 pub fn block_kind_for_end(event: &Event) -> Option<BlockKind> {
-    if let Event::EndBlockQuote = event {
-        Some(BlockKind::Blockquote)
-    } else if let Event::EndCaption = event {
-        Some(BlockKind::Caption)
-    } else if let Event::EndDefinitionDetail = event {
-        Some(BlockKind::DefinitionDetail)
-    } else if let Event::EndDefinitionList = event {
-        Some(BlockKind::DefinitionList)
-    } else if let Event::EndDefinitionTerm = event {
-        Some(BlockKind::DefinitionTerm)
-    } else if let Event::EndDocument = event {
-        Some(BlockKind::Document)
-    } else if let Event::EndFootnote = event {
-        Some(BlockKind::Footnote)
-    } else if let Event::EndHeading = event {
-        Some(BlockKind::Heading)
-    } else if let Event::EndLink = event {
-        Some(BlockKind::Link)
-    } else if let Event::EndOrderedListItem = event {
-        Some(BlockKind::OrderedListItem)
-    } else if let Event::EndUnorderedListItem = event {
-        Some(BlockKind::UnorderedListItem)
-    } else if let Event::EndParagraph = event {
-        Some(BlockKind::Paragraph)
-    } else if let Event::EndPreformatted = event {
-        Some(BlockKind::Preformatted)
-    } else if let Event::EndTable = event {
-        Some(BlockKind::Table)
-    } else if let Event::EndTableCell = event {
-        Some(BlockKind::TableCell)
-    } else if let Event::EndTableHeader = event {
-        Some(BlockKind::TableHeader)
-    } else if let Event::EndTableRow = event {
-        Some(BlockKind::TableRow)
-    } else {
-        None
+    match event {
+        Event::EndBlockQuote => Some(BlockKind::Blockquote),
+        Event::EndCaption => Some(BlockKind::Caption),
+        Event::EndDefinitionDetail => Some(BlockKind::DefinitionDetail),
+        Event::EndDefinitionList => Some(BlockKind::DefinitionList),
+        Event::EndDefinitionTerm => Some(BlockKind::DefinitionTerm),
+        Event::EndDocument => Some(BlockKind::Document),
+        Event::EndFootnote => Some(BlockKind::Footnote),
+        Event::EndHeading => Some(BlockKind::Heading),
+        Event::EndLink => Some(BlockKind::Link),
+        Event::EndOrderedListItem => Some(BlockKind::OrderedListItem),
+        Event::EndParagraph => Some(BlockKind::Paragraph),
+        Event::EndPreformatted => Some(BlockKind::Preformatted),
+        Event::EndTable => Some(BlockKind::Table),
+        Event::EndTableCell => Some(BlockKind::TableCell),
+        Event::EndTableHeader => Some(BlockKind::TableHeader),
+        Event::EndTableRow => Some(BlockKind::TableRow),
+        Event::EndUnorderedListItem => Some(BlockKind::UnorderedListItem),
+        Event::FootnoteRef { .. }
+        | Event::Image { .. }
+        | Event::LineBreak
+        | Event::StartBlockQuote { .. }
+        | Event::StartCaption { .. }
+        | Event::StartDefinitionDetail { .. }
+        | Event::StartDefinitionList { .. }
+        | Event::StartDefinitionTerm { .. }
+        | Event::StartDocument { .. }
+        | Event::StartFootnote { .. }
+        | Event::StartHeading { .. }
+        | Event::StartLink { .. }
+        | Event::StartOrderedListItem { .. }
+        | Event::StartParagraph { .. }
+        | Event::StartPreformatted { .. }
+        | Event::StartTable { .. }
+        | Event::StartTableCell { .. }
+        | Event::StartTableHeader { .. }
+        | Event::StartTableRow { .. }
+        | Event::StartUnorderedListItem { .. }
+        | Event::Text { .. }
+        | Event::ThematicBreak { .. } => None,
     }
 }
 

--- a/crates/docspec-json/src/state.rs
+++ b/crates/docspec-json/src/state.rs
@@ -47,22 +47,12 @@ impl StateStack {
     pub fn expect_key_allowed(&self) -> Result<()> {
         match self.stack.last() {
             Some(Frame::Object(KeyState::ExpectingKey)) => Ok(()),
-            Some(Frame::Object(KeyState::ExpectingValue)) => Err(Error::Json {
-                message: "key not allowed: previous key has no value yet".to_string(),
-                position: None,
-            }),
-            Some(Frame::Array) => Err(Error::Json {
-                message: "key not allowed: inside an array".to_string(),
-                position: None,
-            }),
-            Some(Frame::Root) => Err(Error::Json {
-                message: "key not allowed: not inside an object".to_string(),
-                position: None,
-            }),
-            None => Err(Error::Json {
-                message: "key not allowed: no current frame".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(KeyState::ExpectingValue)) => Err(Self::json_err(
+                "key not allowed: previous key has no value yet",
+            )),
+            Some(Frame::Array) => Err(Self::json_err("key not allowed: inside an array")),
+            Some(Frame::Root) => Err(Self::json_err("key not allowed: not inside an object")),
+            None => Err(Self::json_err("key not allowed: no current frame")),
         }
     }
 
@@ -75,14 +65,10 @@ impl StateStack {
     pub fn expect_value_allowed(&self) -> Result<()> {
         match self.stack.last() {
             Some(Frame::Object(KeyState::ExpectingValue) | Frame::Array | Frame::Root) => Ok(()),
-            Some(Frame::Object(KeyState::ExpectingKey)) => Err(Error::Json {
-                message: "value not allowed: object expects a key first".to_string(),
-                position: None,
-            }),
-            None => Err(Error::Json {
-                message: "value not allowed: no current frame".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(KeyState::ExpectingKey)) => Err(Self::json_err(
+                "value not allowed: object expects a key first",
+            )),
+            None => Err(Self::json_err("value not allowed: no current frame")),
         }
     }
 
@@ -91,6 +77,18 @@ impl StateStack {
     #[must_use]
     pub fn is_finished(&self) -> bool {
         self.stack.is_empty()
+    }
+
+    /// Builds an `Error::Json` with `position: None`. Wrap in `Err(...)` at
+    /// match-arm sites or pass `|| Self::json_err(...)` to `ok_or_else`.
+    /// Centralises the `position: None` and `.to_string()` boilerplate so
+    /// validation methods stay focused on the message that distinguishes each case.
+    #[inline]
+    fn json_err(msg: &str) -> Error {
+        Error::Json {
+            message: msg.to_string(),
+            position: None,
+        }
     }
 
     /// Mark a key as written — transition Object from `ExpectingKey` to `ExpectingValue`.
@@ -105,14 +103,10 @@ impl StateStack {
                 *ks = KeyState::ExpectingValue;
                 Ok(())
             }
-            Some(Frame::Object(_)) => Err(Error::Json {
-                message: "key already written; expected a value next".to_string(),
-                position: None,
-            }),
-            _ => Err(Error::Json {
-                message: "cannot write key: not inside an object".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(_)) => {
+                Err(Self::json_err("key already written; expected a value next"))
+            }
+            _ => Err(Self::json_err("cannot write key: not inside an object")),
         }
     }
 
@@ -130,19 +124,15 @@ impl StateStack {
                 *ks = KeyState::ExpectingKey;
                 Ok(())
             }
-            Some(Frame::Object(_)) => Err(Error::Json {
-                message: "value without key: object expects a key".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(_)) => {
+                Err(Self::json_err("value without key: object expects a key"))
+            }
             Some(Frame::Array) => Ok(()),
             Some(Frame::Root) => {
                 self.stack.pop();
                 Ok(())
             }
-            None => Err(Error::Json {
-                message: "no current frame for value".to_string(),
-                position: None,
-            }),
+            None => Err(Self::json_err("no current frame for value")),
         }
     }
 
@@ -164,14 +154,10 @@ impl StateStack {
     pub fn peek_array(&self) -> Result<()> {
         match self.stack.last() {
             Some(Frame::Array) => Ok(()),
-            Some(Frame::Object(_)) => Err(Error::Json {
-                message: "cannot close array: current frame is an object".to_string(),
-                position: None,
-            }),
-            _ => Err(Error::Json {
-                message: "cannot close array: no open array".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(_)) => Err(Self::json_err(
+                "cannot close array: current frame is an object",
+            )),
+            _ => Err(Self::json_err("cannot close array: no open array")),
         }
     }
 
@@ -185,18 +171,13 @@ impl StateStack {
     pub fn peek_object(&self) -> Result<()> {
         match self.stack.last() {
             Some(Frame::Object(KeyState::ExpectingKey)) => Ok(()),
-            Some(Frame::Object(KeyState::ExpectingValue)) => Err(Error::Json {
-                message: "cannot close object: last key has no value".to_string(),
-                position: None,
-            }),
-            Some(Frame::Array) => Err(Error::Json {
-                message: "cannot close object: current frame is an array".to_string(),
-                position: None,
-            }),
-            _ => Err(Error::Json {
-                message: "cannot close object: no open object".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(KeyState::ExpectingValue)) => {
+                Err(Self::json_err("cannot close object: last key has no value"))
+            }
+            Some(Frame::Array) => Err(Self::json_err(
+                "cannot close object: current frame is an array",
+            )),
+            _ => Err(Self::json_err("cannot close object: no open object")),
         }
     }
 
@@ -207,10 +188,9 @@ impl StateStack {
     /// Returns `Err` if there is no open container to close.
     #[inline]
     pub fn pop(&mut self) -> Result<Frame> {
-        self.stack.pop().ok_or_else(|| Error::Json {
-            message: "cannot close: no open container".to_string(),
-            position: None,
-        })
+        self.stack
+            .pop()
+            .ok_or_else(|| Self::json_err("cannot close: no open container"))
     }
 
     /// Pop the top frame, asserting it is an Array. Returns `Err` if it is not.
@@ -225,14 +205,10 @@ impl StateStack {
                 self.stack.pop();
                 Ok(())
             }
-            Some(Frame::Object(_)) => Err(Error::Json {
-                message: "cannot close array: current frame is an object".to_string(),
-                position: None,
-            }),
-            _ => Err(Error::Json {
-                message: "cannot close array: no open array".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(_)) => Err(Self::json_err(
+                "cannot close array: current frame is an object",
+            )),
+            _ => Err(Self::json_err("cannot close array: no open array")),
         }
     }
 
@@ -248,18 +224,13 @@ impl StateStack {
                 self.stack.pop();
                 Ok(())
             }
-            Some(Frame::Object(KeyState::ExpectingValue)) => Err(Error::Json {
-                message: "cannot close object: last key has no value".to_string(),
-                position: None,
-            }),
-            Some(Frame::Array) => Err(Error::Json {
-                message: "cannot close object: current frame is an array".to_string(),
-                position: None,
-            }),
-            _ => Err(Error::Json {
-                message: "cannot close object: no open object".to_string(),
-                position: None,
-            }),
+            Some(Frame::Object(KeyState::ExpectingValue)) => {
+                Err(Self::json_err("cannot close object: last key has no value"))
+            }
+            Some(Frame::Array) => Err(Self::json_err(
+                "cannot close object: current frame is an array",
+            )),
+            _ => Err(Self::json_err("cannot close object: no open object")),
         }
     }
 

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -59,7 +59,7 @@ use alloc::collections::VecDeque;
 
 pub use docspec_core::EventSource;
 use docspec_core::{Event, ImageSource, ListStyleType, Result, TableHeaderScope, TextStyle};
-use pulldown_cmark::{CodeBlockKind, HeadingLevel, Options, Parser, Tag, TagEnd};
+use pulldown_cmark::{CodeBlockKind, CowStr, HeadingLevel, Options, Parser, Tag, TagEnd};
 
 /// Whether content is inside a block-level element.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -194,64 +194,137 @@ impl<'a> MarkdownReader<'a> {
         }
     }
 
+    /// Emits `EndBlockQuote` for a blockquote closing tag.
+    fn handle_end_blockquote(&mut self) {
+        self.push_event_end(Event::EndBlockQuote);
+    }
+
+    /// Emits the buffered code block content (stripping the parser-added trailing newline)
+    /// followed by `EndPreformatted`. Skips the text event if the buffer is empty.
+    fn handle_end_code_block(&mut self) {
+        if let Some(buf) = self.code_block_buffer.take() {
+            let content = buf.strip_suffix('\n').unwrap_or(&buf).to_owned();
+            if !content.is_empty() {
+                self.queue.push_back(Event::Text {
+                    content,
+                    style: TextStyle::default().code(),
+                });
+            }
+        }
+        self.push_event_end(Event::EndPreformatted);
+    }
+
+    /// Decrements italic depth for an emphasis (italic) closing tag.
+    fn handle_end_emphasis(&mut self) {
+        self.italic_depth = self.italic_depth.saturating_sub(1);
+    }
+
+    /// Emits `EndHeading` for a heading closing tag.
+    fn handle_end_heading(&mut self) {
+        self.push_event_end(Event::EndHeading);
+    }
+
+    /// Emits an `Image` event from the accumulated image buffer, deriving
+    /// `decorative = true` when the trimmed alt text is empty. Consumes the
+    /// in-progress image state; does nothing if no image is in progress.
+    fn handle_end_image(&mut self) {
+        let Some(img) = self.image.take() else { return };
+        let trimmed = img.alt_buf.trim();
+        let alt = if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_owned())
+        };
+        let decorative = alt.is_none();
+        self.queue.push_back(Event::Image {
+            source: ImageSource::Uri { uri: img.url },
+            alt,
+            title: img.title,
+            decorative,
+            id: None,
+        });
+    }
+
+    /// Closes an auto-opened paragraph if one is open, then closes the current
+    /// list item and resets block state.
+    fn handle_end_item(&mut self) {
+        if self.block_state == BlockState::AutoParagraph {
+            self.queue.push_back(Event::EndParagraph);
+        }
+        self.close_current_item_if_open();
+        self.block_state = BlockState::None;
+    }
+
+    /// Closes the current list item if open, pops the list context, and resets block state.
+    fn handle_end_list(&mut self) {
+        self.close_current_item_if_open();
+        self.list_stack.pop();
+        self.block_state = BlockState::None;
+    }
+
+    /// Emits `EndParagraph` for a paragraph closing tag.
+    fn handle_end_paragraph(&mut self) {
+        self.push_event_end(Event::EndParagraph);
+    }
+
+    /// Decrements strikethrough depth for a strikethrough closing tag.
+    fn handle_end_strikethrough(&mut self) {
+        self.strikethrough_depth = self.strikethrough_depth.saturating_sub(1);
+    }
+
+    /// Decrements bold depth for a strong (bold) closing tag.
+    fn handle_end_strong(&mut self) {
+        self.bold_depth = self.bold_depth.saturating_sub(1);
+    }
+
+    /// Emits `EndTable` for a table closing tag.
+    fn handle_end_table(&mut self) {
+        self.push_event_end(Event::EndTable);
+    }
+
+    /// Emits `EndTableCell` or `EndTableHeader` depending on whether the parser
+    /// is currently inside a table header row.
+    fn handle_end_table_cell(&mut self) {
+        if self.in_table_head {
+            self.push_event_end(Event::EndTableHeader);
+        } else {
+            self.push_event_end(Event::EndTableCell);
+        }
+    }
+
+    /// Emits `EndTableRow` and clears the table-head flag for a table head closing tag.
+    fn handle_end_table_head(&mut self) {
+        self.push_event_end(Event::EndTableRow);
+        self.in_table_head = false;
+    }
+
+    /// Emits `EndTableRow` for a table row closing tag.
+    fn handle_end_table_row(&mut self) {
+        self.push_event_end(Event::EndTableRow);
+    }
+
+    /// Dispatches a `pulldown-cmark` end tag to the appropriate per-tag handler.
+    ///
+    /// Tags in the explicit ignore list below are known-unsupported elements whose
+    /// structure is intentionally dropped (text content may still be extracted by
+    /// other event handlers).
     fn handle_end_tag(&mut self, tag_end: TagEnd) {
         match tag_end {
-            TagEnd::Heading(_) => self.push_event_end(Event::EndHeading),
-            TagEnd::Paragraph => self.push_event_end(Event::EndParagraph),
-            TagEnd::BlockQuote(_) => self.push_event_end(Event::EndBlockQuote),
-            TagEnd::Item => {
-                if self.block_state == BlockState::AutoParagraph {
-                    self.queue.push_back(Event::EndParagraph);
-                }
-                self.close_current_item_if_open();
-                self.block_state = BlockState::None;
-            }
-            TagEnd::Emphasis => {
-                self.italic_depth = self.italic_depth.saturating_sub(1);
-            }
-            TagEnd::Strong => {
-                self.bold_depth = self.bold_depth.saturating_sub(1);
-            }
-            TagEnd::Strikethrough => {
-                self.strikethrough_depth = self.strikethrough_depth.saturating_sub(1);
-            }
-            TagEnd::Image => {
-                if let Some(img) = self.image.take() {
-                    let alt = {
-                        let trimmed = img.alt_buf.trim();
-                        if trimmed.is_empty() {
-                            None
-                        } else {
-                            Some(trimmed.to_owned())
-                        }
-                    };
-                    let decorative = alt.is_none();
-                    self.queue.push_back(Event::Image {
-                        source: ImageSource::Uri { uri: img.url },
-                        alt,
-                        title: img.title,
-                        decorative,
-                        id: None,
-                    });
-                }
-            }
-            TagEnd::CodeBlock => {
-                if let Some(buf) = self.code_block_buffer.take() {
-                    let content = buf.strip_suffix('\n').unwrap_or(&buf).to_owned();
-                    if !content.is_empty() {
-                        self.queue.push_back(Event::Text {
-                            content,
-                            style: TextStyle::default().code(),
-                        });
-                    }
-                }
-                self.push_event_end(Event::EndPreformatted);
-            }
-            TagEnd::List(_) => {
-                self.close_current_item_if_open();
-                self.list_stack.pop();
-                self.block_state = BlockState::None;
-            }
+            TagEnd::BlockQuote(_) => self.handle_end_blockquote(),
+            TagEnd::CodeBlock => self.handle_end_code_block(),
+            TagEnd::Emphasis => self.handle_end_emphasis(),
+            TagEnd::Heading(_) => self.handle_end_heading(),
+            TagEnd::Image => self.handle_end_image(),
+            TagEnd::Item => self.handle_end_item(),
+            TagEnd::List(_) => self.handle_end_list(),
+            TagEnd::Paragraph => self.handle_end_paragraph(),
+            TagEnd::Strikethrough => self.handle_end_strikethrough(),
+            TagEnd::Strong => self.handle_end_strong(),
+            TagEnd::Table => self.handle_end_table(),
+            TagEnd::TableCell => self.handle_end_table_cell(),
+            TagEnd::TableHead => self.handle_end_table_head(),
+            TagEnd::TableRow => self.handle_end_table_row(),
+            // Tags intentionally ignored (structure dropped, text extracted elsewhere):
             TagEnd::DefinitionList
             | TagEnd::DefinitionListDefinition
             | TagEnd::DefinitionListTitle
@@ -261,19 +334,6 @@ impl<'a> MarkdownReader<'a> {
             | TagEnd::MetadataBlock(_)
             | TagEnd::Subscript
             | TagEnd::Superscript => {}
-            TagEnd::Table => self.push_event_end(Event::EndTable),
-            TagEnd::TableHead => {
-                self.push_event_end(Event::EndTableRow);
-                self.in_table_head = false;
-            }
-            TagEnd::TableRow => self.push_event_end(Event::EndTableRow),
-            TagEnd::TableCell => {
-                if self.in_table_head {
-                    self.push_event_end(Event::EndTableHeader);
-                } else {
-                    self.push_event_end(Event::EndTableCell);
-                }
-            }
         }
     }
 
@@ -308,60 +368,136 @@ impl<'a> MarkdownReader<'a> {
         });
     }
 
+    /// Emits `StartBlockQuote` for a blockquote opening tag.
+    fn handle_start_blockquote(&mut self) {
+        self.push_event_start(Event::StartBlockQuote { id: None });
+    }
+
+    /// Emits `StartPreformatted` for a code block opening tag, initialising
+    /// the internal code-block buffer for content accumulation.
+    fn handle_start_code_block(&mut self, kind: CodeBlockKind<'a>) {
+        let syntax = match kind {
+            CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.into_string()),
+            CodeBlockKind::Fenced(_) | CodeBlockKind::Indented => None,
+        };
+        self.code_block_buffer = Some(String::new());
+        self.push_event_start(Event::StartPreformatted { id: None, syntax });
+    }
+
+    /// Increments italic depth for an emphasis (italic) opening tag.
+    fn handle_start_emphasis(&mut self) {
+        self.italic_depth = self.italic_depth.saturating_add(1);
+    }
+
+    /// Emits `StartHeading` after mapping a `pulldown-cmark` `HeadingLevel` to a `u8` level.
+    fn handle_start_heading(&mut self, level: HeadingLevel) {
+        let level_u8 = match level {
+            HeadingLevel::H1 => 1,
+            HeadingLevel::H2 => 2,
+            HeadingLevel::H3 => 3,
+            HeadingLevel::H4 => 4,
+            HeadingLevel::H5 => 5,
+            HeadingLevel::H6 => 6,
+        };
+        self.push_event_start(Event::StartHeading {
+            level: level_u8,
+            id: None,
+        });
+    }
+
+    /// Initialises image state for alt-text accumulation when an image opening tag is
+    /// encountered. The title is stored as `None` when the pulldown-cmark title string
+    /// is empty.
+    fn handle_start_image(&mut self, dest_url: CowStr<'a>, title: CowStr<'a>) {
+        self.image = Some(ImageBuffer {
+            alt_buf: String::new(),
+            title: if title.is_empty() {
+                None
+            } else {
+                Some(title.into_string())
+            },
+            url: dest_url.into_string(),
+        });
+    }
+
+    /// Emits `StartParagraph` for a paragraph opening tag.
+    fn handle_start_paragraph(&mut self) {
+        self.push_event_start(Event::StartParagraph {
+            alignment: None,
+            id: None,
+        });
+    }
+
+    /// Increments strikethrough depth for a strikethrough opening tag.
+    fn handle_start_strikethrough(&mut self) {
+        self.strikethrough_depth = self.strikethrough_depth.saturating_add(1);
+    }
+
+    /// Increments bold depth for a strong (bold) opening tag.
+    fn handle_start_strong(&mut self) {
+        self.bold_depth = self.bold_depth.saturating_add(1);
+    }
+
+    /// Emits `StartTable` for a table opening tag.
+    fn handle_start_table(&mut self) {
+        self.push_event_start(Event::StartTable { id: None });
+    }
+
+    /// Emits `StartTableHeader` or `StartTableCell` depending on whether the parser
+    /// is currently inside a table header row.
+    fn handle_start_table_cell(&mut self) {
+        if self.in_table_head {
+            self.push_event_start(Event::StartTableHeader {
+                scope: Some(TableHeaderScope::Column),
+                abbr: None,
+                colspan: None,
+                rowspan: None,
+                id: None,
+            });
+        } else {
+            self.push_event_start(Event::StartTableCell {
+                colspan: None,
+                rowspan: None,
+                id: None,
+            });
+        }
+    }
+
+    /// Sets the table-head flag and emits `StartTableRow` for a table head opening tag.
+    fn handle_start_table_head(&mut self) {
+        self.in_table_head = true;
+        self.push_event_start(Event::StartTableRow { id: None });
+    }
+
+    /// Emits `StartTableRow` for a table row opening tag.
+    fn handle_start_table_row(&mut self) {
+        self.push_event_start(Event::StartTableRow { id: None });
+    }
+
+    /// Dispatches a `pulldown-cmark` start tag to the appropriate per-tag handler.
+    ///
+    /// Tags in the explicit ignore list below are known-unsupported elements whose
+    /// structure is intentionally dropped (text content may still be extracted by
+    /// other event handlers).
     fn handle_start_tag(&mut self, tag: Tag<'a>) {
         match tag {
-            Tag::Heading { level, .. } => {
-                let level_u8 = match level {
-                    HeadingLevel::H1 => 1,
-                    HeadingLevel::H2 => 2,
-                    HeadingLevel::H3 => 3,
-                    HeadingLevel::H4 => 4,
-                    HeadingLevel::H5 => 5,
-                    HeadingLevel::H6 => 6,
-                };
-
-                self.push_event_start(Event::StartHeading {
-                    level: level_u8,
-                    id: None,
-                });
-            }
-            Tag::Paragraph => self.push_event_start(Event::StartParagraph {
-                alignment: None,
-                id: None,
-            }),
-            Tag::BlockQuote(_) => self.push_event_start(Event::StartBlockQuote { id: None }),
-            Tag::CodeBlock(kind) => {
-                let syntax = match kind {
-                    CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.into_string()),
-                    CodeBlockKind::Fenced(_) | CodeBlockKind::Indented => None,
-                };
-                self.code_block_buffer = Some(String::new());
-                self.push_event_start(Event::StartPreformatted { id: None, syntax });
-            }
-            Tag::Emphasis => {
-                self.italic_depth = self.italic_depth.saturating_add(1);
-            }
-            Tag::Strong => {
-                self.bold_depth = self.bold_depth.saturating_add(1);
-            }
-            Tag::Strikethrough => {
-                self.strikethrough_depth = self.strikethrough_depth.saturating_add(1);
-            }
+            Tag::BlockQuote(_) => self.handle_start_blockquote(),
+            Tag::CodeBlock(kind) => self.handle_start_code_block(kind),
+            Tag::Emphasis => self.handle_start_emphasis(),
+            Tag::Heading { level, .. } => self.handle_start_heading(level),
             Tag::Image {
                 dest_url, title, ..
-            } => {
-                self.image = Some(ImageBuffer {
-                    alt_buf: String::new(),
-                    title: if title.is_empty() {
-                        None
-                    } else {
-                        Some(title.into_string())
-                    },
-                    url: dest_url.into_string(),
-                });
-            }
-            Tag::List(start_opt) => self.handle_list_start(start_opt),
+            } => self.handle_start_image(dest_url, title),
             Tag::Item => self.handle_item_start(),
+            Tag::List(start_opt) => self.handle_list_start(start_opt),
+            Tag::Paragraph => self.handle_start_paragraph(),
+            Tag::Strikethrough => self.handle_start_strikethrough(),
+            Tag::Strong => self.handle_start_strong(),
+            Tag::Table(_) => self.handle_start_table(),
+            Tag::TableCell => self.handle_start_table_cell(),
+            Tag::TableHead => self.handle_start_table_head(),
+            Tag::TableRow => self.handle_start_table_row(),
+            // Tags intentionally ignored (structure dropped, text extracted elsewhere):
             Tag::DefinitionList
             | Tag::DefinitionListDefinition
             | Tag::DefinitionListTitle
@@ -371,29 +507,6 @@ impl<'a> MarkdownReader<'a> {
             | Tag::MetadataBlock(_)
             | Tag::Subscript
             | Tag::Superscript => {}
-            Tag::Table(_) => self.push_event_start(Event::StartTable { id: None }),
-            Tag::TableHead => {
-                self.in_table_head = true;
-                self.push_event_start(Event::StartTableRow { id: None });
-            }
-            Tag::TableRow => self.push_event_start(Event::StartTableRow { id: None }),
-            Tag::TableCell => {
-                if self.in_table_head {
-                    self.push_event_start(Event::StartTableHeader {
-                        scope: Some(TableHeaderScope::Column),
-                        abbr: None,
-                        colspan: None,
-                        rowspan: None,
-                        id: None,
-                    });
-                } else {
-                    self.push_event_start(Event::StartTableCell {
-                        colspan: None,
-                        rowspan: None,
-                        id: None,
-                    });
-                }
-            }
         }
     }
 

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -1,8 +1,94 @@
 //! Unit tests for `MarkdownReader`.
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+mod helpers {
+    #![allow(clippy::single_call_fn)]
+
+    use docspec_core::{Event, ListStyleType};
+
+    /// Returns a `StartDocument` event with all optional fields set to `None`.
+    /// Use in tests that do not exercise document-level metadata.
+    pub fn start_document() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    /// Returns a `StartTable` event with no id.
+    pub fn start_table() -> Event {
+        Event::StartTable { id: None }
+    }
+
+    /// Returns a `StartTableRow` event with no id.
+    pub fn start_table_row() -> Event {
+        Event::StartTableRow { id: None }
+    }
+
+    /// Returns a `StartUnorderedListItem` event with `Disc` style at the given level and no id.
+    pub fn start_unordered_list_item(level: u32) -> Event {
+        Event::StartUnorderedListItem {
+            style_type: ListStyleType::Disc,
+            level,
+            id: None,
+        }
+    }
+
+    /// Maps a `DocSpec` event to a short type-name string for use in
+    /// document-structure assertions. Returns `"Other"` for any variant not
+    /// explicitly listed (including future variants added to `docspec_core::Event`).
+    pub fn event_type_name(e: &Event) -> &'static str {
+        match e {
+            Event::StartDocument { .. } => "StartDocument",
+            Event::EndDocument => "EndDocument",
+            Event::StartHeading { level: 1, .. } => "StartHeading(1)",
+            Event::StartHeading { level: 2, .. } => "StartHeading(2)",
+            Event::EndHeading => "EndHeading",
+            Event::StartParagraph { .. } => "StartParagraph",
+            Event::EndParagraph => "EndParagraph",
+            Event::Text { .. } => "Text",
+            Event::EndBlockQuote
+            | Event::EndCaption
+            | Event::EndDefinitionDetail
+            | Event::EndDefinitionList
+            | Event::EndDefinitionTerm
+            | Event::EndFootnote
+            | Event::EndLink
+            | Event::EndOrderedListItem
+            | Event::EndUnorderedListItem
+            | Event::EndPreformatted
+            | Event::EndTable
+            | Event::EndTableCell
+            | Event::EndTableHeader
+            | Event::EndTableRow
+            | Event::FootnoteRef { .. }
+            | Event::Image { .. }
+            | Event::LineBreak
+            | Event::StartBlockQuote { .. }
+            | Event::StartCaption { .. }
+            | Event::StartDefinitionDetail { .. }
+            | Event::StartDefinitionList { .. }
+            | Event::StartDefinitionTerm { .. }
+            | Event::StartFootnote { .. }
+            | Event::StartHeading { .. }
+            | Event::StartLink { .. }
+            | Event::StartOrderedListItem { .. }
+            | Event::StartUnorderedListItem { .. }
+            | Event::StartPreformatted { .. }
+            | Event::StartTable { .. }
+            | Event::StartTableCell { .. }
+            | Event::StartTableHeader { .. }
+            | Event::StartTableRow { .. }
+            | Event::ThematicBreak { .. }
+            | _ => "Other",
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::helpers;
     use docspec_core::{
         Event, EventSource as _, ImageSource, ListStyleType, TableHeaderScope, TextStyle,
     };
@@ -88,53 +174,7 @@ mod tests {
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        let event_types: Vec<&str> = events
-            .iter()
-            .map(|e| match e {
-                Event::StartDocument { .. } => "StartDocument",
-                Event::EndDocument => "EndDocument",
-                Event::StartHeading { level: 1, .. } => "StartHeading(1)",
-                Event::StartHeading { level: 2, .. } => "StartHeading(2)",
-                Event::EndHeading => "EndHeading",
-                Event::StartParagraph { .. } => "StartParagraph",
-                Event::EndParagraph => "EndParagraph",
-                Event::Text { .. } => "Text",
-                Event::EndBlockQuote
-                | Event::EndCaption
-                | Event::EndDefinitionDetail
-                | Event::EndDefinitionList
-                | Event::EndDefinitionTerm
-                | Event::EndFootnote
-                | Event::EndLink
-                | Event::EndOrderedListItem
-                | Event::EndUnorderedListItem
-                | Event::EndPreformatted
-                | Event::EndTable
-                | Event::EndTableCell
-                | Event::EndTableHeader
-                | Event::EndTableRow
-                | Event::FootnoteRef { .. }
-                | Event::Image { .. }
-                | Event::LineBreak
-                | Event::StartBlockQuote { .. }
-                | Event::StartCaption { .. }
-                | Event::StartDefinitionDetail { .. }
-                | Event::StartDefinitionList { .. }
-                | Event::StartDefinitionTerm { .. }
-                | Event::StartFootnote { .. }
-                | Event::StartHeading { .. }
-                | Event::StartLink { .. }
-                | Event::StartOrderedListItem { .. }
-                | Event::StartUnorderedListItem { .. }
-                | Event::StartPreformatted { .. }
-                | Event::StartTable { .. }
-                | Event::StartTableCell { .. }
-                | Event::StartTableHeader { .. }
-                | Event::StartTableRow { .. }
-                | Event::ThematicBreak { .. }
-                | _ => "Other",
-            })
-            .collect();
+        let event_types: Vec<&str> = events.iter().map(helpers::event_type_name).collect();
 
         assert_eq!(
             event_types,
@@ -161,14 +201,7 @@ mod tests {
         let events = collect_events(&mut reader);
 
         assert_eq!(events.len(), 2);
-        assert!(matches!(
-            events.first(),
-            Some(Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None
-            })
-        ));
+        assert_eq!(events.first(), Some(&helpers::start_document()));
         assert!(matches!(events.get(1), Some(Event::EndDocument)));
     }
 
@@ -185,14 +218,7 @@ mod tests {
         let mut reader = MarkdownReader::new("# Hello");
         let events = collect_events(&mut reader);
 
-        assert!(matches!(
-            events.first(),
-            Some(Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None
-            })
-        ));
+        assert_eq!(events.first(), Some(&helpers::start_document()));
         assert!(matches!(
             events.get(1),
             Some(Event::StartHeading { level: 1, .. })
@@ -800,23 +826,14 @@ mod tests {
         let mut reader = MarkdownReader::new(markdown);
         let events = collect_events(&mut reader);
 
-        assert!(matches!(
-            events.get(1),
-            Some(Event::StartTable { id: None })
-        ));
-        assert!(matches!(
-            events.get(2),
-            Some(Event::StartTableRow { id: None })
-        ));
+        assert_eq!(events.get(1), Some(&helpers::start_table()));
+        assert_eq!(events.get(2), Some(&helpers::start_table_row()));
         assert!(matches!(
             events.get(3),
             Some(Event::StartTableHeader { .. })
         ));
         assert!(matches!(events.get(9), Some(Event::EndTableRow)));
-        assert!(matches!(
-            events.get(10),
-            Some(Event::StartTableRow { id: None })
-        ));
+        assert_eq!(events.get(10), Some(&helpers::start_table_row()));
         assert!(matches!(events.get(18), Some(Event::EndTable)));
     }
 
@@ -852,10 +869,7 @@ mod tests {
             events.get(3),
             Some(Event::StartTableHeader { .. })
         ));
-        assert!(matches!(
-            events.get(7),
-            Some(Event::StartTableRow { id: None })
-        ));
+        assert_eq!(events.get(7), Some(&helpers::start_table_row()));
         assert!(matches!(events.get(8), Some(Event::StartTableCell { .. })));
     }
 
@@ -947,14 +961,7 @@ mod tests {
         let mut reader = MarkdownReader::new("- a\n- b\n- c");
         let events = collect_events(&mut reader);
 
-        assert!(matches!(
-            events.get(1),
-            Some(Event::StartUnorderedListItem {
-                style_type: ListStyleType::Disc,
-                level: 0,
-                id: None,
-            })
-        ));
+        assert_eq!(events.get(1), Some(&helpers::start_unordered_list_item(0)));
         assert!(matches!(events.get(2), Some(Event::Text { .. })));
         assert!(matches!(events.get(3), Some(Event::EndUnorderedListItem)));
         assert!(matches!(


### PR DESCRIPTION
## Summary

Zero new abstractions, zero API changes, zero macro additions, zero new dependencies. Pure readability improvements across four docspec crates.

Rebased onto `origin/main` after [#64](https://github.com/docspec/docspec/pull/64) (native BlockNote table emission) landed. The original blocknote-writer scope included three sub-refactors (T3 + T6 + T8a); during rebase, **T6** (per-event handler extraction) and **T8a** (test-helper module in `tests/writer.rs`) were dropped because #64's `close_text_block!` / `return_if_table_cell!` macros and table-aware dispatch made them either redundant or structurally incompatible. **T3** (`encode_asset_as_data_uri` extraction) was re-applied cleanly on top.

## Changes by crate

### `docspec-json` (T2)
- Extract `json_err(&str) -> Error` private associated fn on `StateStack`
- Replaces 21 inline `Error::Json { message: ..., position: None }` constructions in validation paths
- Error messages preserved byte-for-byte

### `docspec-markdown-reader` (T4 + T5 + T8b) — Refs #37
- **T4**: `handle_start_tag` (~88 LOC) split into 12 per-tag private handlers
- **T5**: `handle_end_tag` (~82 LOC) split into 14 per-tag private handlers
- **T8b**: `mod helpers` added in `tests/reader.rs` with `event_type_name` mapping fn and event constructors
- Explicit ignore lists preserved verbatim for `#[non_exhaustive]` forward-compat
- Per-field `None` counts in test fixtures reduced 43–50%

### `docspec-core` (T1 + T7) — Refs #13
- **T1**: `block_kind_for_start` / `block_kind_for_end` — 18-arm if-let chains converted to `match` expressions
- **T7**: `StackTrackingSink::handle_event` (109 LOC) split into four focused methods:
  - `handle_end_document` — `while let` stack drain + `document_finished` flag
  - `handle_end_event` — single-frame pop with mismatch detection
  - `handle_start_event` — Document/Link validation + auto-close Paragraph
  - `handle_other_event` — `ThematicBreak` + `Text` as separate `if` blocks

### `docspec-blocknote-writer` (T3) — Refs #12
- **T3**: `encode_asset_as_data_uri(&self, &str) -> Result<String>` private helper extracted from `handle_image`
- Reduces the `ImageSource::Asset` match arm to a single call
- Failure modes (no provider / asset not found / streaming I/O) documented at the helper
- T6 / T8a dropped during rebase — see Summary

## Verification

- 4 signed commits, one per crate, each Oracle-audited pre-rebase
- All workspace gates pass locally: `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace --all-features`
- Zero fixture changes (`tests/fixtures/**` byte-identical)
- Zero new dependencies, zero new `pub` items, zero `unsafe`, zero `#[allow]`, zero `unwrap`/`expect`
- Public API surface unchanged

## Review responses

The three Copilot inline doc nits from the first review pass were folded into their respective crate commits before rebase. Reply threads with the original fix SHAs remain on this PR for audit.
