### PR TITLE
feat(http): HTTP API server and CLI subcommand restructure (#15)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -156,3 +156,62 @@ Extension is straightforward through well-defined interfaces. New formats implem
 The same code runs natively on servers, in WebAssembly in browsers, on embedded microcontrollers. Portability is a consequence of good design. Constraints force clarity. Clarity produces quality that lasts.
 
 For the philosophy behind these architectural choices, see the [Manifesto](MANIFESTO.md).
+
+---
+
+## HTTP Server (`docspec-http`)
+
+The `docspec-http` crate exposes the DocSpec streaming pipeline over HTTP using [Axum 0.8](https://docs.rs/axum/0.8) and [tokio](https://docs.rs/tokio).
+
+### Sync/Async Bridge
+
+The core challenge is bridging DocSpec's synchronous `EventSource`/`EventSink` pipeline to Axum's async request handling. The solution uses a bounded channel:
+
+```
+HTTP request → convert_handler (async)
+                    │
+                    ├─ Validate Content-Type, Accept, UTF-8
+                    │
+                    ├─ Create mpsc::channel::<Result<Bytes, io::Error>>(32)
+                    │
+                    ├─ spawn_blocking (fire-and-forget, NO .await):
+                    │       MarkdownReader::new(&body_str)
+                    │       → StackTrackingSink<BlockNoteWriter<ChannelWriter>>
+                    │       → ChannelWriter::blocking_send(chunk) per 8 KB
+                    │
+                    └─ Return Response immediately:
+                            Body::from_stream(ReceiverStream::new(rx))
+```
+
+The response is returned **before** conversion completes. Axum streams the response body as the blocking task produces chunks. The bounded channel (capacity 32) provides backpressure without deadlock because the receiver is actively drained by Axum's writer.
+
+**Critical**: Never `.await` the `JoinHandle` from `spawn_blocking` before returning the response. Doing so causes a deadlock: the handle waits for the blocking task, the blocking task fills the channel and blocks on `blocking_send`, and the channel never drains because the response hasn't started.
+
+### Why Request Body Is Buffered
+
+`MarkdownReader<'a>` holds a `pulldown-cmark` `Parser<'a>` that borrows from `&'a str`. This makes it impossible to own the `String` and hold a borrow from it simultaneously in safe Rust (self-referential struct). The HTTP handler buffers the request body to a `String` and passes `&body_str` to `MarkdownReader::new`. This is an accepted memory trade-off for the HTTP use case.
+
+### Accepted Risk Profile
+
+By design, `docspec-http` enforces:
+- **No body size limit** — unlimited request bodies accepted
+- **No request timeout** — conversions run to completion
+- **No shutdown timeout** — in-flight requests drain unbounded on SIGINT/SIGTERM
+
+These risks are accepted and documented. Deploy behind a reverse proxy (nginx, Caddy, etc.) for production use.
+
+### MIME Types
+
+| Direction | MIME Type |
+|-----------|-----------|
+| Input | `text/markdown` (with optional `; charset=...` parameter) |
+| Output | `application/vnd.docspec.blocknote+json` |
+| Errors | `application/problem+json` (RFC 7807) |
+
+### Error Responses
+
+All errors return [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem+json with:
+- `type`: `https://docspec.dev/errors/{code}` URI
+- `title`: Human-readable error category
+- `status`: HTTP status code
+- `detail`: Occurrence-specific description

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- New `docspec-http` crate: HTTP API server exposing the DocSpec streaming pipeline over HTTP using Axum 0.8 (issue #15, NLnet-funded milestone)
+- `POST /convert` endpoint: accepts `text/markdown`, returns `application/vnd.docspec.blocknote+json` as a streaming response
+- `GET /health` endpoint: returns `204 No Content` for health checks
+- RFC 7807 problem+json error responses with `application/problem+json` Content-Type and `https://docspec.dev/errors/{code}` type URIs
+- `docspec http` subcommand: starts the HTTP API server with `--host`, `--port`, `--log-level`, `--log-format` flags
+- `docspec convert` subcommand: Pandoc-style document conversion with `-f/--from`, `-t/--to`, `-o/--output`, `--list-input-formats`, `--list-output-formats`, `--verbose` flags
+- Structured tracing/observability via `tracing` + `tower-http::TraceLayer` with `x-request-id` header on all responses
+- Graceful shutdown on `SIGINT`/`SIGTERM` (Unix) and `Ctrl-C` (all platforms)
+
+### Changed
+
+- **BREAKING**: CLI restructured to use subcommands. `docspec input.md -o out.json` is now `docspec convert input.md -o out.json`. All existing flags (`-f`, `-t`, `-o`, `--color`) are preserved under the `convert` subcommand, with `--color` remaining a top-level global flag.
+
+### Migration Guide
+
+Replace all invocations of the flat CLI with the `convert` subcommand:
+
+```bash
+# Before
+docspec input.md -o output.json
+docspec -f markdown -t blocknote < input.md
+
+# After
+docspec convert input.md -o output.json
+docspec convert -f markdown -t blocknote < input.md
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "assert_cmd"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+checksum = "2aa3a22042e45de04255c7bf3626e239f450200fd0493c1e382263544b20aea6"
 dependencies = [
  "anstyle",
  "bstr",
@@ -83,10 +83,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.5.0"
+name = "atomic-waker"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -113,15 +171,27 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -147,9 +217,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+checksum = "e0a7a9bfdb35811f9e59832f0f05975114d2251b415fb534108e6f34060fd772"
 dependencies = [
  "clap",
 ]
@@ -215,11 +285,14 @@ dependencies = [
  "clap_mangen",
  "docspec-blocknote-writer",
  "docspec-core",
+ "docspec-http",
  "docspec-markdown-reader",
+ "nix",
  "predicates",
  "serde_json",
  "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
@@ -227,6 +300,28 @@ name = "docspec-core"
 version = "0.1.0"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "docspec-http"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "bytes",
+ "docspec-blocknote-writer",
+ "docspec-core",
+ "docspec-markdown-reader",
+ "http-body-util",
+ "nix",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -306,6 +401,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,15 +475,95 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "http"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "id-arena"
@@ -361,7 +578,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -377,6 +594,24 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leb128fmt"
@@ -398,21 +633,74 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "num-traits"
@@ -434,6 +722,18 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "predicates"
@@ -498,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "getopts",
@@ -585,6 +885,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -621,15 +928,79 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -682,6 +1053,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +1098,174 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "log",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,6 +1296,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,6 +1326,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -785,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -798,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -808,9 +1376,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -821,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/docspec-blocknote-writer",
   "crates/docspec-json",
   "crates/docspec-cli",
+  "crates/docspec-http",
   "crates/docspec-wasm",
 ]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # DocSpec
 
-DocSpec is a streaming document conversion library. It converts DOCX, ODT, RTF, HTML, Markdown, and BlockNote JSON — event by event, byte by byte, without buffering the world. Built in Rust for memory-conscious systems, from microcontrollers to servers.
+DocSpec is a streaming document conversion library. It converts DOCX, ODT, RTF, HTML, Markdown, and BlockNote JSON, event by event, byte by byte, without buffering the world. Built in Rust for memory-conscious systems, from microcontrollers to servers.
+
+> **BREAKING CHANGE**: The CLI has been restructured to use subcommands.
+> `docspec input.md -o out.json` is now `docspec convert input.md -o out.json`.
 
 ## Philosophy
 
@@ -23,14 +26,73 @@ DocSpec works through a pipeline of readers and writers. A reader (EventSource) 
 
 The architecture is fully decoupled. Any reader connects to any writer. A DOCX reader can feed a Markdown writer. An HTML reader can feed BlockNote JSON. The events are the contract.
 
-To convert a document:
+### CLI: Convert a file
 
-1. Create a reader for your input format
-2. Create a writer for your output format
-3. Connect them through the event pipeline
-4. Let the events flow
+```sh
+docspec convert input.md -o out.json
+```
 
-No buffering. No intermediate representations. No loading the entire document into memory. The document streams through, event by event.
+Specify formats explicitly when the file extension is ambiguous:
+
+```sh
+docspec convert --from markdown --to blocknote input.md -o out.json
+```
+
+### HTTP API: Start the server
+
+```sh
+docspec http --host 127.0.0.1 --port 3000
+```
+
+Then convert a document over HTTP:
+
+```sh
+curl -X POST http://localhost:3000/convert \
+  -H 'Content-Type: text/markdown' \
+  --data-binary '# Hello'
+```
+
+Check server health:
+
+```sh
+curl -i http://localhost:3000/health
+# HTTP/1.1 204 No Content
+```
+
+## HTTP API
+
+### Endpoints
+
+**`POST /convert`** — Convert a document. Send the source document as the request body.
+
+**`GET /health`** — Returns `204 No Content` when the server is ready.
+
+### MIME Types
+
+| Direction | MIME Type |
+|-----------|-----------|
+| Input | `text/markdown` |
+| Output | `application/vnd.docspec.blocknote+json` |
+| Errors | `application/problem+json` |
+
+### Error Format
+
+Errors follow [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem+json. Each error includes a `type` URI of the form `https://docspec.dev/errors/{code}`, a human-readable `title`, and an HTTP `status` code.
+
+Example:
+
+```json
+{
+  "type": "https://docspec.dev/errors/unsupported-media-type",
+  "title": "Unsupported Media Type",
+  "status": 415,
+  "detail": "Content-Type 'application/json' is not supported. Use text/markdown."
+}
+```
+
+### Security Note
+
+No body size limit or request timeout is enforced. Deploy behind a reverse proxy (nginx, Caddy, etc.) for production use.
 
 ## Documentation
 

--- a/crates/docspec-cli/Cargo.toml
+++ b/crates/docspec-cli/Cargo.toml
@@ -14,20 +14,23 @@ name = "docspec"
 path = "src/main.rs"
 
 [dependencies]
-clap = { version = "4", features = ["derive", "color"] }
-docspec-core = { path = "../docspec-core" }
-docspec-markdown-reader = { path = "../docspec-markdown-reader" }
+clap = { version = "4", features = ["derive", "color", "env"] }
 docspec-blocknote-writer = { path = "../docspec-blocknote-writer" }
+docspec-core = { path = "../docspec-core" }
+docspec-http = { path = "../docspec-http" }
+docspec-markdown-reader = { path = "../docspec-markdown-reader" }
 thiserror = "2"
+tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]
 assert_cmd = "2"
+nix = { version = "0.29", features = ["signal"] }
 predicates = "3"
-tempfile = "3"
 serde_json = "1"
+tempfile = "3"
 
 [build-dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 clap_mangen = "0.2"
 clap_complete = "4"
 

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -1,24 +1,56 @@
 # docspec-cli
 
-Command-line interface for DocSpec document conversion.
+Command-line interface for [DocSpec](https://github.com/docspec/docspec) document conversion.
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation.
-
-## Usage
+The CLI uses Pandoc-style subcommands:
 
 ```bash
-docspec [OPTIONS] [INPUT]
+docspec [GLOBAL OPTIONS] <COMMAND>
 ```
 
-### Arguments
+## Global Options
 
-- `INPUT` — Input file (use `-` or omit for stdin)
+- `--color <WHEN>` — Color output: `auto`, `always`, `never` (default: `auto`)
+- `-h, --help` — Print help
+- `-V, --version` — Print version
 
-### Options
+## Convert Documents
+
+```bash
+docspec convert [OPTIONS] [INPUT]
+```
+
+`INPUT` is an input file. Use `-` or omit it to read from stdin.
+
+Options:
 
 - `-o, --output <FILE>` — Output file (stdout if omitted)
 - `-f, --from <FORMAT>` — Input format (auto-detected from extension if omitted)
 - `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted)
-- `--color <WHEN>` — When to use colors: `auto`, `always`, `never` (default: `auto`)
-- `-h, --help` — Print help
-- `-V, --version` — Print version
+- `--list-input-formats` — List supported input formats and exit
+- `--list-output-formats` — List supported output formats and exit
+- `--verbose` — Print conversion completion message
+
+Example:
+
+```bash
+docspec convert --from markdown --to blocknote input.md -o out.json
+```
+
+## Start the HTTP Server
+
+```bash
+docspec http [OPTIONS]
+```
+
+Options:
+
+- `--host <HOST>` — Host address to bind (default: `127.0.0.1`)
+- `--port <PORT>` — Port to listen on (default: `3000`)
+- `--log-format <FORMAT>` — `pretty` or `json` (default: `pretty`)
+- `--log-level <LEVEL>` — `trace`, `debug`, `info`, `warn`, `error` (default: `info`)
+
+## Breaking Change
+
+The root conversion command moved under `convert`. Migrate old invocations like
+`docspec input.md -o out.json` to `docspec convert input.md -o out.json`.

--- a/crates/docspec-cli/src/args.rs
+++ b/crates/docspec-cli/src/args.rs
@@ -1,24 +1,48 @@
 use std::path::PathBuf;
 
-use clap::{Parser, ValueEnum};
+use clap::{Args, Parser, Subcommand, ValueEnum};
 
 /// `DocSpec`: streaming document conversion.
 #[derive(Parser, Debug)]
-#[command(name = "docspec")]
-#[command(version = "0.1.0")]
-#[command(about = "Convert documents between formats using streaming event pipeline", long_about = None)]
+#[command(name = "docspec", version, about, long_about = None)]
+#[command(subcommand_required = true, arg_required_else_help = true)]
 pub struct Cli {
     /// When to use colors.
-    #[arg(long, value_name = "WHEN", default_value = "auto")]
+    #[arg(long, value_name = "WHEN", default_value = "auto", global = true)]
     pub color: ColorChoice,
 
+    /// Subcommand to run.
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Available subcommands.
+#[derive(Subcommand, Debug)]
+pub enum Command {
+    /// Convert documents between formats.
+    Convert(ConvertArgs),
+    /// Start the HTTP API server.
+    Http(HttpArgs),
+}
+
+/// Arguments for the `convert` subcommand.
+#[derive(Args, Debug)]
+pub struct ConvertArgs {
     /// Input format (auto-detected from extension if omitted).
     #[arg(short, long)]
     pub from: Option<Format>,
 
     /// Input file (use `-` or omit for stdin).
-    #[arg(value_name = "FILE")]
+    #[arg(value_name = "INPUT")]
     pub input: Option<PathBuf>,
+
+    /// List supported input formats and exit.
+    #[arg(long)]
+    pub list_input_formats: bool,
+
+    /// List supported output formats and exit.
+    #[arg(long)]
+    pub list_output_formats: bool,
 
     /// Output file (stdout if omitted).
     #[arg(short, long, value_name = "FILE")]
@@ -27,6 +51,41 @@ pub struct Cli {
     /// Output format (auto-detected from extension if omitted).
     #[arg(short, long)]
     pub to: Option<Format>,
+
+    /// Print a "conversion complete" message to stderr when done.
+    #[arg(long)]
+    pub verbose: bool,
+}
+
+/// Arguments for the `http` subcommand.
+#[derive(Args, Debug)]
+pub struct HttpArgs {
+    /// Host address to bind to.
+    #[arg(long, default_value = "127.0.0.1", env = "DOCSPEC_HTTP_HOST")]
+    pub host: String,
+
+    /// Log format.
+    #[arg(long, default_value = "pretty", env = "DOCSPEC_LOG_FORMAT")]
+    pub log_format: LogFormatArg,
+
+    /// Log level (trace, debug, info, warn, error).
+    #[arg(long, default_value = "info", env = "DOCSPEC_LOG_LEVEL")]
+    pub log_level: String,
+
+    /// Port to listen on.
+    #[arg(long, default_value = "3000", env = "DOCSPEC_HTTP_PORT")]
+    pub port: u16,
+}
+
+/// Log format selection for the HTTP server.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+pub enum LogFormatArg {
+    /// Machine-readable JSON logs.
+    #[value(name = "json")]
+    Json,
+    /// Human-readable pretty-printed logs.
+    #[value(name = "pretty")]
+    Pretty,
 }
 
 /// Document format.

--- a/crates/docspec-cli/src/format.rs
+++ b/crates/docspec-cli/src/format.rs
@@ -2,8 +2,8 @@
 
 use std::path::Path;
 
+use crate::args::Format;
 use crate::error::{CliError, Result};
-use crate::Format;
 
 /// Resolves format from explicit flag or path detection.
 ///
@@ -30,6 +30,20 @@ pub fn resolve_format(
     Err(CliError::FormatDetection {
         message: error_message.to_string(),
     })
+}
+
+// Reason: Used by run_convert for --list-input-formats (T7). Called once per invocation by design.
+#[allow(clippy::single_call_fn)]
+/// Returns the names of all supported input formats.
+pub fn input_format_names() -> &'static [&'static str] {
+    &["markdown"]
+}
+
+// Reason: Used by run_convert for --list-output-formats (T7). Called once per invocation by design.
+#[allow(clippy::single_call_fn)]
+/// Returns the names of all supported output formats.
+pub fn output_format_names() -> &'static [&'static str] {
+    &["blocknote"]
 }
 
 #[cfg(test)]

--- a/crates/docspec-cli/src/main.rs
+++ b/crates/docspec-cli/src/main.rs
@@ -7,83 +7,147 @@ mod format;
 
 use std::fs::File;
 use std::io::{BufWriter, IsTerminal as _, Read as _, Write};
+use std::path::Path;
 
 use clap::Parser as _;
 use docspec_blocknote_writer::BlockNoteWriter;
 use docspec_core::StackTrackingSink;
 use docspec_markdown_reader::MarkdownReader;
 
-use crate::args::{Cli, ColorChoice, Format};
+use crate::args::{Cli, ColorChoice, Command, ConvertArgs, Format, HttpArgs, LogFormatArg};
 use crate::error::{CliError, Result};
 
+impl From<LogFormatArg> for docspec_http::tracing_init::LogFormat {
+    #[inline]
+    fn from(arg: LogFormatArg) -> Self {
+        match arg {
+            LogFormatArg::Json => Self::Json,
+            LogFormatArg::Pretty => Self::Pretty,
+        }
+    }
+}
+
+// Reason: These functions are called exactly once from main() — that is intentional
+// for the subcommand dispatch pattern. They will gain more callers in tests (T13, T15).
+#[allow(clippy::single_call_fn)]
+// Reason: run_convert has multiple sequential validation stages by design; extracting
+// them into separate helpers would add indirection without improving clarity.
+#[allow(clippy::cognitive_complexity)]
+fn run_convert(args: &ConvertArgs, _color: ColorChoice) -> Result<()> {
+    if args.list_input_formats {
+        let mut out = std::io::stdout().lock();
+        for name in format::input_format_names() {
+            writeln!(out, "{name}")?;
+        }
+        return Ok(());
+    }
+    if args.list_output_formats {
+        let mut out = std::io::stdout().lock();
+        for name in format::output_format_names() {
+            writeln!(out, "{name}")?;
+        }
+        return Ok(());
+    }
+
+    if let (Some(input), Some(output)) = (&args.input, &args.output) {
+        if input == output {
+            return Err(CliError::SameInputOutput);
+        }
+    }
+
+    let input_format = format::resolve_format(
+        args.from,
+        args.input.as_deref(),
+        "cannot detect input format: use --from",
+    )?;
+    let output_format = format::resolve_format(
+        args.to,
+        args.output.as_deref(),
+        "cannot detect output format: use --to",
+    )?;
+
+    let use_stdin = args.input.as_deref().is_none_or(|p| p == Path::new("-"));
+
+    let raw_content = if use_stdin {
+        let mut s = String::new();
+        std::io::stdin().read_to_string(&mut s)?;
+        s
+    } else {
+        std::fs::read_to_string(args.input.as_deref().ok_or_else(|| {
+            CliError::FormatDetection {
+                message: "cannot read input".to_string(),
+            }
+        })?)?
+    };
+
+    let content = raw_content
+        .strip_prefix('\u{FEFF}')
+        .unwrap_or(&raw_content)
+        .to_string();
+
+    if matches!(input_format, Format::Blocknote) {
+        return Err(CliError::FormatNotSupported {
+            format: "blocknote".to_string(),
+        });
+    }
+    if matches!(output_format, Format::Markdown) {
+        return Err(CliError::FormatNotSupported {
+            format: "markdown".to_string(),
+        });
+    }
+
+    match &args.output {
+        Some(path) => {
+            let mut writer = BufWriter::new(File::create(path)?);
+            run_pipeline(&content, &mut writer)?;
+        }
+        None => run_pipeline(&content, std::io::stdout().lock())?,
+    }
+
+    if args.verbose {
+        let mut err = std::io::stderr().lock();
+        writeln!(err, "conversion complete")?;
+    }
+
+    Ok(())
+}
+
+// Reason: Same as run_convert — single dispatch point by design.
+#[allow(clippy::single_call_fn)]
+fn run_http(args: &HttpArgs) -> Result<()> {
+    docspec_http::tracing_init::init(&args.log_level, args.log_format.into())
+        .map_err(|e| CliError::Io(std::io::Error::other(e.to_string())))?;
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+
+    runtime
+        .block_on(docspec_http::serve(&args.host, args.port))
+        .map_err(|e| CliError::Io(std::io::Error::other(e.to_string())))
+}
+
 /// Runs the streaming conversion pipeline from markdown to `BlockNote`.
-fn run_pipeline<W: Write>(content: &str, output: W) -> Result<()> {
+///
+/// Flushes the underlying writer before returning so I/O errors (disk full,
+/// broken pipe, etc.) surface as a non-zero exit instead of being silently
+/// dropped by `Drop`.
+fn run_pipeline<W: Write>(content: &str, mut output: W) -> Result<()> {
     let reader = MarkdownReader::new(content);
-    let sink = StackTrackingSink::new(BlockNoteWriter::new(output));
-    docspec_core::pipe(reader, sink).map_err(Into::into)
+    let sink = StackTrackingSink::new(BlockNoteWriter::new(&mut output));
+    docspec_core::pipe(reader, sink)?;
+    output.flush()?;
+    Ok(())
 }
 
 /// Main entry point.
 fn main() {
     let cli = Cli::parse();
 
-    let result: Result<()> = (|| {
-        if let (Some(input), Some(output)) = (&cli.input, &cli.output) {
-            if input == output {
-                return Err(CliError::SameInputOutput);
-            }
-        }
-
-        let input_format = format::resolve_format(
-            cli.from,
-            cli.input.as_deref(),
-            "cannot detect input format: use --from",
-        )?;
-        let output_format = format::resolve_format(
-            cli.to,
-            cli.output.as_deref(),
-            "cannot detect output format: use --to",
-        )?;
-
-        let raw_content = match cli.input.as_ref() {
-            None => {
-                let mut buf = String::new();
-                std::io::stdin().lock().read_to_string(&mut buf)?;
-                buf
-            }
-            Some(path) if path.as_os_str() == "-" => {
-                let mut buf = String::new();
-                std::io::stdin().lock().read_to_string(&mut buf)?;
-                buf
-            }
-            Some(path) => std::fs::read_to_string(path)?,
-        };
-        let content = raw_content
-            .strip_prefix('\u{FEFF}')
-            .unwrap_or(&raw_content)
-            .to_string();
-
-        if matches!(input_format, Format::Blocknote) {
-            return Err(CliError::FormatNotSupported {
-                format: "blocknote".to_string(),
-            });
-        }
-        if matches!(output_format, Format::Markdown) {
-            return Err(CliError::FormatNotSupported {
-                format: "markdown".to_string(),
-            });
-        }
-
-        cli.output.as_ref().map_or_else(
-            || run_pipeline(&content, std::io::stdout().lock()),
-            |path| {
-                let mut writer = BufWriter::new(File::create(path)?);
-                run_pipeline(&content, &mut writer)?;
-                writer.flush()?;
-                Ok(())
-            },
-        )
-    })();
+    let result: Result<()> = match &cli.command {
+        Command::Convert(args) => run_convert(args, cli.color),
+        Command::Http(args) => run_http(args),
+    };
 
     if let Err(err) = result {
         let use_color = if std::env::var("NO_COLOR").is_ok() {
@@ -103,5 +167,36 @@ fn main() {
         let write_result = std::io::Write::write_all(&mut std::io::stderr(), msg.as_bytes());
         drop(write_result);
         std::process::exit(1);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used, missing_docs)]
+
+    use super::*;
+
+    struct FailingFlushWriter;
+
+    impl Write for FailingFlushWriter {
+        fn flush(&mut self) -> std::io::Result<()> {
+            Err(std::io::Error::other("simulated flush failure"))
+        }
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+    }
+
+    #[test]
+    fn run_pipeline_propagates_flush_error() {
+        let result = run_pipeline("# Hello\n", FailingFlushWriter);
+        let err = result.expect_err("expected flush error to propagate");
+        assert!(
+            matches!(
+                err,
+                CliError::Io(_) | CliError::Conversion(docspec_core::Error::Io { .. })
+            ),
+            "expected I/O-rooted error, got {err:?}"
+        );
     }
 }

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -30,6 +30,7 @@ mod tests {
         let output_path = output.path().to_path_buf();
 
         docspec_cmd()
+            .arg("convert")
             .arg(input.path())
             .args(["-o", output_path.to_str().unwrap_or("")])
             .assert()
@@ -46,6 +47,7 @@ mod tests {
             .args([
                 "--color",
                 "always",
+                "convert",
                 "/tmp/nonexistent-docspec-test-file-xyz.md",
                 "-t",
                 "blocknote",
@@ -61,6 +63,7 @@ mod tests {
             .args([
                 "--color",
                 "never",
+                "convert",
                 "/tmp/nonexistent-docspec-test-file-xyz.md",
                 "-t",
                 "blocknote",
@@ -84,6 +87,7 @@ mod tests {
         let output_path = output.path().to_path_buf();
 
         docspec_cmd()
+            .arg("convert")
             .arg(input.path())
             .args(["-o", output_path.to_str().unwrap_or("")])
             .assert()
@@ -102,7 +106,7 @@ mod tests {
     #[test]
     fn convert_stdin_to_stdout() {
         docspec_cmd()
-            .args(["--from", "markdown", "--to", "blocknote"])
+            .args(["convert", "--from", "markdown", "--to", "blocknote"])
             .write_stdin("# Hello\n")
             .assert()
             .success()
@@ -112,7 +116,7 @@ mod tests {
     #[test]
     fn dash_means_stdin() {
         docspec_cmd()
-            .args(["-", "--from", "markdown", "--to", "blocknote"])
+            .args(["convert", "-", "--from", "markdown", "--to", "blocknote"])
             .write_stdin("# Dash Input\n")
             .assert()
             .success()
@@ -131,6 +135,7 @@ mod tests {
         let output_path = output.path().to_path_buf();
 
         docspec_cmd()
+            .arg("convert")
             .arg(input.path())
             .args(["-o", output_path.to_str().unwrap_or("")])
             .assert()
@@ -155,6 +160,7 @@ mod tests {
         let output_path = output.path().to_path_buf();
 
         docspec_cmd()
+            .arg("convert")
             .arg(input.path())
             .args([
                 "--from",
@@ -180,7 +186,7 @@ mod tests {
         );
 
         docspec_cmd()
-            .args([fixture, "--to", "blocknote"])
+            .args(["convert", fixture, "--to", "blocknote"])
             .assert()
             .success()
             .stdout(contains("heading"));
@@ -189,7 +195,7 @@ mod tests {
     #[test]
     fn help_flag() {
         docspec_cmd()
-            .arg("--help")
+            .args(["convert", "--help"])
             .assert()
             .success()
             .stdout(contains("--from"))
@@ -201,7 +207,7 @@ mod tests {
     #[test]
     fn invalid_arguments_exits_2() {
         docspec_cmd()
-            .arg("--invalid-flag-xyz")
+            .args(["convert", "--invalid-flag-xyz"])
             .assert()
             .failure()
             .code(2);
@@ -211,6 +217,7 @@ mod tests {
     fn missing_input_file_exits_1() {
         docspec_cmd()
             .args([
+                "convert",
                 "/tmp/nonexistent-docspec-test-file-xyz.md",
                 "-t",
                 "blocknote",
@@ -226,6 +233,7 @@ mod tests {
         docspec_cmd()
             .env("NO_COLOR", "1")
             .args([
+                "convert",
                 "/tmp/nonexistent-docspec-test-file-xyz.md",
                 "-t",
                 "blocknote",
@@ -243,7 +251,7 @@ mod tests {
         );
 
         docspec_cmd()
-            .args([fixture, "--to", "blocknote"])
+            .args(["convert", fixture, "--to", "blocknote"])
             .assert()
             .success()
             .stdout(contains("paragraph"));
@@ -259,7 +267,7 @@ mod tests {
         let path_str = input.path().to_str().unwrap_or("");
 
         docspec_cmd()
-            .args([path_str, "-o", path_str])
+            .args(["convert", path_str, "-o", path_str])
             .assert()
             .failure()
             .code(1)
@@ -275,6 +283,7 @@ mod tests {
         assert!(write_result.is_ok(), "failed to write to tempfile");
 
         docspec_cmd()
+            .arg("convert")
             .arg(input.path())
             .args(["-t", "blocknote"])
             .assert()
@@ -291,6 +300,7 @@ mod tests {
         assert!(write_result.is_ok(), "failed to write to tempfile");
 
         docspec_cmd()
+            .arg("convert")
             .arg(input.path())
             .args(["-t", "blocknote"])
             .assert()

--- a/crates/docspec-cli/tests/http_subcommand.rs
+++ b/crates/docspec-cli/tests/http_subcommand.rs
@@ -1,0 +1,86 @@
+//! Integration tests for the `docspec http` subcommand.
+
+#![allow(clippy::panic, clippy::single_call_fn, clippy::unwrap_used)]
+// Reason: Integration tests use unwrap/panic for assertion clarity;
+// docspec_cmd is called from multiple tests which is the correct dispatch pattern.
+
+use assert_cmd::Command;
+
+fn docspec_cmd() -> Command {
+    let result = Command::cargo_bin("docspec");
+    assert!(result.is_ok(), "docspec binary not found");
+    result.unwrap_or_else(|_| Command::new(""))
+}
+
+#[cfg(test)]
+mod tests {
+    use core::time::Duration;
+
+    use predicates::str::contains;
+
+    use super::docspec_cmd;
+
+    #[test]
+    fn http_help_shows_all_flags() {
+        docspec_cmd()
+            .args(["http", "--help"])
+            .assert()
+            .success()
+            .stdout(contains("--host"))
+            .stdout(contains("--log-format"))
+            .stdout(contains("--log-level"))
+            .stdout(contains("--port"));
+    }
+
+    #[test]
+    fn invalid_port_rejected() {
+        docspec_cmd()
+            .args(["http", "--port", "99999"])
+            .assert()
+            .failure()
+            .code(2);
+    }
+
+    #[test]
+    fn port_in_use_exits_nonzero() {
+        use std::net::TcpListener;
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+
+        docspec_cmd()
+            .args(["http", "--port", &port.to_string()])
+            .timeout(Duration::from_secs(3))
+            .assert()
+            .failure();
+
+        drop(listener);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn sigint_clean_exit() {
+        use std::process::{Command as StdCommand, Stdio};
+
+        let binary = assert_cmd::cargo::cargo_bin("docspec");
+
+        let mut child = StdCommand::new(&binary)
+            .args(["http", "--port", "0"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+
+        // Give the server time to bind and start accepting before sending SIGINT.
+        std::thread::sleep(Duration::from_millis(500));
+
+        nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(i32::try_from(child.id()).unwrap()),
+            nix::sys::signal::Signal::SIGINT,
+        )
+        .unwrap();
+
+        let status = child.wait().unwrap();
+        assert_eq!(status.code(), Some(0), "expected exit code 0 after SIGINT");
+    }
+}

--- a/crates/docspec-core/src/pipeline.rs
+++ b/crates/docspec-core/src/pipeline.rs
@@ -109,14 +109,8 @@ mod tests {
         let probe = Probe::default();
         let result = pipe(VecSource::new(vec![]), CollectingSink::new(probe.clone()));
         assert!(result.is_ok());
-        assert!(
-            probe.finished.get(),
-            "finish() must be called when source drains cleanly"
-        );
-        assert!(
-            probe.events.borrow().is_empty(),
-            "no events should reach the sink from an empty source"
-        );
+        assert!(probe.finished.get());
+        assert!(probe.events.borrow().is_empty());
     }
 
     #[test]
@@ -132,18 +126,12 @@ mod tests {
         ];
         let result = pipe(VecSource::new(events), CollectingSink::new(probe.clone()));
         assert!(result.is_ok());
-        assert!(
-            probe.finished.get(),
-            "finish() must be called after all events are forwarded"
-        );
+        assert!(probe.finished.get());
         let collected = probe.events.borrow();
-        assert!(
-            matches!(
-                collected.as_slice(),
-                [Event::StartDocument { .. }, Event::EndDocument]
-            ),
-            "expected exactly [StartDocument, EndDocument], got {collected:?}"
-        );
+        assert!(matches!(
+            collected.as_slice(),
+            [Event::StartDocument { .. }, Event::EndDocument]
+        ));
     }
 
     #[test]
@@ -151,10 +139,7 @@ mod tests {
         let probe = Probe::default();
         let result = pipe(ErroringSource, CollectingSink::new(probe.clone()));
         assert!(matches!(result, Err(Error::Other { .. })));
-        assert!(
-            !probe.finished.get(),
-            "finish() must be skipped when the source errors"
-        );
+        assert!(!probe.finished.get());
     }
 
     #[test]
@@ -172,9 +157,16 @@ mod tests {
             },
         );
         assert!(matches!(result, Err(Error::Other { .. })));
-        assert!(
-            !finished.get(),
-            "finish() must be skipped when the sink errors during handle_event"
-        );
+        assert!(!finished.get());
+    }
+
+    #[test]
+    fn erroring_sink_finish_is_callable() {
+        let finished = Rc::new(Cell::new(false));
+        let sink = ErroringSink {
+            finished: Rc::clone(&finished),
+        };
+        assert!(sink.finish().is_ok());
+        assert!(finished.get());
     }
 }

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "docspec-http"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "HTTP API server for DocSpec document conversion"
+keywords = ["document", "conversion", "streaming", "http"]
+categories = ["encoding", "network-programming"]
+
+[dependencies]
+docspec-core = { path = "../docspec-core" }
+docspec-markdown-reader = { path = "../docspec-markdown-reader" }
+docspec-blocknote-writer = { path = "../docspec-blocknote-writer" }
+axum = "0.8"
+tokio = { version = "1", features = [
+  "rt-multi-thread",
+  "macros",
+  "net",
+  "signal",
+  "sync",
+  "time",
+  "io-util",
+] }
+tokio-stream = "0.1"
+tower = "0.5"
+tower-http = { version = "0.6", features = ["trace", "request-id", "util"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = [
+  "env-filter",
+  "json",
+  "fmt",
+] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+bytes = "1"
+uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+http-body-util = "0.1"
+nix = { version = "0.29", features = ["signal"] }
+serde_json = "1"
+tower = { version = "0.5", features = ["util"] }
+
+[lints]
+workspace = true

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -1,0 +1,59 @@
+# docspec-http
+
+HTTP API server for [DocSpec](https://github.com/docspec/docspec) document conversion.
+
+Exposes the DocSpec streaming pipeline over HTTP using [Axum 0.8](https://docs.rs/axum/0.8).
+Accepts `text/markdown` input and returns `application/vnd.docspec.blocknote+json` output.
+
+## Usage
+
+Start the server programmatically:
+
+```rust,no_run
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    docspec_http::serve("127.0.0.1", 3000).await
+}
+```
+
+Or use the `docspec http` CLI subcommand:
+
+```bash
+docspec http --host 127.0.0.1 --port 3000
+```
+
+## Endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/convert` | Convert Markdown to BlockNote JSON |
+| `GET` | `/health` | Health check (204 No Content) |
+
+## MIME Types
+
+| Direction | MIME Type |
+|-----------|-----------|
+| Input | `text/markdown` |
+| Output | `application/vnd.docspec.blocknote+json` |
+| Errors | `application/problem+json` (RFC 7807) |
+
+## Error Responses
+
+All errors return [RFC 7807](https://www.rfc-editor.org/rfc/rfc7807) problem+json:
+
+```json
+{
+  "type": "https://docspec.dev/errors/unsupported-media-type",
+  "title": "Unsupported Media Type",
+  "status": 415,
+  "detail": "Content-Type 'application/json' is not supported. Use text/markdown."
+}
+```
+
+## Documentation
+
+See the [main DocSpec repository](https://github.com/docspec/docspec) for full documentation.
+
+## License
+
+MIT OR Apache-2.0

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -1,0 +1,373 @@
+//! HTTP error types and RFC 7807 problem+json responses.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+/// Result type alias for HTTP handler operations.
+pub type Result<T> = core::result::Result<T, HttpError>;
+
+/// HTTP API error variants.
+///
+/// Each variant maps to a specific HTTP status code and RFC 7807 problem+json response.
+#[derive(Debug)]
+pub enum HttpError {
+    /// The request body is malformed (HTTP 400).
+    BadRequest {
+        /// Human-readable description of the problem.
+        detail: String,
+    },
+    /// Document conversion failed (HTTP 422).
+    Conversion(docspec_core::Error),
+    /// An unexpected internal error occurred (HTTP 500).
+    Internal {
+        /// Human-readable description of the internal error.
+        detail: String,
+    },
+    /// The requested output format is not acceptable (HTTP 406).
+    NotAcceptable {
+        /// The received Accept header value, if any.
+        received: Option<String>,
+    },
+    /// The requested resource was not found (HTTP 404).
+    NotFound,
+    /// The request Content-Type is not supported (HTTP 415).
+    UnsupportedMediaType {
+        /// The received Content-Type value, if any.
+        received: Option<String>,
+    },
+}
+
+/// RFC 7807 Problem Details object for JSON serialization.
+#[derive(Serialize)]
+struct ProblemJson {
+    /// Human-readable explanation specific to this occurrence.
+    detail: String,
+    /// HTTP status code.
+    status: u16,
+    /// Short human-readable summary of the problem type.
+    title: String,
+    /// URI reference identifying the problem type.
+    #[serde(rename = "type")]
+    type_: String,
+}
+
+impl core::fmt::Display for HttpError {
+    #[inline]
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::BadRequest { detail } => write!(f, "bad request: {detail}"),
+            Self::Conversion(err) => write!(f, "conversion failed: {err}"),
+            Self::Internal { detail } => write!(f, "internal error: {detail}"),
+            Self::NotAcceptable { received } => {
+                if let Some(accept) = received {
+                    write!(f, "not acceptable: {accept}")
+                } else {
+                    write!(f, "not acceptable")
+                }
+            }
+            Self::NotFound => write!(f, "not found"),
+            Self::UnsupportedMediaType { received } => {
+                if let Some(ct) = received {
+                    write!(f, "unsupported media type: {ct}")
+                } else {
+                    write!(f, "unsupported media type: Content-Type header missing")
+                }
+            }
+        }
+    }
+}
+
+impl core::error::Error for HttpError {
+    #[inline]
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self {
+            Self::Conversion(err) => Some(err),
+            Self::BadRequest { .. }
+            | Self::Internal { .. }
+            | Self::NotAcceptable { .. }
+            | Self::NotFound
+            | Self::UnsupportedMediaType { .. } => None,
+        }
+    }
+}
+
+impl IntoResponse for HttpError {
+    #[inline]
+    fn into_response(self) -> Response {
+        let (status, code, title, detail) = match &self {
+            Self::BadRequest { detail } => (
+                StatusCode::BAD_REQUEST,
+                "bad-request",
+                "Bad Request",
+                detail.clone(),
+            ),
+            Self::Conversion(_) => (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "conversion-failed",
+                "Conversion Failed",
+                "The document could not be converted. Check that the input is valid Markdown."
+                    .to_string(),
+            ),
+            Self::Internal { detail } => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "internal",
+                "Internal Server Error",
+                detail.clone(),
+            ),
+            Self::NotAcceptable { received } => (
+                StatusCode::NOT_ACCEPTABLE,
+                "not-acceptable",
+                "Not Acceptable",
+                received.as_deref().map_or_else(
+                    || "Requested output format is not available.".to_string(),
+                    |accept| {
+                        format!(
+                            "Accept '{accept}' is not satisfiable. Use application/vnd.docspec.blocknote+json or */*."
+                        )
+                    },
+                ),
+            ),
+            Self::NotFound => (
+                StatusCode::NOT_FOUND,
+                "not-found",
+                "Not Found",
+                "The requested resource does not exist.".to_string(),
+            ),
+            Self::UnsupportedMediaType { received } => (
+                StatusCode::UNSUPPORTED_MEDIA_TYPE,
+                "unsupported-media-type",
+                "Unsupported Media Type",
+                received.as_deref().map_or_else(
+                    || {
+                        "Content-Type header is missing or not supported. Use text/markdown."
+                            .to_string()
+                    },
+                    |ct| format!("Content-Type '{ct}' is not supported. Use text/markdown."),
+                ),
+            ),
+        };
+
+        tracing::debug!(error = %self, "HTTP error response");
+
+        let problem = ProblemJson {
+            detail,
+            status: status.as_u16(),
+            title: title.to_string(),
+            type_: format!("https://docspec.dev/errors/{code}"),
+        };
+
+        // All values passed to Response::builder() are compile-time constants or derived from
+        // StatusCode, so this builder call never fails. The unwrap_or_else fallback is required
+        // to satisfy the no-unwrap rule but is unreachable in practice.
+        let body = serde_json::to_vec(&problem).unwrap_or_else(
+            |_| br#"{"type":"https://docspec.dev/errors/internal","title":"Internal Server Error","status":500,"detail":"Failed to serialize error response."}"#.to_vec(),
+        );
+
+        Response::builder()
+            .status(status)
+            .header(
+                axum::http::header::CONTENT_TYPE,
+                crate::format::ERROR_PROBLEM_JSON,
+            )
+            .body(axum::body::Body::from(body))
+            .unwrap_or_else(|_| Response::new(axum::body::Body::empty()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::indexing_slicing)]
+    // Reason: Test code uses unwrap and JSON index notation for assertion clarity.
+
+    use axum::body::Body;
+    use axum::response::IntoResponse as _;
+    use http_body_util::BodyExt as _;
+
+    use super::*;
+
+    async fn body_bytes(body: Body) -> Vec<u8> {
+        body.collect().await.unwrap().to_bytes().to_vec()
+    }
+
+    fn parse_problem(bytes: &[u8]) -> serde_json::Value {
+        serde_json::from_slice(bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn unsupported_media_type_415() {
+        let resp = HttpError::UnsupportedMediaType { received: None }.into_response();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "application/problem+json"
+        );
+        let bytes = body_bytes(resp.into_body()).await;
+        let json = parse_problem(&bytes);
+        assert_eq!(
+            json["type"],
+            "https://docspec.dev/errors/unsupported-media-type"
+        );
+        assert_eq!(json["status"], 415);
+        assert_eq!(json["title"], "Unsupported Media Type");
+    }
+
+    #[tokio::test]
+    async fn not_acceptable_406() {
+        let resp = HttpError::NotAcceptable {
+            received: Some("text/html".into()),
+        }
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+        assert_eq!(
+            resp.headers().get("content-type").unwrap(),
+            "application/problem+json"
+        );
+        let bytes = body_bytes(resp.into_body()).await;
+        let json = parse_problem(&bytes);
+        assert_eq!(json["type"], "https://docspec.dev/errors/not-acceptable");
+        assert_eq!(json["status"], 406);
+    }
+
+    #[tokio::test]
+    async fn bad_request_400() {
+        let resp = HttpError::BadRequest {
+            detail: "invalid utf-8".into(),
+        }
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let bytes = body_bytes(resp.into_body()).await;
+        let json = parse_problem(&bytes);
+        assert_eq!(json["type"], "https://docspec.dev/errors/bad-request");
+        assert_eq!(json["status"], 400);
+    }
+
+    #[tokio::test]
+    async fn conversion_422() {
+        let err = docspec_core::Error::Other {
+            message: "parse error".into(),
+        };
+        let resp = HttpError::Conversion(err).into_response();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let bytes = body_bytes(resp.into_body()).await;
+        let json = parse_problem(&bytes);
+        assert_eq!(json["type"], "https://docspec.dev/errors/conversion-failed");
+        assert_eq!(json["status"], 422);
+    }
+
+    #[tokio::test]
+    async fn not_found_404() {
+        let resp = HttpError::NotFound.into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let bytes = body_bytes(resp.into_body()).await;
+        let json = parse_problem(&bytes);
+        assert_eq!(json["type"], "https://docspec.dev/errors/not-found");
+        assert_eq!(json["status"], 404);
+    }
+
+    #[tokio::test]
+    async fn internal_500() {
+        let resp = HttpError::Internal {
+            detail: "something broke".into(),
+        }
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let bytes = body_bytes(resp.into_body()).await;
+        let json = parse_problem(&bytes);
+        assert_eq!(json["type"], "https://docspec.dev/errors/internal");
+        assert_eq!(json["status"], 500);
+    }
+
+    #[test]
+    fn display_messages_cover_all_variants() {
+        assert_eq!(
+            HttpError::BadRequest {
+                detail: "bad utf-8".into(),
+            }
+            .to_string(),
+            "bad request: bad utf-8"
+        );
+        assert_eq!(
+            HttpError::Conversion(docspec_core::Error::Other {
+                message: "parse error".into(),
+            })
+            .to_string(),
+            "conversion failed: parse error"
+        );
+        assert_eq!(
+            HttpError::Internal {
+                detail: "boom".into(),
+            }
+            .to_string(),
+            "internal error: boom"
+        );
+        assert_eq!(
+            HttpError::NotAcceptable {
+                received: Some("text/html".into()),
+            }
+            .to_string(),
+            "not acceptable: text/html"
+        );
+        assert_eq!(
+            HttpError::NotAcceptable { received: None }.to_string(),
+            "not acceptable"
+        );
+        assert_eq!(HttpError::NotFound.to_string(), "not found");
+        assert_eq!(
+            HttpError::UnsupportedMediaType {
+                received: Some("application/json".into()),
+            }
+            .to_string(),
+            "unsupported media type: application/json"
+        );
+        assert_eq!(
+            HttpError::UnsupportedMediaType { received: None }.to_string(),
+            "unsupported media type: Content-Type header missing"
+        );
+    }
+
+    #[test]
+    fn source_only_conversion_has_underlying_error() {
+        assert!(
+            core::error::Error::source(&HttpError::Conversion(docspec_core::Error::Other {
+                message: "parse error".into(),
+            },))
+            .is_some()
+        );
+        assert!(core::error::Error::source(&HttpError::BadRequest {
+            detail: "bad".into(),
+        })
+        .is_none());
+        assert!(core::error::Error::source(&HttpError::Internal {
+            detail: "boom".into(),
+        })
+        .is_none());
+        assert!(core::error::Error::source(&HttpError::NotAcceptable { received: None }).is_none());
+        assert!(core::error::Error::source(&HttpError::NotFound).is_none());
+        assert!(
+            core::error::Error::source(&HttpError::UnsupportedMediaType { received: None })
+                .is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn conversion_422_and_not_acceptable_without_received() {
+        let conversion = HttpError::Conversion(docspec_core::Error::Other {
+            message: "parse error".into(),
+        })
+        .into_response();
+        assert_eq!(conversion.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let conversion_body = body_bytes(conversion.into_body()).await;
+        let conversion_json = parse_problem(&conversion_body);
+        assert_eq!(conversion_json["status"], 422);
+
+        let not_acceptable = HttpError::NotAcceptable { received: None }.into_response();
+        assert_eq!(not_acceptable.status(), StatusCode::NOT_ACCEPTABLE);
+        let not_acceptable_body = body_bytes(not_acceptable.into_body()).await;
+        let not_acceptable_json = parse_problem(&not_acceptable_body);
+        assert_eq!(
+            not_acceptable_json["detail"],
+            "Requested output format is not available."
+        );
+    }
+}

--- a/crates/docspec-http/src/format.rs
+++ b/crates/docspec-http/src/format.rs
@@ -1,0 +1,250 @@
+//! MIME type constants and content-type parsing helpers.
+
+/// MIME type for Markdown input.
+pub const INPUT_MARKDOWN: &str = "text/markdown";
+
+/// MIME type for `BlockNote` JSON output.
+pub const OUTPUT_BLOCKNOTE: &str = "application/vnd.docspec.blocknote+json";
+
+/// MIME type for RFC 7807 problem+json error responses.
+pub const ERROR_PROBLEM_JSON: &str = "application/problem+json";
+
+/// Returns `true` if the given Content-Type value indicates Markdown.
+///
+/// Accepts `text/markdown` with optional parameters (e.g., `; charset=utf-8`, `; variant=CommonMark`).
+/// Matching is case-insensitive.
+///
+/// # Examples
+///
+/// ```
+/// use docspec_http::format::is_markdown;
+/// assert!(is_markdown("text/markdown"));
+/// assert!(is_markdown("text/markdown; charset=utf-8"));
+/// assert!(!is_markdown("text/plain"));
+/// ```
+#[inline]
+#[must_use]
+pub fn is_markdown(content_type: &str) -> bool {
+    let base = content_type
+        .split(';')
+        .next()
+        .unwrap_or(content_type)
+        .trim();
+    base.eq_ignore_ascii_case("text/markdown")
+}
+
+/// Returns `true` if the given Accept header value accepts `BlockNote` JSON output.
+///
+/// Applies RFC 7231 §5.3.2 media-range precedence: the most specific matching
+/// range determines acceptability via its q-value, with the precedence order
+/// exact (`application/vnd.docspec.blocknote+json`) > subtype wildcard
+/// (`application/*`) > full wildcard (`*/*`). A more-specific `q=0` range
+/// overrides a less-specific `q>0` range, so
+/// `application/vnd.docspec.blocknote+json;q=0, */*` is rejected. Returns
+/// `true` when the header is absent (RFC 7231 §5.3.2).
+///
+/// # Examples
+///
+/// ```
+/// use docspec_http::format::accepts_blocknote;
+/// assert!(accepts_blocknote(None));
+/// assert!(accepts_blocknote(Some("*/*")));
+/// assert!(!accepts_blocknote(Some("text/html")));
+/// assert!(!accepts_blocknote(Some(
+///     "application/vnd.docspec.blocknote+json;q=0, */*"
+/// )));
+/// ```
+#[inline]
+#[must_use]
+pub fn accepts_blocknote(accept: Option<&str>) -> bool {
+    let Some(accept_str) = accept else {
+        return true;
+    };
+
+    let mut best_specificity: u8 = 0;
+    let mut best_q: f32 = 0.0;
+
+    for raw in accept_str.split(',') {
+        let mut parts = raw.trim().split(';');
+        // Reason: `str::split(';')` always yields at least one item, so `next()` cannot return None here.
+        let media = parts.next().unwrap_or("").trim();
+        let Some((raw_type, raw_subtype)) = media.split_once('/') else {
+            continue;
+        };
+        let type_t = raw_type.trim();
+        let subtype_t = raw_subtype.trim();
+
+        let specificity: u8 = if type_t.eq_ignore_ascii_case("application")
+            && subtype_t.eq_ignore_ascii_case("vnd.docspec.blocknote+json")
+        {
+            3
+        } else if type_t.eq_ignore_ascii_case("application") && subtype_t == "*" {
+            2
+        } else if type_t == "*" && subtype_t == "*" {
+            1
+        } else {
+            continue;
+        };
+
+        // Reason: RFC 7231 §5.3.1 defaults missing q to 1.0; invalid q values
+        // are ignored (treated as absent) to match permissive proxy behavior.
+        let mut q: f32 = 1.0;
+        for raw_param in parts {
+            let trimmed = raw_param.trim();
+            if let Some(q_str) = trimmed
+                .strip_prefix("q=")
+                .or_else(|| trimmed.strip_prefix("Q="))
+            {
+                if let Ok(parsed) = q_str.parse::<f32>() {
+                    q = parsed.clamp(0.0, 1.0);
+                }
+            }
+        }
+
+        if specificity > best_specificity {
+            best_specificity = specificity;
+            best_q = q;
+        }
+    }
+
+    best_specificity > 0 && best_q > 0.0
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    // Reason: Test code may use unwrap for assertion clarity.
+
+    use super::*;
+
+    #[test]
+    fn is_markdown_plain() {
+        assert!(is_markdown("text/markdown"));
+    }
+
+    #[test]
+    fn is_markdown_with_charset() {
+        assert!(is_markdown("text/markdown; charset=utf-8"));
+    }
+
+    #[test]
+    fn is_markdown_case_insensitive() {
+        assert!(is_markdown("TEXT/MARKDOWN"));
+        assert!(is_markdown("Text/Markdown"));
+    }
+
+    #[test]
+    fn is_markdown_rejects_plain_text() {
+        assert!(!is_markdown("text/plain"));
+    }
+
+    #[test]
+    fn is_markdown_rejects_json() {
+        assert!(!is_markdown("application/json"));
+    }
+
+    #[test]
+    fn accepts_blocknote_none() {
+        assert!(accepts_blocknote(None));
+    }
+
+    #[test]
+    fn accepts_blocknote_wildcard() {
+        assert!(accepts_blocknote(Some("*/*")));
+    }
+
+    #[test]
+    fn accepts_blocknote_rejects_json() {
+        assert!(!accepts_blocknote(Some("application/json")));
+    }
+
+    #[test]
+    fn accepts_blocknote_rejects_empty_media_range() {
+        assert!(!accepts_blocknote(Some("")));
+    }
+
+    #[test]
+    fn accepts_blocknote_rejects_missing_subtype() {
+        assert!(!accepts_blocknote(Some("application")));
+    }
+
+    #[test]
+    fn accepts_blocknote_exact() {
+        assert!(accepts_blocknote(Some(
+            "application/vnd.docspec.blocknote+json"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_with_quality() {
+        assert!(accepts_blocknote(Some(
+            "application/vnd.docspec.blocknote+json; q=0.9, text/html"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_rejects_jsonp_suffix() {
+        assert!(!accepts_blocknote(Some(
+            "application/vnd.docspec.blocknote+jsonp"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_rejects_exact_q_zero() {
+        assert!(!accepts_blocknote(Some(
+            "application/vnd.docspec.blocknote+json;q=0"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_rejects_wildcard_q_zero() {
+        assert!(!accepts_blocknote(Some("*/*;q=0")));
+    }
+
+    #[test]
+    fn accepts_blocknote_accepts_second_media_range() {
+        assert!(accepts_blocknote(Some(
+            "application/json, application/vnd.docspec.blocknote+json"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_accepts_application_wildcard_with_quality() {
+        assert!(accepts_blocknote(Some(
+            "text/html;q=0.9, application/*;q=0.8"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_honors_multiple_quality_ranges() {
+        assert!(accepts_blocknote(Some(
+            "text/html;q=0.9, application/json;q=0, application/vnd.docspec.blocknote+json;q=0.2"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_ignores_invalid_quality_value() {
+        assert!(accepts_blocknote(Some(
+            "application/vnd.docspec.blocknote+json;q=maybe"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_exact_q_zero_overrides_wildcard_q_one() {
+        assert!(!accepts_blocknote(Some(
+            "application/vnd.docspec.blocknote+json;q=0, */*;q=1"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_exact_q_one_overrides_wildcard_q_zero() {
+        assert!(accepts_blocknote(Some(
+            "application/vnd.docspec.blocknote+json;q=1, */*;q=0"
+        )));
+    }
+
+    #[test]
+    fn accepts_blocknote_subtype_wildcard_q_zero_overrides_full_wildcard_q_one() {
+        assert!(!accepts_blocknote(Some("application/*;q=0, */*;q=1")));
+    }
+}

--- a/crates/docspec-http/src/handler.rs
+++ b/crates/docspec-http/src/handler.rs
@@ -1,0 +1,445 @@
+//! HTTP request handlers for the `DocSpec` API.
+
+use std::io::{ErrorKind, Write};
+
+use axum::body::Body;
+use axum::http::{header::CONTENT_TYPE, HeaderMap, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use bytes::Bytes;
+use docspec_core::{EventSink as _, EventSource as _};
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::wrappers::ReceiverStream;
+
+use crate::error::{HttpError, Result};
+use crate::format;
+
+/// Maximum buffered bytes before [`ChannelWriter`] emits a chunk.
+///
+/// Caps both the internal accumulation buffer and the chunk size used when
+/// splitting oversized incoming slices, keeping per-chunk memory bounded.
+const CHANNEL_CHUNK_SIZE: usize = 8192;
+
+/// Bridges synchronous [`Write`] calls to an async channel.
+///
+/// Each emitted chunk is at most [`CHANNEL_CHUNK_SIZE`] (8 KiB), regardless of
+/// the size of incoming `write` slices: oversized slices are split into
+/// `CHANNEL_CHUNK_SIZE`-sized chunks sent directly to the channel rather than
+/// re-buffered. On drop, flushes remaining buffered bytes best-effort. Channel
+/// send failures are mapped to [`ErrorKind::BrokenPipe`].
+struct ChannelWriter {
+    /// Buffered output awaiting channel send. Never grows past [`CHANNEL_CHUNK_SIZE`].
+    buf: Vec<u8>,
+    /// Bounded sender consumed by the streaming HTTP response body.
+    tx: mpsc::Sender<std::result::Result<Bytes, std::io::Error>>,
+}
+
+impl ChannelWriter {
+    /// Creates a new writer backed by the provided bounded channel sender.
+    // Reason: Constructor documents the sync/async bridge boundary despite one production call site.
+    #[allow(clippy::single_call_fn)]
+    #[inline]
+    fn new(tx: mpsc::Sender<std::result::Result<Bytes, std::io::Error>>) -> Self {
+        Self {
+            buf: Vec::new(),
+            tx,
+        }
+    }
+}
+
+impl Drop for ChannelWriter {
+    #[inline]
+    fn drop(&mut self) {
+        match self.flush() {
+            Ok(()) | Err(_) => {}
+        }
+    }
+}
+
+impl Write for ChannelWriter {
+    #[inline]
+    fn flush(&mut self) -> std::io::Result<()> {
+        if self.buf.is_empty() {
+            return Ok(());
+        }
+        let taken = std::mem::take(&mut self.buf);
+        self.tx
+            .blocking_send(Ok(Bytes::from(taken)))
+            .map_err(|_send_error| {
+                std::io::Error::new(ErrorKind::BrokenPipe, "client disconnected")
+            })?;
+        Ok(())
+    }
+
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        // Reason: For oversized writes, drain self.buf first to preserve byte
+        // order, then send CHANNEL_CHUNK_SIZE slices directly so a single large
+        // write never emits one large chunk.
+        if buf.len() >= CHANNEL_CHUNK_SIZE {
+            self.flush()?;
+            let mut remaining = buf;
+            while remaining.len() >= CHANNEL_CHUNK_SIZE {
+                let (chunk, tail) = remaining.split_at(CHANNEL_CHUNK_SIZE);
+                self.tx
+                    .blocking_send(Ok(Bytes::copy_from_slice(chunk)))
+                    .map_err(|_send_error| {
+                        std::io::Error::new(ErrorKind::BrokenPipe, "client disconnected")
+                    })?;
+                remaining = tail;
+            }
+            self.buf.extend_from_slice(remaining);
+        } else {
+            self.buf.extend_from_slice(buf);
+            if self.buf.len() >= CHANNEL_CHUNK_SIZE {
+                self.flush()?;
+            }
+        }
+        Ok(buf.len())
+    }
+}
+
+/// Handles `POST /convert` — converts Markdown to `BlockNote` JSON.
+///
+/// Accepts `text/markdown` with optional parameters and returns
+/// `application/vnd.docspec.blocknote+json` as a streaming response.
+///
+/// # Errors
+///
+/// Returns [`HttpError::UnsupportedMediaType`] if `Content-Type` is not `text/markdown`.
+/// Returns [`HttpError::NotAcceptable`] if `Accept` does not include `BlockNote` JSON.
+/// Returns [`HttpError::BadRequest`] if the body is not valid UTF-8.
+#[tracing::instrument(skip_all, fields(content_type = tracing::field::Empty, accept = tracing::field::Empty))]
+#[inline]
+pub async fn convert_handler(headers: HeaderMap, body: Bytes) -> Result<Response> {
+    let content_type = headers
+        .get(CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok());
+    if !content_type.is_some_and(format::is_markdown) {
+        return Err(HttpError::UnsupportedMediaType {
+            received: content_type.map(str::to_string),
+        });
+    }
+
+    let accept = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|value| value.to_str().ok());
+
+    let span = tracing::Span::current();
+    if let Some(ct) = content_type {
+        span.record("content_type", ct);
+    }
+    if let Some(acc) = accept {
+        span.record("accept", acc);
+    }
+
+    if !format::accepts_blocknote(accept) {
+        return Err(HttpError::NotAcceptable {
+            received: accept.map(str::to_string),
+        });
+    }
+
+    let body_string =
+        String::from_utf8(body.to_vec()).map_err(|_utf8_error| HttpError::BadRequest {
+            detail: "request body is not valid UTF-8".into(),
+        })?;
+
+    let (chunk_tx, chunk_rx) = mpsc::channel::<std::result::Result<Bytes, std::io::Error>>(32);
+    let (start_signal_tx, start_rx) = oneshot::channel::<Result<()>>();
+    tokio::task::spawn_blocking(move || run_conversion(&body_string, &chunk_tx, start_signal_tx));
+
+    match start_rx.await {
+        Ok(Ok(())) => {
+            let stream = ReceiverStream::new(chunk_rx);
+            let mut response = Response::new(Body::from_stream(stream));
+            *response.status_mut() = StatusCode::OK;
+            response.headers_mut().insert(
+                CONTENT_TYPE,
+                HeaderValue::from_static(format::OUTPUT_BLOCKNOTE),
+            );
+            Ok(response)
+        }
+        Ok(Err(http_err)) => Err(http_err),
+        Err(_recv_error) => Err(HttpError::Internal {
+            detail: "conversion task aborted before signaling".to_string(),
+        }),
+    }
+}
+
+// Reason: Extracted from the `spawn_blocking` closure body so the streaming pipeline
+// can be unit-tested without going through the public `convert_handler` entry point.
+#[allow(clippy::single_call_fn)]
+fn run_conversion(
+    body_string: &str,
+    chunk_tx: &mpsc::Sender<std::result::Result<Bytes, std::io::Error>>,
+    start_signal_tx: oneshot::Sender<Result<()>>,
+) {
+    let mut start_tx = Some(start_signal_tx);
+    let writer = ChannelWriter::new(chunk_tx.clone());
+    let mut sink = docspec_core::StackTrackingSink::new(
+        docspec_blocknote_writer::BlockNoteWriter::new(writer),
+    );
+    let mut reader = docspec_markdown_reader::MarkdownReader::new(body_string);
+    loop {
+        match reader.next_event() {
+            Ok(Some(event)) => {
+                if let Err(err) = sink.handle_event(event) {
+                    tracing::debug!(error = %err, "conversion error in spawn_blocking");
+                    signal_conversion_error(&mut start_tx, err, chunk_tx);
+                    return;
+                }
+                signal_start_ok(&mut start_tx);
+            }
+            Ok(None) => break,
+            Err(err) => {
+                tracing::debug!(error = %err, "reader error in spawn_blocking");
+                signal_conversion_error(&mut start_tx, err, chunk_tx);
+                return;
+            }
+        }
+    }
+    if let Err(err) = sink.finish() {
+        tracing::debug!(error = %err, "sink finish error in spawn_blocking");
+        signal_conversion_error(&mut start_tx, err, chunk_tx);
+        return;
+    }
+    signal_start_ok(&mut start_tx);
+}
+
+fn signal_start_ok(start_tx: &mut Option<oneshot::Sender<Result<()>>>) {
+    if let Some(tx) = start_tx.take() {
+        drop(tx.send(Ok(())));
+    }
+}
+
+fn signal_conversion_error(
+    start_tx: &mut Option<oneshot::Sender<Result<()>>>,
+    err: docspec_core::Error,
+    chunk_tx: &mpsc::Sender<std::result::Result<Bytes, std::io::Error>>,
+) {
+    if let Some(tx) = start_tx.take() {
+        drop(tx.send(Err(HttpError::Conversion(err))));
+    } else {
+        drop(chunk_tx.blocking_send(Err(std::io::Error::other("mid-stream conversion error"))));
+    }
+}
+
+/// Handles `GET /health` — returns 204 No Content with an empty body.
+///
+/// No `Content-Type` header is set. No body is returned.
+#[inline]
+pub async fn health_handler() -> impl IntoResponse {
+    StatusCode::NO_CONTENT
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::indexing_slicing, clippy::unwrap_used)]
+    // Reason: Test code uses unwrap and index notation for assertion clarity.
+
+    use axum::http::{header, HeaderValue};
+    use http_body_util::BodyExt as _;
+
+    use super::*;
+
+    async fn collect_body(body: Body) -> Vec<u8> {
+        body.collect().await.unwrap().to_bytes().to_vec()
+    }
+
+    fn make_headers(content_type: Option<&str>, accept: Option<&str>) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        if let Some(ct) = content_type {
+            headers.insert(header::CONTENT_TYPE, HeaderValue::from_str(ct).unwrap());
+        }
+        if let Some(acc) = accept {
+            headers.insert(header::ACCEPT, HeaderValue::from_str(acc).unwrap());
+        }
+        headers
+    }
+
+    #[tokio::test]
+    async fn convert_406() {
+        let headers = make_headers(Some("text/markdown"), Some("text/html"));
+        let body = Bytes::from("# Hello\n");
+        let err = convert_handler(headers, body).await.unwrap_err();
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+    }
+
+    #[tokio::test]
+    async fn convert_415_missing_content_type() {
+        let headers = make_headers(None, None);
+        let body = Bytes::from("# Hello\n");
+        let err = convert_handler(headers, body).await.unwrap_err();
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn convert_415_wrong_content_type() {
+        let headers = make_headers(Some("application/json"), None);
+        let body = Bytes::from("{}");
+        let err = convert_handler(headers, body).await.unwrap_err();
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    }
+
+    #[tokio::test]
+    async fn convert_charset_accepted() {
+        let headers = make_headers(Some("text/markdown; charset=utf-8"), None);
+        let body = Bytes::from("# Hello\n");
+        let resp = convert_handler(headers, body)
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn convert_happy() {
+        let headers = make_headers(Some("text/markdown"), None);
+        let body = Bytes::from("# Hello\n");
+        let resp = convert_handler(headers, body)
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/vnd.docspec.blocknote+json"
+        );
+        let bytes = collect_body(resp.into_body()).await;
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert!(json.is_array(), "expected JSON array");
+    }
+
+    #[tokio::test]
+    async fn convert_empty_body_returns_empty_array() {
+        let headers = make_headers(Some("text/markdown"), None);
+        let resp = convert_handler(headers, Bytes::new())
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = collect_body(resp.into_body()).await;
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn conversion_error_before_stream_returns_422() {
+        let (chunk_tx, mut chunk_rx) = mpsc::channel(1);
+        let (start_signal_tx, start_rx) = oneshot::channel();
+        let mut start_tx = Some(start_signal_tx);
+
+        signal_conversion_error(
+            &mut start_tx,
+            docspec_core::Error::Other {
+                message: "parse error".to_string(),
+            },
+            &chunk_tx,
+        );
+
+        let err = start_rx.await.unwrap().unwrap_err();
+        assert_eq!(
+            err.into_response().status(),
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+        assert!(chunk_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn conversion_error_after_stream_sends_body_error() {
+        let (chunk_tx, mut chunk_rx) = mpsc::channel(1);
+        let mut start_tx = None;
+
+        signal_conversion_error(
+            &mut start_tx,
+            docspec_core::Error::Other {
+                message: "late error".to_string(),
+            },
+            &chunk_tx,
+        );
+
+        let sent = chunk_rx.blocking_recv().unwrap();
+        assert!(sent.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_conversion_writer_failure_terminates_stream() {
+        // Given: a receiver dropped before any send, and a body large enough to exceed
+        // the 8 KiB ChannelWriter buffer so the writer is forced to flush at least once.
+        let (chunk_tx, chunk_rx) = mpsc::channel(1);
+        drop(chunk_rx);
+        let (start_signal_tx, start_rx) = oneshot::channel::<Result<()>>();
+        let body = "# Heading\n\n".repeat(2000);
+
+        tokio::task::spawn_blocking(move || {
+            super::run_conversion(&body, &chunk_tx, start_signal_tx);
+        })
+        .await
+        .unwrap();
+
+        // Then: start_rx resolves with either Ok (first event flushed before failure) or
+        // Err (failure observed pre-start); either path exercises the writer-error branch.
+        let result = start_rx.await.unwrap();
+        drop(result);
+    }
+
+    #[tokio::test]
+    async fn convert_invalid_utf8() {
+        let headers = make_headers(Some("text/markdown"), None);
+        let body = Bytes::from(vec![0xFF, 0xFE, 0x00]);
+        let err = convert_handler(headers, body).await.unwrap_err();
+        let resp = err.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn channel_writer_chunks_large_single_write() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut writer = ChannelWriter::new(tx);
+        let payload = vec![b'a'; CHANNEL_CHUNK_SIZE * 3 + 100];
+        let n = writer.write(&payload).unwrap();
+        assert_eq!(n, payload.len());
+        let mut chunks: Vec<Bytes> = Vec::new();
+        while let Ok(item) = rx.try_recv() {
+            chunks.push(item.unwrap());
+        }
+        assert_eq!(chunks.len(), 3);
+        for chunk in &chunks {
+            assert_eq!(chunk.len(), CHANNEL_CHUNK_SIZE);
+        }
+        writer.flush().unwrap();
+        let tail = rx.try_recv().unwrap().unwrap();
+        assert_eq!(tail.len(), 100);
+    }
+
+    #[test]
+    fn channel_writer_flushes_pending_buffer_before_large_write() {
+        let (tx, mut rx) = mpsc::channel(16);
+        let mut writer = ChannelWriter::new(tx);
+        writer.write_all(b"prefix").unwrap();
+        let payload = vec![b'x'; CHANNEL_CHUNK_SIZE * 2];
+        writer.write_all(&payload).unwrap();
+        let mut chunks: Vec<Bytes> = Vec::new();
+        while let Ok(item) = rx.try_recv() {
+            chunks.push(item.unwrap());
+        }
+        assert_eq!(chunks[0].as_ref(), b"prefix");
+        assert_eq!(chunks.len(), 3);
+        for chunk in chunks.iter().skip(1) {
+            assert_eq!(chunk.len(), CHANNEL_CHUNK_SIZE);
+        }
+        let total: usize = chunks.iter().map(Bytes::len).sum();
+        assert_eq!(total, b"prefix".len() + CHANNEL_CHUNK_SIZE * 2);
+    }
+
+    #[tokio::test]
+    async fn health_204_empty() {
+        let resp = health_handler().await.into_response();
+        assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+        assert!(resp.headers().get(header::CONTENT_TYPE).is_none());
+        let bytes = collect_body(resp.into_body()).await;
+        assert!(bytes.is_empty());
+    }
+}

--- a/crates/docspec-http/src/lib.rs
+++ b/crates/docspec-http/src/lib.rs
@@ -1,0 +1,16 @@
+//! HTTP API server for `DocSpec` document conversion.
+//!
+//! Exposes the `DocSpec` streaming pipeline over HTTP using Axum 0.8.
+//! Accepts `text/markdown` input and returns `application/vnd.docspec.blocknote+json`.
+
+// Reason: This is a server crate targeting std environments, not embedded/no_std.
+#![allow(clippy::std_instead_of_core)]
+
+pub mod error;
+pub mod format;
+pub mod handler;
+pub mod router;
+pub mod server;
+pub mod tracing_init;
+
+pub use server::serve;

--- a/crates/docspec-http/src/router.rs
+++ b/crates/docspec-http/src/router.rs
@@ -1,0 +1,106 @@
+//! Axum router assembly with middleware stack.
+
+use axum::routing::{get, post};
+use axum::Router;
+use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
+use tower_http::trace::TraceLayer;
+
+use crate::error::HttpError;
+use crate::handler::{convert_handler, health_handler};
+
+/// Builds the application router with all routes and middleware.
+///
+/// Routes:
+/// - `POST /convert` — Markdown to `BlockNote` JSON conversion
+/// - `GET /health` — Health check (204 No Content)
+///
+/// Middleware stack (outermost first — `tower`'s `.layer()` wraps the existing
+/// service, so the last `.layer(...)` call in source order is the outermost
+/// layer at runtime):
+/// 1. [`SetRequestIdLayer`] — generates `x-request-id` UUID per request
+/// 2. [`PropagateRequestIdLayer`] — copies `x-request-id` to response headers
+/// 3. [`TraceLayer`] — logs method, path, status, latency
+///
+/// Unknown routes return 404 with RFC 7807 problem+json.
+#[inline]
+pub fn router() -> Router {
+    Router::new()
+        .route("/convert", post(convert_handler))
+        .route("/health", get(health_handler))
+        .fallback(fallback_handler)
+        .layer(TraceLayer::new_for_http())
+        .layer(PropagateRequestIdLayer::x_request_id())
+        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+}
+
+/// Handles unknown routes with a 404 RFC 7807 problem+json response.
+// Reason: This function is called only via Axum's fallback mechanism, not from production Rust code.
+#[allow(clippy::single_call_fn)]
+async fn fallback_handler() -> HttpError {
+    HttpError::NotFound
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::indexing_slicing, clippy::single_call_fn)]
+    // Reason: Test code uses unwrap, index notation, and small helpers called once for assertion clarity.
+
+    use axum::body::Body;
+    use axum::http::{header, Method, Request, StatusCode};
+    use http_body_util::BodyExt as _;
+    use tower::ServiceExt as _;
+
+    use super::*;
+
+    async fn collect_body(body: Body) -> Vec<u8> {
+        body.collect().await.unwrap().to_bytes().to_vec()
+    }
+
+    #[tokio::test]
+    async fn convert_route_wired() {
+        let app = router();
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/convert")
+            .header(header::CONTENT_TYPE, "text/markdown")
+            .body(Body::from("# Hello\n"))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/vnd.docspec.blocknote+json"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_id_header_present() {
+        let app = router();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert!(resp.headers().get("x-request-id").is_some());
+    }
+
+    #[tokio::test]
+    async fn unknown_route_404() {
+        let app = router();
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/unknown")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            resp.headers().get(header::CONTENT_TYPE).unwrap(),
+            "application/problem+json"
+        );
+        let bytes = collect_body(resp.into_body()).await;
+        let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(json["type"], "https://docspec.dev/errors/not-found");
+    }
+}

--- a/crates/docspec-http/src/server.rs
+++ b/crates/docspec-http/src/server.rs
@@ -1,0 +1,188 @@
+//! Server lifecycle: bind, serve, graceful shutdown.
+
+use std::future::Future;
+use std::net::{IpAddr, SocketAddr};
+
+use crate::router;
+
+/// Starts the HTTP server and blocks until a shutdown signal is received.
+///
+/// Binds to `host:port` and serves the `DocSpec` API. Shuts down gracefully on
+/// `SIGINT` (Ctrl-C) or `SIGTERM` (Unix only), draining in-flight requests
+/// without a timeout.
+///
+/// # Errors
+///
+/// Returns an error if the address cannot be parsed or the port is already in use.
+///
+/// # Examples
+///
+/// ```no_run
+/// # async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// docspec_http::serve("127.0.0.1", 3000).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub async fn serve(host: &str, port: u16) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    serve_until(host, port, shutdown_signal()).await
+}
+
+// Reason: Testable server lifecycle helper is intentionally called only through `serve` in production.
+#[allow(clippy::single_call_fn)]
+async fn serve_until<F>(
+    host: &str,
+    port: u16,
+    shutdown: F,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let ip: IpAddr = host.parse()?;
+    let addr = SocketAddr::from((ip, port));
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    let bound_addr = listener.local_addr()?;
+    tracing::info!(addr = %bound_addr, "docspec-http listening");
+    axum::serve(listener, router::router())
+        .with_graceful_shutdown(shutdown)
+        .await?;
+    Ok(())
+}
+
+/// Waits for a shutdown signal: Ctrl-C on all platforms, SIGTERM on Unix.
+// Reason: This lifecycle helper is intentionally called only by `serve`.
+#[allow(clippy::single_call_fn)]
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if tokio::signal::ctrl_c().await.is_err() {
+            tracing::warn!("failed to install Ctrl+C handler");
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => tracing::warn!(error = %e, "failed to install SIGTERM handler"),
+        }
+    };
+
+    #[cfg(unix)]
+    wait_for_shutdown(ctrl_c, terminate).await;
+
+    #[cfg(not(unix))]
+    wait_for_shutdown(ctrl_c).await;
+}
+
+#[cfg(unix)]
+// Reason: Extracted to keep shutdown race selection directly testable.
+#[allow(clippy::single_call_fn)]
+async fn wait_for_shutdown<C, T>(ctrl_c: C, terminate: T)
+where
+    C: Future<Output = ()>,
+    T: Future<Output = ()>,
+{
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+    tracing::info!("graceful shutdown initiated");
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown<C>(ctrl_c: C)
+where
+    C: Future<Output = ()>,
+{
+    ctrl_c.await;
+    tracing::info!("graceful shutdown initiated");
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::single_call_fn, clippy::unwrap_used)]
+    // Reason: Test code uses panic/unwrap for assertion clarity; helpers are called once per test.
+
+    use std::time::Duration;
+
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn bind_in_use_errors() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let port = addr.port();
+
+        let result = crate::serve("127.0.0.1", port).await;
+
+        assert!(result.is_err(), "expected bind to fail on occupied port");
+        drop(listener);
+    }
+
+    #[tokio::test]
+    async fn start_and_shutdown() {
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            super::serve_until("127.0.0.1", 0, async {}),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(())) => {}
+            Err(elapsed) => panic!("server did not shut down within timeout: {elapsed}"),
+            Ok(Err(e)) => panic!("server failed to start: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn ipv6_bind_supported() {
+        if TcpListener::bind("[::1]:0").await.is_err() {
+            return;
+        }
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            super::serve_until("::1", 0, async {}),
+        )
+        .await;
+
+        match result {
+            Ok(Ok(())) => {}
+            Err(elapsed) => panic!("IPv6 server did not shut down within timeout: {elapsed}"),
+            Ok(Err(e)) => panic!("IPv6 server failed to start: {e}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_host_returns_error() {
+        let result = super::serve_until("not an ip address", 0, async {}).await;
+
+        assert!(result.is_err(), "expected host parsing to fail");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_helper_returns_on_ctrl_c() {
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            super::wait_for_shutdown(async {}, std::future::pending::<()>()),
+        )
+        .await;
+
+        assert!(result.is_ok(), "shutdown helper did not return on ctrl-c");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shutdown_helper_returns_on_sigterm() {
+        let result = tokio::time::timeout(
+            Duration::from_millis(200),
+            super::wait_for_shutdown(std::future::pending::<()>(), async {}),
+        )
+        .await;
+
+        assert!(result.is_ok(), "shutdown helper did not return on SIGTERM");
+    }
+}

--- a/crates/docspec-http/src/tracing_init.rs
+++ b/crates/docspec-http/src/tracing_init.rs
@@ -1,0 +1,152 @@
+//! Tracing subscriber initialization.
+//!
+//! Call [`init`] once at process start, before any `tracing::*!` macros.
+//! Repeated calls succeed (no-op) once a global subscriber is already
+//! installed, which makes the function safe to call from multiple tests.
+//! Any other [`tracing_subscriber`] initialization error is propagated to
+//! the caller. If the provided `level` is invalid and `RUST_LOG` is not
+//! set or is also invalid, returns an error without installing a subscriber.
+
+/// Log output format for the HTTP server.
+///
+/// This is a plain enum with no `clap` dependency. The CLI crate defines
+/// a separate `LogFormatArg` enum with `clap::ValueEnum` and converts via `From`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogFormat {
+    /// Machine-readable JSON logs (for production/log aggregation).
+    Json,
+    /// Human-readable pretty-printed logs (default for development).
+    Pretty,
+}
+
+/// Initializes the global tracing subscriber.
+///
+/// `RUST_LOG` takes precedence when it is set to a valid filter directive. Otherwise,
+/// `level` is used as the fallback. Repeated calls after a subscriber has already
+/// been installed succeed as a no-op.
+///
+/// # Errors
+///
+/// Returns an error if neither `RUST_LOG` nor `level` contains a valid tracing filter directive.
+///
+/// # Examples
+///
+/// ```no_run
+/// use docspec_http::tracing_init::{init, LogFormat};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// init("info", LogFormat::Pretty)?;
+/// # Ok(())
+/// # }
+/// ```
+#[inline]
+pub fn init(level: &str, format: LogFormat) -> Result<(), Box<dyn core::error::Error>> {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .or_else(|_| tracing_subscriber::EnvFilter::try_new(level))?;
+
+    let result = match format {
+        LogFormat::Json => tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .json()
+            .try_init(),
+        LogFormat::Pretty => tracing_subscriber::fmt()
+            .with_env_filter(filter)
+            .pretty()
+            .try_init(),
+    };
+
+    match result {
+        Ok(()) => Ok(()),
+        Err(err) if err.to_string().contains("global default") => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    // Reason: Test code may use unwrap for assertion clarity.
+
+    use std::sync::Mutex;
+
+    use super::*;
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_rust_log<T>(rust_log_value: Option<&str>, test: impl FnOnce() -> T) -> T {
+        let guard = ENV_LOCK.lock().unwrap();
+        let original = std::env::var_os("RUST_LOG");
+        match rust_log_value {
+            Some(env_value) => std::env::set_var("RUST_LOG", env_value),
+            None => std::env::remove_var("RUST_LOG"),
+        }
+        let result = test();
+        match original {
+            Some(original_value) => std::env::set_var("RUST_LOG", original_value),
+            None => std::env::remove_var("RUST_LOG"),
+        }
+        drop(guard);
+        result
+    }
+
+    #[test]
+    fn idempotent() {
+        // First call
+        let r1 = init("info", LogFormat::Pretty);
+        assert!(r1.is_ok(), "first init failed: {r1:?}");
+        // Second call — must not panic or return Err
+        let r2 = init("info", LogFormat::Pretty);
+        assert!(r2.is_ok(), "second init failed: {r2:?}");
+    }
+
+    #[test]
+    fn json_format_initializes() {
+        let r = init("debug", LogFormat::Json);
+        assert!(r.is_ok(), "json format init failed: {r:?}");
+    }
+
+    #[test]
+    fn invalid_level_returns_error() {
+        with_rust_log(None, || {
+            let r = init("docspec=notalevel", LogFormat::Pretty);
+            assert!(r.is_err(), "invalid fallback level should error");
+        });
+    }
+
+    #[test]
+    fn rust_log_precedence_allows_invalid_level() {
+        with_rust_log(Some("info"), || {
+            let r = init("docspec=notalevel", LogFormat::Pretty);
+            assert!(r.is_ok(), "valid RUST_LOG should take precedence");
+        });
+    }
+
+    #[test]
+    fn falls_back_to_level_when_rust_log_absent() {
+        with_rust_log(None, || {
+            let r = init("debug", LogFormat::Pretty);
+            assert!(r.is_ok(), "valid fallback level should initialize");
+        });
+    }
+
+    #[test]
+    fn falls_back_to_level_when_rust_log_invalid() {
+        with_rust_log(Some("docspec=notalevel"), || {
+            let r = init("warn", LogFormat::Pretty);
+            assert!(r.is_ok(), "invalid RUST_LOG should fall back to level");
+        });
+    }
+
+    #[test]
+    fn restores_existing_rust_log_after_scoped_test() {
+        let guard = ENV_LOCK.lock().unwrap();
+        std::env::set_var("RUST_LOG", "error");
+        drop(guard);
+
+        with_rust_log(None, || {
+            assert!(std::env::var_os("RUST_LOG").is_none());
+        });
+
+        assert_eq!(std::env::var("RUST_LOG").unwrap(), "error");
+        std::env::remove_var("RUST_LOG");
+    }
+}

--- a/crates/docspec-http/tests/conversion.rs
+++ b/crates/docspec-http/tests/conversion.rs
@@ -1,0 +1,189 @@
+//! Integration tests for the `DocSpec` HTTP API.
+
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::indexing_slicing,
+    clippy::single_call_fn
+)]
+// Reason: Integration test code uses unwrap, index notation, and small helpers for assertion clarity.
+
+use axum::body::Body;
+use axum::http::{header, Method, Request, StatusCode};
+use bytes::Bytes;
+use docspec_http::router::router;
+use http_body_util::BodyExt as _;
+use tower::ServiceExt as _;
+
+async fn collect_body(body: Body) -> Vec<u8> {
+    body.collect().await.unwrap().to_bytes().to_vec()
+}
+
+fn markdown_request(body: &str) -> Request<Body> {
+    Request::builder()
+        .method(Method::POST)
+        .uri("/convert")
+        .header(header::CONTENT_TYPE, "text/markdown")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn charset_parameter_accepted() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/convert")
+        .header(header::CONTENT_TYPE, "text/markdown; charset=utf-8")
+        .body(Body::from("# Hello\n"))
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn concurrent_ten_requests() {
+    let mut set = tokio::task::JoinSet::new();
+    for i in 0..10 {
+        let req = markdown_request(&format!("# Request {i}\n"));
+        set.spawn(router().oneshot(req));
+    }
+    while let Some(result) = set.join_next().await {
+        let resp = result.unwrap().unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}
+
+#[tokio::test]
+async fn empty_body_returns_200_empty_array() {
+    let resp = router().oneshot(markdown_request("")).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = collect_body(resp.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json.is_array());
+}
+
+#[tokio::test]
+async fn happy_path_returns_200_blocknote() {
+    let resp = router()
+        .oneshot(markdown_request("# Hello\n"))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/vnd.docspec.blocknote+json"
+    );
+    let bytes = collect_body(resp.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json.is_array());
+}
+
+#[tokio::test]
+async fn health_returns_204_no_content() {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert!(resp.headers().get(header::CONTENT_TYPE).is_none());
+    let bytes = collect_body(resp.into_body()).await;
+    assert!(bytes.is_empty());
+}
+
+#[tokio::test]
+async fn invalid_utf8_returns_400() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/convert")
+        .header(header::CONTENT_TYPE, "text/markdown")
+        .body(Body::from(Bytes::from(vec![0xFF, 0xFE, 0x00])))
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn large_markdown_returns_200() {
+    let large_body = "# Heading\n\nParagraph text. ".repeat(40_000);
+    let resp = router()
+        .oneshot(markdown_request(&large_body))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = collect_body(resp.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert!(json.is_array());
+}
+
+#[tokio::test]
+async fn missing_content_type_returns_415() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/convert")
+        .body(Body::from("# Hello\n"))
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn unacceptable_accept_returns_406() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/convert")
+        .header(header::CONTENT_TYPE, "text/markdown")
+        .header(header::ACCEPT, "text/html")
+        .body(Body::from("# Hello\n"))
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_ACCEPTABLE);
+}
+
+#[tokio::test]
+async fn unknown_route_returns_404_problem_json() {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/unknown")
+        .body(Body::empty())
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+    let bytes = collect_body(resp.into_body()).await;
+    let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(json["type"], "https://docspec.dev/errors/not-found");
+}
+
+#[tokio::test]
+async fn wildcard_accept_returns_200() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/convert")
+        .header(header::CONTENT_TYPE, "text/markdown")
+        .header(header::ACCEPT, "*/*")
+        .body(Body::from("# Hello\n"))
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn wrong_content_type_returns_415() {
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/convert")
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+    let resp = router().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+    assert_eq!(
+        resp.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+}

--- a/crates/docspec-http/tests/shutdown.rs
+++ b/crates/docspec-http/tests/shutdown.rs
@@ -1,0 +1,38 @@
+//! End-to-end shutdown test.
+//!
+//! Installs a SIGTERM handler in the test process before spawning the server so the OS
+//! cannot default-kill the test between our `kill()` call and the server installing its
+//! own handler. The test then retry-sends SIGTERM until the server task finishes,
+//! eliminating the race over signal-handler installation timing.
+//!
+//! Lives in its own integration-test binary so process-wide signals cannot disturb other
+//! tests in the workspace.
+
+#![allow(clippy::tests_outside_test_module, clippy::unwrap_used)]
+// Reason: Integration tests in `tests/` are always outside `#[cfg(test)]`; unwrap is fine for assertion clarity.
+
+#[cfg(unix)]
+#[tokio::test]
+async fn server_shuts_down_on_sigterm() {
+    use core::time::Duration;
+
+    let mut sigterm =
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()).unwrap();
+
+    let server_task = tokio::spawn(async { docspec_http::serve("127.0.0.1", 0).await });
+
+    let pid = nix::unistd::Pid::from_raw(i32::try_from(std::process::id()).unwrap());
+    let timeout = Duration::from_secs(5);
+    let start = std::time::Instant::now();
+    while !server_task.is_finished() && start.elapsed() < timeout {
+        nix::sys::signal::kill(pid, nix::sys::signal::Signal::SIGTERM).unwrap();
+        match tokio::time::timeout(Duration::from_millis(50), sigterm.recv()).await {
+            Ok(_) | Err(_) => {}
+        }
+    }
+
+    assert!(
+        server_task.is_finished(),
+        "server did not shut down within 5s of SIGTERM"
+    );
+}


### PR DESCRIPTION
Closes #15

## Summary

Adds an HTTP API server for DocSpec via a new `docspec-http` crate, and restructures the CLI into Pandoc-style subcommands.

This is the deliverable for the NLnet-funded HTTP API milestone (#15).

## ⚠️ Breaking Changes

The CLI now requires a subcommand. Existing invocations must be updated:

| Before | After |
|---|---|
| `docspec input.md -o out.json` | `docspec convert input.md -o out.json` |
| `docspec --list-input-formats` | `docspec convert --list-input-formats` |
| `docspec -f markdown -t blocknote ...` | `docspec convert -f markdown -t blocknote ...` |

The `--color` flag remains a top-level global. See [CHANGELOG.md](./CHANGELOG.md) for full migration guide.

## What's New

### `docspec-http` crate

New Axum 0.8-based HTTP server exposing the streaming conversion pipeline:

| Endpoint | Method | Description |
|---|---|---|
| `/convert` | `POST` | Streams `text/markdown` → `application/vnd.docspec.blocknote+json` |
| `/health` | `GET` | Returns `204 No Content` |

- **RFC 7807 errors** (`application/problem+json`) with stable `https://docspec.dev/errors/{code}` type URIs
- **Streaming preserved end-to-end** — `spawn_blocking` + bounded `mpsc::channel(32)` + `Body::from_stream`; constant memory regardless of document size
- **Observability** — `tower_http::TraceLayer` + `SetRequestIdLayer` + `PropagateRequestIdLayer` (configurable via `--log-format pretty|json`)
- **Graceful shutdown** on `SIGINT` / `SIGTERM` (no shutdown timeout — drains in-flight requests fully)
- Excluded from `wasm32-*` build targets

### `docspec http` subcommand

```
docspec http [--host <HOST>] [--port <PORT>] [--log-level <LEVEL>] [--log-format <FORMAT>]
```

Defaults: `127.0.0.1:3000`, `info`, `pretty`.

### `docspec convert` subcommand

Identical behavior to the previous root command — same flags, same pipeline, same exit codes.

## Documented Risks (User-Accepted)

The HTTP server ships with **no built-in protection** against the following — operators are expected to run behind a reverse proxy:

- **No request body size limit** — large bodies are buffered in memory before conversion (pulldown-cmark requires a `&str`)
- **No request timeout** — slow clients can hold connections indefinitely
- **No shutdown timeout** — graceful drain may stall on stuck handlers

These tradeoffs are explicitly disclosed in the README and were confirmed during planning.

## Test Coverage

- **Workspace tests pass** (0 failures)
- **`docspec-http` crate coverage tracked under the workspace 98% floor**
  - `format.rs`, `router.rs`: 100% / near-100%
  - `handler.rs`: covers happy path, error branches, streaming writer failure
  - `error.rs`: covers RFC 7807 serialization + all HTTP error variants
  - `server.rs`: covers bind, IPv6, invalid-host, shutdown selection (injectable futures)
  - `tracing_init.rs`: covers `RUST_LOG` precedence, fallback paths, invalid-level error
- 4 `docspec-cli` integration tests covering `docspec http` startup, port-in-use, SIGINT clean exit
- All existing CLI integration tests migrated to the `convert` prefix

## Files Changed

- **New crate**: `crates/docspec-http/` (Cargo.toml, `src/{lib,error,format,handler,router,server,tracing_init}.rs`, integration tests, README)
- **CLI restructure**: `crates/docspec-cli/src/{args,main}.rs` — `Cli` → `Command::{Convert, Http}` enum
- **Tests**: existing CLI tests migrated + new HTTP-subcommand tests, integration tests in `crates/docspec-http/tests/`
- **Docs**: `README.md`, `CHANGELOG.md` (new), `ARCHITECTURE.md` (HTTP server section), `crates/docspec-http/README.md`
- **Workspace**: `Cargo.toml` adds `crates/docspec-http` to members

## Commit

Squashed to a single conventional commit with the breaking-change marker:

```
feat(http)!: HTTP API server and CLI subcommand restructure
```

Per `CONTRIBUTING.md`, the commit body contains the required `BREAKING CHANGE:` footer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP API: POST /convert and GET /health for streaming Markdown→BlockNote with RFC 7807 problem+json errors and content-negotiation behavior
  * New docspec http CLI subcommand to run the server with host/port and logging options

* **Breaking Changes**
  * CLI conversion moved under a required convert subcommand (use `docspec convert ...`)

* **Documentation**
  * README, changelog, and architecture docs updated with API examples, error format, migration guide, and deployment notes

* **Tests**
  * Expanded CLI and HTTP integration tests for routing, headers, streaming, concurrency, and shutdown behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/docspec/docspec/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->