### PR TITLE
feat(markdown-reader,blocknote-writer): emit and serialize inline links

### DIFF
--- a/crates/docspec-blocknote-writer/README.md
+++ b/crates/docspec-blocknote-writer/README.md
@@ -15,14 +15,15 @@ Converts a DocSpec event stream into [BlockNote](https://www.blocknotejs.org/) J
 | Thematic break | `divider` |
 | Unordered list item | `bulletListItem` |
 | Ordered list item | `numberedListItem` |
+| Inline link | `link` inline type with `href` (title is dropped) |
 
 Inline styles supported within text content: bold, italic, code, strikethrough, underline.
+Inline links (`StartLink`/`EndLink`) emit a `link` inline type with the `href`. The optional `title` field is dropped (BlockNote's default link schema has no title).
 
 List items support arbitrary nesting via BlockNote's native `children: Block[]` arrays. The `start` prop on `numberedListItem` is preserved when the first item in a sequence carries an explicit start number.
 
 ## Not Yet Supported
 
-- Links — `StartLink`/`EndLink` are silently ignored, so link metadata (`href`, `title`) is not emitted; `Text` events nested between them are still emitted as plain text in the surrounding inline content
 - Footnotes — `StartFootnote`/`EndFootnote`/`FootnoteRef` are silently ignored; BlockNote's default schema has no equivalent
 - Definition lists — `StartDefinitionList`/`StartDefinitionTerm`/`StartDefinitionDetail` (and their `End*` pairs) are silently ignored; BlockNote's default schema has no equivalent
 - Captions — `StartCaption`/`EndCaption` are silently ignored
@@ -94,6 +95,8 @@ let json = String::from_utf8(buf)?;
 **Non-paragraph children inside list items**: headings, images, code blocks, and blockquotes that appear as children of a list item are dropped. The first paragraph's inline content populates the item's `content[]` array; each subsequent paragraph becomes a child `paragraph` block in `children[]`.
 
 **Blockquote + list interaction**: a list item encountered while inside a blockquote force-closes the blockquote and emits the list item at the top level as a sibling.
+
+**Image-in-link**: BlockNote does not allow block-level images inside inline links. The reader closes the link before emitting the image as a sibling block, and the writer serialises that sequence directly. Content preceding the image stays inside the link; the image becomes a sibling block after the link closes; content following the image appears outside the link, losing its link wrapper. The link is empty only when the image is the sole link label, e.g. `[![alt](img.png)](url)`. All variants are lossy mappings of the original "image-inside-link" structure.
 
 ## API Documentation
 

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -153,15 +153,16 @@ use docspec_json::{JsonEmitter, Null, StrusonBackend};
 
 macro_rules! close_text_block {
     ($writer:expr) => {{
+        $writer.close_open_link_if_any()?;
         $writer.close_content_block()?;
-        $writer.in_text_block = false;
+        $writer.context.in_text_block = false;
         Ok(())
     }};
 }
 
 macro_rules! return_if_table_cell {
     ($writer:expr) => {
-        if $writer.in_table_cell {
+        if $writer.context.in_table_cell {
             return Ok(());
         }
     };
@@ -209,6 +210,13 @@ struct ListStackEntry {
     level: u32,
 }
 
+#[derive(Default)]
+struct BlockContext {
+    blockquote_has_content: bool,
+    in_table_cell: bool,
+    in_text_block: bool,
+}
+
 /// A streaming `BlockNote` JSON writer.
 ///
 /// Writes JSON tokens directly to the underlying `Write` as events arrive using `docspec-json`.
@@ -224,22 +232,25 @@ pub struct BlockNoteWriter<'a, W: Write> {
     assets: Option<&'a dyn AssetProvider>,
     blockquote_depth: u32,
     blockquote_force_closed_count: usize,
-    blockquote_has_content: bool,
+    context: BlockContext,
     drop_inside_list_depth: u32,
     dropped_list_depth: u32,
-    in_table_cell: bool,
-    in_text_block: bool,
+    /// Whether the writer is currently inside an open link inline container.
+    in_link: bool,
     json: JsonEmitter<StrusonBackend<W>>,
+    /// Whether at least one `StyledText` has been emitted into the current link's content array.
+    link_emitted_styled_text: bool,
     list_stack: Vec<ListStackEntry>,
     table_depth: u32,
 }
 
 impl<'a, W: Write> BlockNoteWriter<'a, W> {
     fn close_blockquote_for_sibling(&mut self) -> Result<()> {
+        self.close_open_link_if_any()?;
         self.close_content_block()?;
         self.blockquote_depth = self.blockquote_depth.saturating_sub(1);
         self.blockquote_force_closed_count = self.blockquote_force_closed_count.saturating_add(1);
-        self.in_text_block = self.blockquote_depth > 0;
+        self.context.in_text_block = self.blockquote_depth > 0;
         Ok(())
     }
 
@@ -253,6 +264,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         let popped_entry = self.list_stack.pop();
         if let Some(list_entry) = popped_entry {
             if list_entry.content_array_open {
+                self.close_open_link_if_any()?;
                 self.json.close_array()?;
             }
             if list_entry.children_array_open {
@@ -272,9 +284,22 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         if self.blockquote_depth > 0 {
             return self.close_blockquote_for_sibling();
         }
-        if self.in_text_block {
+        if self.context.in_text_block {
+            self.close_open_link_if_any()?;
             self.close_content_block()?;
-            self.in_text_block = false;
+            self.context.in_text_block = false;
+        }
+        Ok(())
+    }
+
+    /// Defensive: close any open inline link before closing a surrounding block.
+    ///
+    /// Under the canonical reader + `StackTrackingSink` contract this is a no-op,
+    /// but it hardens the writer against direct API misuse where a block may end
+    /// while a link is still open.
+    fn close_open_link_if_any(&mut self) -> Result<()> {
+        if self.in_link {
+            self.handle_end_link()?;
         }
         Ok(())
     }
@@ -325,8 +350,8 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         self.write_id(id)?;
         self.json.key("content").open_array()?;
         self.blockquote_depth = self.blockquote_depth.saturating_add(1);
-        self.blockquote_has_content = false;
-        self.in_text_block = true;
+        self.context.blockquote_has_content = false;
+        self.context.in_text_block = true;
         Ok(())
     }
 
@@ -338,6 +363,30 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             }
             Ok(())
         })
+    }
+
+    /// Closes the current inline link object.
+    ///
+    /// If no `StyledText` was emitted into the link's `content` array, inserts an empty
+    /// `StyledText` (`{"type":"text","text":"","styles":{}}`) to satisfy the `BlockNote`
+    /// schema (links must have at least one content item).
+    fn handle_end_link(&mut self) -> Result<()> {
+        if !self.in_link {
+            return Ok(());
+        }
+        if !self.link_emitted_styled_text {
+            self.json.open_object()?;
+            self.json.key("type").value("text")?;
+            self.json.key("text").value("")?;
+            self.json.key("styles").open_object()?;
+            self.json.close_object()?;
+            self.json.close_object()?;
+        }
+        self.json.close_array()?;
+        self.json.close_object()?;
+        self.in_link = false;
+        self.link_emitted_styled_text = false;
+        Ok(())
     }
 
     fn handle_end_list_item(&mut self) -> Result<()> {
@@ -360,12 +409,13 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
                 .list_stack
                 .last()
                 .is_some_and(|e| e.first_paragraph_consumed)
-            && self.in_text_block
+            && self.context.in_text_block
         {
+            self.close_open_link_if_any()?;
             self.json.close_array()?;
             self.json.key("children").array(|_| Ok(()))?;
             self.json.close_object()?;
-            self.in_text_block = false;
+            self.context.in_text_block = false;
             return Ok(());
         }
         if self.in_list_item_content() {
@@ -374,7 +424,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             }
             return Ok(());
         }
-        if self.blockquote_depth > 0 || !self.in_text_block || self.in_table_cell {
+        if self.blockquote_depth > 0 || !self.context.in_text_block || self.context.in_table_cell {
             return Ok(());
         }
         close_text_block!(self)
@@ -401,9 +451,10 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         if self.drop_inside_list_depth > 0 || self.table_depth > 1 {
             return Ok(());
         }
+        self.close_open_link_if_any()?;
         self.json.close_array()?;
         self.json.close_object()?;
-        self.in_table_cell = false;
+        self.context.in_table_cell = false;
         Ok(())
     }
 
@@ -424,7 +475,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             j.key("textAlignment").value("left")
         })?;
         self.json.key("content").open_array()?;
-        self.in_text_block = true;
+        self.context.in_text_block = true;
         Ok(())
     }
 
@@ -434,7 +485,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         alt: Option<String>,
         id: Option<&String>,
     ) -> Result<()> {
-        if self.in_table_cell || self.drop_inside_list_depth > 0 {
+        if self.context.in_table_cell || self.drop_inside_list_depth > 0 {
             return Ok(());
         }
         if self.in_any_list_item() {
@@ -465,7 +516,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         if self.drop_inside_list_depth > 0 {
             return Ok(());
         }
-        if (self.in_text_block || self.in_table_cell || self.in_list_item_content())
+        if (self.context.in_text_block || self.context.in_table_cell || self.in_list_item_content())
             && self.table_depth <= 1
         {
             self.handle_text("\n", &TextStyle::default())
@@ -476,7 +527,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
 
     fn handle_paragraph(&mut self, id: Option<&String>) -> Result<()> {
         // Inside a table cell, BlockNote's content type is InlineContent[] — block-level events are dropped.
-        if self.in_table_cell {
+        if self.context.in_table_cell {
             return Ok(());
         }
         // Paragraphs nested inside a dropped block must not mutate list state or emit JSON;
@@ -515,7 +566,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
                 .key("props")
                 .object(|j| j.key("textAlignment").value("left"))?;
             self.json.key("content").open_array()?;
-            self.in_text_block = true;
+            self.context.in_text_block = true;
             return Ok(());
         }
         if self.in_list_item_content() {
@@ -525,7 +576,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             self.close_open_list_items()?;
         }
         if self.blockquote_depth > 0 {
-            if self.blockquote_has_content {
+            if self.context.blockquote_has_content {
                 self.handle_text("\n\n", &TextStyle::default())?;
             }
             return Ok(());
@@ -537,7 +588,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             .key("props")
             .object(|j| j.key("textAlignment").value("left"))?;
         self.json.key("content").open_array()?;
-        self.in_text_block = true;
+        self.context.in_text_block = true;
         Ok(())
     }
 
@@ -551,7 +602,35 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
                 .object(|j| j.key("language").value(lang.as_str()))?;
         }
         self.json.key("content").open_array()?;
-        self.in_text_block = true;
+        self.context.in_text_block = true;
+        Ok(())
+    }
+
+    /// Opens a `BlockNote` inline link object and its `content` array.
+    ///
+    /// Drops `title` and `id` — `BlockNote`'s inline link schema has no slot for these.
+    fn handle_start_link(&mut self, href: &str) -> Result<()> {
+        if self.drop_inside_list_depth > 0
+            || self.dropped_list_depth > 0
+            || (!self.context.in_text_block
+                && !self.context.in_table_cell
+                && !self.in_list_item_content())
+            || self.table_depth > 1
+        {
+            return Ok(());
+        }
+        if self.in_link {
+            return Ok(());
+        }
+        if self.blockquote_depth > 0 {
+            self.context.blockquote_has_content = true;
+        }
+        self.json.open_object()?;
+        self.json.key("type").value("link")?;
+        self.json.key("href").value(href)?;
+        self.json.key("content").open_array()?;
+        self.in_link = true;
+        self.link_emitted_styled_text = false;
         Ok(())
     }
 
@@ -562,7 +641,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         level: u32,
         start: Option<u64>,
     ) -> Result<()> {
-        if self.in_table_cell || self.table_depth > 1 || self.drop_inside_list_depth > 0 {
+        if self.context.in_table_cell || self.table_depth > 1 || self.drop_inside_list_depth > 0 {
             self.dropped_list_depth = self.dropped_list_depth.saturating_add(1);
             return Ok(());
         }
@@ -633,7 +712,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         self.json.key("columnWidths").array(|_| Ok(()))?;
         self.json.key("rows").open_array()?;
         self.table_depth = 1;
-        self.in_text_block = false;
+        self.context.in_text_block = false;
         Ok(())
     }
 
@@ -659,21 +738,23 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             p.key("textAlignment").value("left")
         })?;
         self.json.key("content").open_array()?;
-        self.in_table_cell = true;
-        self.in_text_block = false;
+        self.context.in_table_cell = true;
+        self.context.in_text_block = false;
         Ok(())
     }
 
     fn handle_text(&mut self, content: &str, style: &TextStyle) -> Result<()> {
         if self.drop_inside_list_depth > 0
             || self.dropped_list_depth > 0
-            || (!self.in_text_block && !self.in_table_cell && !self.in_list_item_content())
+            || (!self.context.in_text_block
+                && !self.context.in_table_cell
+                && !self.in_list_item_content())
             || self.table_depth > 1
         {
             return Ok(());
         }
         if self.blockquote_depth > 0 {
-            self.blockquote_has_content = true;
+            self.context.blockquote_has_content = true;
         }
         self.json.object(|j| {
             j.key("type").value("text")?;
@@ -692,14 +773,18 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
                 }
                 Ok(())
             })
-        })
+        })?;
+        if self.in_link {
+            self.link_emitted_styled_text = true;
+        }
+        Ok(())
     }
 
     fn handle_text_event(&mut self, content: &str, style: &TextStyle) -> Result<()> {
         // Auto-open paragraph for orphan text (e.g., text after image closed paragraph)
-        if !self.in_text_block
+        if !self.context.in_text_block
             && self.blockquote_depth == 0
-            && !self.in_table_cell
+            && !self.context.in_table_cell
             && !self.in_list_item_content()
         {
             self.handle_paragraph(None)?;
@@ -736,12 +821,12 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             assets: None,
             blockquote_depth: 0,
             blockquote_force_closed_count: 0,
-            blockquote_has_content: false,
+            context: BlockContext::default(),
             drop_inside_list_depth: 0,
             dropped_list_depth: 0,
-            in_table_cell: false,
-            in_text_block: false,
+            in_link: false,
             json: JsonEmitter::new(StrusonBackend::new(writer)),
+            link_emitted_styled_text: false,
             list_stack: Vec::new(),
             table_depth: 0,
         }
@@ -830,12 +915,12 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             assets: Some(assets),
             blockquote_depth: 0,
             blockquote_force_closed_count: 0,
-            blockquote_has_content: false,
+            context: BlockContext::default(),
             drop_inside_list_depth: 0,
             dropped_list_depth: 0,
-            in_table_cell: false,
-            in_text_block: false,
+            in_link: false,
             json: JsonEmitter::new(StrusonBackend::new(writer)),
+            link_emitted_styled_text: false,
             list_stack: Vec::new(),
             table_depth: 0,
         }
@@ -873,7 +958,7 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             }
             Event::EndHeading => {
                 drop_block_in_list_end!(self);
-                if !self.in_text_block {
+                if !self.context.in_text_block {
                     return Ok(());
                 }
                 close_text_block!(self)
@@ -881,7 +966,7 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             Event::EndPreformatted => {
                 drop_block_in_list_end!(self);
                 return_if_table_cell!(self);
-                if !self.in_text_block {
+                if !self.context.in_text_block {
                     return Ok(());
                 }
                 close_text_block!(self)
@@ -902,9 +987,10 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
                         self.blockquote_force_closed_count.saturating_sub(1);
                     return Ok(());
                 }
+                self.close_open_link_if_any()?;
                 self.close_content_block()?;
                 self.blockquote_depth = self.blockquote_depth.saturating_sub(1);
-                self.in_text_block = self.blockquote_depth > 0;
+                self.context.in_text_block = self.blockquote_depth > 0;
                 Ok(())
             }
             Event::StartPreformatted { id, syntax, .. } => {
@@ -941,19 +1027,19 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
                 self.handle_table_cell(id.as_ref())
             }
             Event::EndTableCell | Event::EndTableHeader => self.handle_end_table_cell(),
+            Event::StartLink { href, .. } => self.handle_start_link(&href),
+            Event::EndLink => self.handle_end_link(),
             Event::EndCaption
             | Event::EndDefinitionDetail
             | Event::EndDefinitionList
             | Event::EndDefinitionTerm
             | Event::EndFootnote
-            | Event::EndLink
             | Event::FootnoteRef { .. }
             | Event::StartCaption { .. }
             | Event::StartDefinitionDetail { .. }
             | Event::StartDefinitionList { .. }
             | Event::StartDefinitionTerm { .. }
             | Event::StartFootnote { .. }
-            | Event::StartLink { .. }
             | _ => Ok(()),
         }
     }

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -133,6 +133,20 @@ mod tests {
         string_result.unwrap_or_default()
     }
 
+    fn run_direct_writer_events(events: &[Event]) -> String {
+        let mut buf = Vec::<u8>::new();
+        let mut writer = BlockNoteWriter::new(&mut buf);
+        for event in events {
+            let handle_result = writer.handle_event(event.clone());
+            assert!(handle_result.is_ok(), "handle_event failed");
+        }
+        let finish_result = writer.finish();
+        assert!(finish_result.is_ok(), "finish failed");
+        let string_result = String::from_utf8(buf);
+        assert!(string_result.is_ok(), "invalid UTF-8 output");
+        string_result.unwrap_or_default()
+    }
+
     #[test]
     fn empty_document() {
         let json = run_events(&[
@@ -4073,44 +4087,6 @@ mod tests {
     }
 
     #[test]
-    fn link_events_in_paragraph_are_silently_ignored_by_writer() {
-        // Drives the wildcard catch-all arm (StartLink / EndLink and related events).
-        // BlockNoteWriter has no link block type; these events are silently dropped
-        // while text inside the link is still emitted as inline content.
-        let json = run_events(&[
-            Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            },
-            Event::StartParagraph {
-                alignment: None,
-                id: None,
-            },
-            Event::StartLink {
-                id: None,
-                href: "https://example.com".to_string(),
-                title: None,
-            },
-            Event::Text {
-                content: "click".to_string(),
-                style: TextStyle::default(),
-            },
-            Event::EndLink,
-            Event::EndParagraph,
-            Event::EndDocument,
-        ]);
-        assert!(
-            json.contains("\"text\":\"click\""),
-            "text inside link must appear in output"
-        );
-        assert!(
-            !json.contains("link"),
-            "no link structure should be emitted"
-        );
-    }
-
-    #[test]
     fn end_heading_without_open_heading_is_noop() {
         // Drives EndHeading when in_text_block is false and drop_inside_list_depth
         // is zero — the !in_text_block guard returns Ok(()) silently.
@@ -4208,18 +4184,12 @@ mod tests {
             Event::EndDefinitionList,
             Event::EndDefinitionTerm,
             Event::EndFootnote,
-            Event::EndLink,
             Event::FootnoteRef { id: 1 },
             Event::StartCaption { id: None },
             Event::StartDefinitionDetail { id: None },
             Event::StartDefinitionList { id: None },
             Event::StartDefinitionTerm { id: None },
             Event::StartFootnote { id: 1 },
-            Event::StartLink {
-                id: None,
-                href: "https://example.com".to_string(),
-                title: None,
-            },
         ] {
             assert!(
                 writer.handle_event(event).is_ok(),
@@ -5047,7 +5017,6 @@ mod tests {
             Event::EndDefinitionList,
             Event::EndDefinitionTerm,
             Event::EndFootnote,
-            Event::EndLink,
             Event::FootnoteRef { id: 99 },
             Event::StartCaption {
                 id: Some("c".to_string()),
@@ -5056,11 +5025,6 @@ mod tests {
             Event::StartDefinitionList { id: None },
             Event::StartDefinitionTerm { id: None },
             Event::StartFootnote { id: 7 },
-            Event::StartLink {
-                id: None,
-                href: "https://x.com".to_string(),
-                title: Some("title".to_string()),
-            },
         ] {
             let mut buf = Vec::<u8>::new();
             let mut writer = BlockNoteWriter::new(&mut buf);
@@ -5681,6 +5645,497 @@ mod tests {
         assert!(
             json.contains(&expected_children),
             "continuation paragraph must be a sibling of the nested item inside the outer item's children[], not nested inside the nested item's children[]: {json}"
+        );
+    }
+
+    // ============================================================================
+    // LINK TESTS
+    // ============================================================================
+
+    #[test]
+    fn link_simple() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "text".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"link","href":"https://example.com","content":[{"type":"text","text":"text","styles":{}}]}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn nested_start_link_is_silently_ignored() {
+        let json = run_direct_writer_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://a.example".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://b.example".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "inner".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        let parsed_result: Result<serde_json::Value, _> = serde_json::from_str(&json);
+        assert!(parsed_result.is_ok(), "output must be valid JSON: {json}");
+        assert_eq!(json.matches(r#""type":"link""#).count(), 1);
+        assert!(json.contains(r#""href":"https://a.example""#));
+        assert!(!json.contains(r#""href":"https://b.example""#));
+        assert!(
+            json.contains(r#""content":[{"type":"link","href":"https://a.example","content":[{"type":"text","text":"inner","styles":{}}]}]"#),
+            "text must remain inside the outer link content: {json}"
+        );
+    }
+
+    #[test]
+    fn link_left_open_at_paragraph_end_is_defensively_closed() {
+        let json = run_direct_writer_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://x.example".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "label".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        let parsed_result: Result<serde_json::Value, _> = serde_json::from_str(&json);
+        assert!(parsed_result.is_ok(), "output must be valid JSON: {json}");
+        assert_eq!(json.matches(r#""type":"link""#).count(), 1);
+        assert!(json.contains(r#""href":"https://x.example""#));
+        assert!(
+            json.contains(r#"{"type":"text","text":"label","styles":{}}"#),
+            "link label text must be preserved: {json}"
+        );
+    }
+
+    #[test]
+    fn link_left_open_at_table_cell_end_is_defensively_closed() {
+        let json = run_direct_writer_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartTable { id: None },
+            Event::StartTableRow { id: None },
+            Event::StartTableCell {
+                id: None,
+                colspan: None,
+                rowspan: None,
+            },
+            Event::StartLink {
+                href: "https://cell.example".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "cell".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        let parsed_result: Result<serde_json::Value, _> = serde_json::from_str(&json);
+        assert!(parsed_result.is_ok(), "output must be valid JSON: {json}");
+        assert_eq!(json.matches(r#""type":"link""#).count(), 1);
+        assert!(json.contains(r#""href":"https://cell.example""#));
+        assert!(
+            json.contains(r#"{"type":"text","text":"cell","styles":{}}"#),
+            "table cell link text must be preserved: {json}"
+        );
+    }
+
+    #[test]
+    fn link_empty_content_emits_empty_styled_text() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"link","href":"https://example.com","content":[{"type":"text","text":"","styles":{}}]}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn link_drops_title_field() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: Some("a title".to_string()),
+                id: None,
+            },
+            Event::Text {
+                content: "text".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert!(
+            !json.contains(r#""title""#),
+            "title field must not appear in BlockNote link JSON, got: {json}"
+        );
+        assert!(
+            json.contains(r#""type":"link""#),
+            "link object must be present"
+        );
+        assert!(
+            json.contains(r#""href":"https://example.com""#),
+            "href must be present"
+        );
+    }
+
+    #[test]
+    fn link_with_styled_content_array() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "bold".to_string(),
+                style: TextStyle::default().bold(),
+            },
+            Event::Text {
+                content: "italic".to_string(),
+                style: TextStyle::default().italic(),
+            },
+            Event::Text {
+                content: "plain".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"link","href":"https://example.com","content":[{"type":"text","text":"bold","styles":{"bold":true}},{"type":"text","text":"italic","styles":{"italic":true}},{"type":"text","text":"plain","styles":{}}]}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn link_in_paragraph_alongside_other_text() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "before ".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "link".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::Text {
+                content: " after".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"before ","styles":{}},{"type":"link","href":"https://example.com","content":[{"type":"text","text":"link","styles":{}}]},{"type":"text","text":" after","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn link_in_heading() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartHeading { level: 1, id: None },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "title link".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndHeading,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"heading","props":{"level":1,"textAlignment":"left"},"content":[{"type":"link","href":"https://example.com","content":[{"type":"text","text":"title link","styles":{}}]}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn link_in_list_item() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "link".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains(r#""type":"bulletListItem""#));
+        assert!(json.contains(r#""type":"link""#));
+        assert!(json.contains(r#""href":"https://example.com""#));
+        assert!(
+            json.contains(r#"{"type":"text","text":"link","styles":{}}"#),
+            "link content must preserve styled text: {json}"
+        );
+    }
+
+    #[test]
+    fn link_in_blockquote() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartBlockQuote { id: None },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "link".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains(r#""type":"quote""#));
+        assert!(json.contains(r#""type":"link""#));
+        assert!(json.contains(r#""href":"https://example.com""#));
+    }
+
+    #[test]
+    fn empty_link_in_blockquote() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartBlockQuote { id: None },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains(r#""type":"quote""#));
+        assert!(
+            json.contains(r#""content":[{"type":"link","href":"https://example.com","content":[{"type":"text","text":"","styles":{}}]}]"#),
+            "quote content must contain the empty link fallback: {json}"
+        );
+    }
+
+    #[test]
+    fn link_in_table_cell() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartTable { id: None },
+            Event::StartTableRow { id: None },
+            Event::StartTableCell {
+                id: None,
+                colspan: None,
+                rowspan: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "link".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert!(json.contains(r#""type":"table""#));
+        assert!(json.contains(r#""type":"link""#));
+        assert!(json.contains(r#""href":"https://example.com""#));
+    }
+
+    #[test]
+    fn link_in_dropped_heading_inside_list_emits_no_link() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            Event::StartHeading { level: 1, id: None },
+            Event::StartLink {
+                href: "https://x".to_string(),
+                title: None,
+                id: None,
+            },
+            Event::Text {
+                content: "hidden".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndHeading,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert!(
+            json.contains(r#""type":"bulletListItem""#),
+            "list item must still be emitted: {json}"
+        );
+        assert!(
+            !json.contains(r#""type":"link""#),
+            "dropped heading content must not leak a phantom link: {json}"
         );
     }
 }

--- a/crates/docspec-cli/src/main.rs
+++ b/crates/docspec-cli/src/main.rs
@@ -6,7 +6,7 @@ mod error;
 mod format;
 
 use std::fs::File;
-use std::io::{IsTerminal as _, Read as _, Write};
+use std::io::{BufWriter, IsTerminal as _, Read as _, Write};
 
 use clap::Parser as _;
 use docspec_blocknote_writer::BlockNoteWriter;
@@ -86,7 +86,12 @@ fn main() {
 
         cli.output.as_ref().map_or_else(
             || run_pipeline(&content, std::io::stdout().lock()),
-            |path| run_pipeline(&content, File::create(path)?),
+            |path| {
+                let mut writer = BufWriter::new(File::create(path)?);
+                run_pipeline(&content, &mut writer)?;
+                writer.flush()?;
+                Ok(())
+            },
         )
     })();
 

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -41,13 +41,17 @@
 //!   (`start: Option<u64>` is `Some(n)` on the first item of each list, `None` on subsequent items;
 //!   child items may nest inside their parent's `Start*`/`End*` pair with `level` indicating
 //!   indent depth; task list markers (`- [ ]`/`- [x]`) are parsed as literal text)
+//! - Links → `StartLink { href, title }` / `EndLink` (inline, reference, collapsed,
+//!   shortcut, autolink, and email autolink variants — all resolved to inline form
+//!   by pulldown-cmark; image-inside-link closes the link before emitting the image
+//!   as a sibling block: content preceding the image stays inside the link, content
+//!   following the image is outside the link, and the link is empty only when the
+//!   image is the sole link label, e.g. `[![alt](img)](url)`)
 //!
 //! # Unsupported Elements
 //!
 //! The following elements are not emitted as structured events. Text content is
 //! recursively extracted where applicable; structure is silently dropped:
-//!
-//! - Links (text extracted, structure dropped)
 //! - Definition lists and footnotes
 //! - HTML blocks and inline HTML
 //! - Math blocks and inline math
@@ -104,6 +108,16 @@ struct ImageBuffer {
     url: String,
 }
 
+/// Buffered link state during link inline content collection.
+struct LinkBuffer {
+    /// Link target URL.
+    href: String,
+    /// Whether `StartLink` has been emitted yet (deferred until first inline event arrives).
+    started: bool,
+    /// Optional link title (from `CommonMark` `[text](url "title")` syntax).
+    title: Option<String>,
+}
+
 /// A streaming Markdown reader that implements [`EventSource`].
 ///
 /// `MarkdownReader` parses Markdown using `pulldown-cmark` and emits `DocSpec` events
@@ -134,6 +148,8 @@ pub struct MarkdownReader<'a> {
     in_table_head: bool,
     /// Nesting depth for italic (emphasis) formatting.
     italic_depth: usize,
+    /// Buffered link being processed (deferred Start emission for image-in-link extraction).
+    link: Option<LinkBuffer>,
     /// LIFO stack of list contexts. `len()` gives the current nesting depth;
     /// `level = list_stack.len().saturating_sub(1)` at item-emit time.
     list_stack: alloc::vec::Vec<ListContext>,
@@ -176,10 +192,26 @@ impl<'a> MarkdownReader<'a> {
         style
     }
 
+    /// Emits `StartLink` for the buffered link if it hasn't been emitted yet.
+    /// Called before any inline event that would belong inside a link.
+    fn emit_pending_link_start(&mut self) {
+        if let Some(link) = self.link.as_mut() {
+            if !link.started {
+                self.queue.push_back(Event::StartLink {
+                    href: link.href.clone(),
+                    id: None,
+                    title: link.title.clone(),
+                });
+                link.started = true;
+            }
+        }
+    }
+
     fn handle_code(&mut self, content: String) {
         if let Some(img) = &mut self.image {
             img.alt_buf.push_str(&content);
         } else {
+            self.emit_pending_link_start();
             if self.block_state == BlockState::None {
                 self.queue.push_back(Event::StartParagraph {
                     alignment: None,
@@ -255,6 +287,21 @@ impl<'a> MarkdownReader<'a> {
         self.block_state = BlockState::None;
     }
 
+    /// Emits `EndLink` (and `StartLink` if not yet emitted) for the buffered link.
+    fn handle_end_link(&mut self) {
+        let Some(link) = self.link.take() else { return };
+        if link.started {
+            self.queue.push_back(Event::EndLink);
+        } else {
+            self.queue.push_back(Event::StartLink {
+                href: link.href,
+                id: None,
+                title: link.title,
+            });
+            self.queue.push_back(Event::EndLink);
+        }
+    }
+
     /// Closes the current list item if open, pops the list context, and resets block state.
     fn handle_end_list(&mut self) {
         self.close_current_item_if_open();
@@ -316,6 +363,7 @@ impl<'a> MarkdownReader<'a> {
             TagEnd::Heading(_) => self.handle_end_heading(),
             TagEnd::Image => self.handle_end_image(),
             TagEnd::Item => self.handle_end_item(),
+            TagEnd::Link => self.handle_end_link(),
             TagEnd::List(_) => self.handle_end_list(),
             TagEnd::Paragraph => self.handle_end_paragraph(),
             TagEnd::Strikethrough => self.handle_end_strikethrough(),
@@ -330,7 +378,6 @@ impl<'a> MarkdownReader<'a> {
             | TagEnd::DefinitionListTitle
             | TagEnd::FootnoteDefinition
             | TagEnd::HtmlBlock
-            | TagEnd::Link
             | TagEnd::MetadataBlock(_)
             | TagEnd::Subscript
             | TagEnd::Superscript => {}
@@ -409,6 +456,27 @@ impl<'a> MarkdownReader<'a> {
     /// encountered. The title is stored as `None` when the pulldown-cmark title string
     /// is empty.
     fn handle_start_image(&mut self, dest_url: CowStr<'a>, title: CowStr<'a>) {
+        // Image-in-link extraction: close the link before processing the image so the
+        // image can be emitted as a sibling block (BlockNote and similar schemas do not
+        // allow block-level images inside inline links). When `link.started` is true, the
+        // link already contains preceding inline content — emit only `EndLink`. When it
+        // is false (image is the sole link label, e.g. `[![alt](img)](url)`), emit an
+        // empty `StartLink`/`EndLink` pair so the URL is preserved. `TagEnd::Image` fires
+        // `Event::Image` before `TagEnd::Paragraph`, so downstream writers close the
+        // surrounding paragraph before serialising the image as a sibling block.
+        if let Some(link) = self.link.take() {
+            if link.started {
+                self.queue.push_back(Event::EndLink);
+            } else {
+                self.queue.push_back(Event::StartLink {
+                    href: link.href,
+                    id: None,
+                    title: link.title,
+                });
+                self.queue.push_back(Event::EndLink);
+            }
+        }
+
         self.image = Some(ImageBuffer {
             alt_buf: String::new(),
             title: if title.is_empty() {
@@ -417,6 +485,22 @@ impl<'a> MarkdownReader<'a> {
                 Some(title.into_string())
             },
             url: dest_url.into_string(),
+        });
+    }
+
+    /// Stores link state for deferred `StartLink` emission.
+    ///
+    /// Emission is deferred until the first inline event arrives (lazy emission).
+    /// This allows image-in-link to be detected before any `StartLink` is emitted.
+    fn handle_start_link(&mut self, dest_url: CowStr<'a>, title: CowStr<'a>) {
+        self.link = Some(LinkBuffer {
+            href: dest_url.into_string(),
+            started: false,
+            title: if title.is_empty() {
+                None
+            } else {
+                Some(title.into_string())
+            },
         });
     }
 
@@ -489,6 +573,9 @@ impl<'a> MarkdownReader<'a> {
                 dest_url, title, ..
             } => self.handle_start_image(dest_url, title),
             Tag::Item => self.handle_item_start(),
+            Tag::Link {
+                dest_url, title, ..
+            } => self.handle_start_link(dest_url, title),
             Tag::List(start_opt) => self.handle_list_start(start_opt),
             Tag::Paragraph => self.handle_start_paragraph(),
             Tag::Strikethrough => self.handle_start_strikethrough(),
@@ -503,7 +590,6 @@ impl<'a> MarkdownReader<'a> {
             | Tag::DefinitionListTitle
             | Tag::FootnoteDefinition(_)
             | Tag::HtmlBlock
-            | Tag::Link { .. }
             | Tag::MetadataBlock(_)
             | Tag::Subscript
             | Tag::Superscript => {}
@@ -516,6 +602,7 @@ impl<'a> MarkdownReader<'a> {
         } else if let Some(buf) = &mut self.code_block_buffer {
             buf.push_str(&content);
         } else {
+            self.emit_pending_link_start();
             if self.block_state == BlockState::None {
                 self.queue.push_back(Event::StartParagraph {
                     alignment: None,
@@ -554,6 +641,7 @@ impl<'a> MarkdownReader<'a> {
             image: None,
             in_table_head: false,
             italic_depth: 0,
+            link: None,
             list_stack: Vec::new(),
             parser,
             phase: Phase::NotStarted,
@@ -580,6 +668,7 @@ impl<'a> MarkdownReader<'a> {
                 if let Some(img) = &mut self.image {
                     img.alt_buf.push(' ');
                 } else {
+                    self.emit_pending_link_start();
                     self.queue.push_back(Event::LineBreak);
                 }
             }
@@ -587,6 +676,7 @@ impl<'a> MarkdownReader<'a> {
                 if let Some(img) = &mut self.image {
                     img.alt_buf.push(' ');
                 } else {
+                    self.emit_pending_link_start();
                     self.queue.push_back(Event::Text {
                         content: " ".to_string(),
                         style: self.current_text_style(),

--- a/crates/docspec-markdown-reader/tests/integration.rs
+++ b/crates/docspec-markdown-reader/tests/integration.rs
@@ -138,6 +138,14 @@ mod tests {
     }
 
     #[test]
+    fn pipeline_links() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/links.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/links.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
+
+    #[test]
     fn pipeline_list_inside_blockquote_inside_list_item_is_well_formed() {
         // Regression for cmark-gfm/test.md edge case.
         // A list nested inside a blockquote that is itself inside a list item

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -1,5 +1,5 @@
 //! Unit tests for `MarkdownReader`.
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
 
 mod helpers {
     #![allow(clippy::single_call_fn)]
@@ -1264,6 +1264,206 @@ mod tests {
             end_blockquote_idx < end_outer_item_idx,
             "EndBlockQuote (at {end_blockquote_idx}) must precede outer EndOrderedListItem \
              (at {end_outer_item_idx}); events: {events:#?}"
+        );
+    }
+
+    #[test]
+    fn link_simple() {
+        let markdown = "[text](https://example.com)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let start_link_pos = events.iter().position(
+            |e| matches!(e, Event::StartLink { href, .. } if href == "https://example.com"),
+        );
+        assert!(start_link_pos.is_some(), "StartLink not found");
+        let pos = start_link_pos.unwrap();
+        assert!(
+            matches!(&events[pos], Event::StartLink { href, title, id } if href == "https://example.com" && title.is_none() && id.is_none())
+        );
+        assert!(matches!(&events[pos + 1], Event::Text { content, .. } if content == "text"));
+        assert!(matches!(&events[pos + 2], Event::EndLink));
+    }
+
+    #[test]
+    fn link_with_title() {
+        let markdown = r#"[text](https://example.com "a title")"#;
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let start_link = events.iter().find(|e| matches!(e, Event::StartLink { .. }));
+        assert!(start_link.is_some(), "StartLink not found");
+        assert!(
+            matches!(start_link.unwrap(), Event::StartLink { href, title, .. } if href == "https://example.com" && title.as_deref() == Some("a title"))
+        );
+    }
+
+    #[test]
+    fn link_empty_text() {
+        let markdown = "[](https://example.com)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let start_link_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::StartLink { .. }));
+        assert!(start_link_pos.is_some(), "StartLink not found");
+        let pos = start_link_pos.unwrap();
+        assert!(
+            matches!(&events[pos + 1], Event::EndLink),
+            "Expected EndLink immediately after StartLink for empty link"
+        );
+    }
+
+    #[test]
+    fn link_styled_content() {
+        let markdown = "[**bold** text](https://example.com)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let start_link_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::StartLink { .. }));
+        assert!(start_link_pos.is_some(), "StartLink not found");
+        let pos = start_link_pos.unwrap();
+        let end_link_pos = events[pos..]
+            .iter()
+            .position(|e| matches!(e, Event::EndLink))
+            .map(|i| i + pos);
+        assert!(end_link_pos.is_some(), "EndLink not found after StartLink");
+        let end_pos = end_link_pos.unwrap();
+        let has_bold = events[pos + 1..end_pos]
+            .iter()
+            .any(|e| matches!(e, Event::Text { style, .. } if style.bold));
+        assert!(has_bold, "Expected bold Text between StartLink and EndLink");
+    }
+
+    #[test]
+    fn link_with_code_span() {
+        let markdown = "[`code`](https://example.com)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let start_link_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::StartLink { .. }));
+        assert!(start_link_pos.is_some(), "StartLink not found");
+        let pos = start_link_pos.unwrap();
+        let end_link_pos = events[pos..]
+            .iter()
+            .position(|e| matches!(e, Event::EndLink))
+            .map(|i| i + pos);
+        assert!(end_link_pos.is_some(), "EndLink not found");
+        let end_pos = end_link_pos.unwrap();
+        let has_code = events[pos + 1..end_pos].iter().any(
+            |e| matches!(e, Event::Text { content, style, .. } if content == "code" && style.code),
+        );
+        assert!(
+            has_code,
+            "Expected code-styled Text between StartLink and EndLink"
+        );
+    }
+
+    #[test]
+    fn autolink() {
+        let markdown = "<https://example.com>";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let start_link_pos = events.iter().position(
+            |e| matches!(e, Event::StartLink { href, .. } if href == "https://example.com"),
+        );
+        assert!(start_link_pos.is_some(), "StartLink not found for autolink");
+        let pos = start_link_pos.unwrap();
+        let end_link_pos = events[pos..]
+            .iter()
+            .position(|e| matches!(e, Event::EndLink))
+            .map(|i| i + pos);
+        assert!(end_link_pos.is_some(), "EndLink not found");
+        let end_pos = end_link_pos.unwrap();
+        let has_url_text = events[pos + 1..end_pos]
+            .iter()
+            .any(|e| matches!(e, Event::Text { content, .. } if content == "https://example.com"));
+        assert!(has_url_text, "Expected URL as Text content inside autolink");
+    }
+
+    #[test]
+    fn link_in_heading() {
+        let markdown = "# [text](https://example.com)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let heading_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::StartHeading { level: 1, .. }));
+        assert!(heading_pos.is_some(), "StartHeading not found");
+        let h_pos = heading_pos.unwrap();
+        let end_heading_pos = events[h_pos..]
+            .iter()
+            .position(|e| matches!(e, Event::EndHeading))
+            .map(|i| i + h_pos);
+        assert!(end_heading_pos.is_some(), "EndHeading not found");
+        let eh_pos = end_heading_pos.unwrap();
+        let has_link = events[h_pos..eh_pos]
+            .iter()
+            .any(|e| matches!(e, Event::StartLink { .. }));
+        assert!(has_link, "Expected StartLink inside heading");
+        let has_end_link = events[h_pos..eh_pos]
+            .iter()
+            .any(|e| matches!(e, Event::EndLink));
+        assert!(has_end_link, "Expected EndLink inside heading");
+    }
+
+    #[test]
+    fn link_in_paragraph_with_surrounding_text() {
+        let markdown = "before [link text](https://example.com) after";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let start_link_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::StartLink { .. }));
+        assert!(start_link_pos.is_some(), "StartLink not found");
+        let pos = start_link_pos.unwrap();
+        assert!(pos > 0, "Expected text before StartLink");
+        assert!(
+            matches!(&events[pos - 1], Event::Text { content, .. } if content.contains("before")),
+            "Expected 'before' text before StartLink"
+        );
+        assert!(
+            matches!(&events[pos + 1], Event::Text { content, .. } if content == "link text"),
+            "Expected link text inside link"
+        );
+        assert!(
+            matches!(&events[pos + 2], Event::EndLink),
+            "Expected EndLink after link text"
+        );
+        assert!(
+            matches!(&events[pos + 3], Event::Text { content, .. } if content.contains("after")),
+            "Expected 'after' text after EndLink"
+        );
+    }
+
+    #[test]
+    fn image_in_link_extracts_image_as_sibling() {
+        // pulldown-cmark event sequence: Tag::Link > Tag::Image > Text("alt") > TagEnd::Image > TagEnd::Link
+        // Reader should emit: StartParagraph, StartLink, EndLink, Image, EndParagraph
+        // (Image appears BEFORE EndParagraph because pulldown fires End(Image) before End(Paragraph))
+        let markdown = "[![alt](img.png)](https://example.com)";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+        let para_pos = events
+            .iter()
+            .position(|e| matches!(e, Event::StartParagraph { .. }));
+        assert!(para_pos.is_some(), "StartParagraph not found");
+        let p = para_pos.unwrap();
+        assert!(
+            matches!(&events[p + 1], Event::StartLink { href, .. } if href == "https://example.com"),
+            "Expected StartLink after StartParagraph"
+        );
+        assert!(
+            matches!(&events[p + 2], Event::EndLink),
+            "Expected EndLink immediately after StartLink (image-in-link extraction)"
+        );
+        assert!(
+            matches!(&events[p + 3], Event::Image { .. }),
+            "Expected Image event after EndLink"
+        );
+        assert!(
+            matches!(&events[p + 4], Event::EndParagraph),
+            "Expected EndParagraph after Image"
         );
     }
 }

--- a/tests/fixtures/blocknote/links.json
+++ b/tests/fixtures/blocknote/links.json
@@ -1,0 +1,316 @@
+[
+  {
+    "type": "heading",
+    "props": {
+      "textAlignment": "left",
+      "level": 1
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "Heading with ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "an inline link",
+            "styles": {}
+          }
+        ]
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "A paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "a link",
+            "styles": {}
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " inline.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "A paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "a ",
+            "styles": {}
+          },
+          {
+            "type": "text",
+            "text": "bold",
+            "styles": {
+              "bold": true
+            }
+          },
+          {
+            "type": "text",
+            "text": " link",
+            "styles": {}
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " styled inside.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "A paragraph with an autolink: ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://autolink.example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "https://autolink.example.com",
+            "styles": {}
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ".",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "A paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://titled.example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "a link with title",
+            "styles": {}
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ".",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "An empty-text link: ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://empty.example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "",
+            "styles": {}
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ".",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "A paragraph with ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://code.example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "inline code",
+            "styles": {
+              "code": true
+            }
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " inside a link.",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "An image-in-link: ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://wrapper.example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "",
+            "styles": {}
+          }
+        ]
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "image",
+    "props": {
+      "url": "https://img.example.com/pic.png",
+      "caption": "alt text"
+    },
+    "content": null,
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": ".",
+        "styles": {}
+      }
+    ],
+    "children": []
+  },
+  {
+    "type": "paragraph",
+    "props": {
+      "textAlignment": "left"
+    },
+    "content": [
+      {
+        "type": "text",
+        "text": "A paragraph with multiple links: see ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://one.example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "first",
+            "styles": {}
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": " and ",
+        "styles": {}
+      },
+      {
+        "type": "link",
+        "href": "https://two.example.com",
+        "content": [
+          {
+            "type": "text",
+            "text": "second",
+            "styles": {}
+          }
+        ]
+      },
+      {
+        "type": "text",
+        "text": ".",
+        "styles": {}
+      }
+    ],
+    "children": []
+  }
+]

--- a/tests/fixtures/markdown/links.md
+++ b/tests/fixtures/markdown/links.md
@@ -1,0 +1,17 @@
+# Heading with [an inline link](https://example.com)
+
+A paragraph with [a link](https://example.com) inline.
+
+A paragraph with [a **bold** link](https://example.com) styled inside.
+
+A paragraph with an autolink: <https://autolink.example.com>.
+
+A paragraph with [a link with title](https://titled.example.com "the title").
+
+An empty-text link: [](https://empty.example.com).
+
+A paragraph with [`inline code`](https://code.example.com) inside a link.
+
+An image-in-link: [![alt text](https://img.example.com/pic.png)](https://wrapper.example.com).
+
+A paragraph with multiple links: see [first](https://one.example.com) and [second](https://two.example.com).


### PR DESCRIPTION
Adds CommonMark link support to the md→blocknote pipeline.

## Commits
1. \`fix(cli): wrap file output in BufWriter with explicit flush\` — Refs: #16
   Carrier-fix included in the same PR for convenience: wraps the CLI's file-output path in \`BufWriter\` with explicit \`flush()\`. Previously the unbuffered \`File::create\` writer caused ~45× wall-clock slowdown when writing JSON output to a file vs stdout, due to per-byte syscall overhead from struson's token-by-token emission. The explicit \`flush()\` ensures errors surface (per AGENTS.md fail-fast).
2. \`feat(markdown-reader,blocknote-writer): emit and serialize inline links\` — Refs: #37, #12

## Changes (commit 2)
- \`docspec-markdown-reader\` now emits \`Event::StartLink { href, title }\` / \`Event::EndLink\` for all CommonMark link variants (inline, reference, collapsed, shortcut, autolink, email autolink).
- \`docspec-blocknote-writer\` now serializes link events as BlockNote inline link JSON: \`{"type":"link","href":"<url>","content":[StyledText...]}\` per the BlockNote.js inline content schema.
- Image-in-link (\`[![alt](img)](url)\`) is handled by extracting the image as a sibling block: the link is emitted as empty, then the image follows. This preserves the streaming model (no block-inside-inline violation).
- Empty-text links \`[](url)\` emit \`content: [{"type":"text","text":"","styles":{}}]\` matching BlockNote test fixtures.
- \`title\` field is preserved in the event stream (\`Event::StartLink { title }\`) for forward compatibility with other writers, but dropped on the floor by the BlockNote writer since BlockNote's JSON schema has no slot for link titles (they are render-time HTMLAttributes).

## Empirical regression baseline
In-tree fixture round-trip (\`tests/fixtures/markdown/links.md\` → \`tests/fixtures/blocknote/links.json\`):
- Before: 0 inline link objects in output; fixture round-trip fails (no link support)
- After: round-trip byte-equal after canonical JSON sort; link count matches the fixture's 10 link instances

## Tests
- 9 new reader unit tests covering all CommonMark link variants
- 6 new writer unit tests covering JSON schema compliance
- 1 new integration test \`pipeline_links\` round-tripping a fixture through the full pipeline

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown links are now fully supported and emitted into BlockNote across paragraphs, headings, lists, tables, autolinks, and empty-text links (placeholder emitted).

* **Improvements**
  * Preserves styled inline segments inside links and mixes link content with surrounding text.
  * Link handling now reliably closes/open blocks to avoid leaks.
  * More reliable file output via buffered writes with an explicit flush.

* **Tests**
  * New fixtures and extensive tests covering many link scenarios and image-in-link behavior.

* **Documentation**
  * Updated docs describing link support and image-in-link limitations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/66?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->