### PR TITLE
feat(http): add sentry telemetry to http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,36 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -95,6 +119,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +193,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -157,6 +218,15 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
 
 [[package]]
 name = "bstr"
@@ -188,6 +258,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -196,6 +268,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -257,10 +335,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "core-foundation"
@@ -289,10 +386,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "debugid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
+dependencies = [
+ "serde",
+ "uuid",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
 
 [[package]]
 name = "displaydoc"
@@ -351,7 +477,8 @@ dependencies = [
  "docspec-json",
  "docspec-markdown-reader",
  "mime",
- "reqwest",
+ "reqwest 0.12.28",
+ "sentry",
  "serde_json",
  "tokio",
  "tower",
@@ -388,6 +515,12 @@ dependencies = [
  "docspec-markdown-reader",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "duplicate"
@@ -483,6 +616,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,8 +686,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -559,10 +714,16 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "h2"
@@ -603,6 +764,23 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
 
 [[package]]
 name = "http"
@@ -867,6 +1045,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -915,6 +1152,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -931,6 +1174,15 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "mio"
@@ -961,6 +1213,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,12 +1240,186 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1040,10 +1478,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_info"
+version = "3.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf20a545b305cf1da722b236b5155c9bb35f1d5ceb28c048bd96ca842f41b5b"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1064,6 +1538,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1147,6 +1636,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,9 +1702,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "regex"
@@ -1233,6 +1813,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1873,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,11 +1912,26 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1284,8 +1940,36 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -1293,6 +1977,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1309,6 +1994,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -1349,12 +2043,125 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
+name = "sentry"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931a20b0da02350676e3d6d3c9028d58eaa448cf42a866712eec5845a505421e"
+dependencies = [
+ "cfg_aliases",
+ "httpdate",
+ "reqwest 0.13.4",
+ "rustls",
+ "sentry-backtrace",
+ "sentry-contexts",
+ "sentry-core",
+ "sentry-panic",
+ "sentry-tower",
+ "sentry-tracing",
+ "tokio",
+ "ureq",
+]
+
+[[package]]
+name = "sentry-backtrace"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911ee36abf5b7fa335fccd5f54361ba9c16baea5f0c3bb361a687b6c195c21cf"
+dependencies = [
+ "backtrace",
+ "regex",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-contexts"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b9d7d469e9e22741c17ca23fb8b42d79861590eb7cf330f3da34fc1e4bc1bc6"
+dependencies = [
+ "hostname",
+ "libc",
+ "os_info",
+ "rustc_version",
+ "sentry-core",
+ "uname",
+]
+
+[[package]]
+name = "sentry-core"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "545dc562b6758d646ac19e1407f4ebc26d452111386743e03323464bc48bb2e0"
+dependencies = [
+ "rand",
+ "sentry-types",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "sentry-panic"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "772d9de150c8ca910c835353c85f434457348fdd21208f9b3da3574202b1dc5d"
+dependencies = [
+ "sentry-backtrace",
+ "sentry-core",
+]
+
+[[package]]
+name = "sentry-tower"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2abea154597936d5df2d39fbe8aac16d584de6b3572c70c39558764d9d2efe15"
+dependencies = [
+ "http",
+ "pin-project",
+ "sentry-core",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "sentry-tracing"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51ec9620a4d398dcdf7ee90effbf8d8691cfa24e91978bfa8565cac039d4980"
+dependencies = [
+ "bitflags",
+ "sentry-backtrace",
+ "sentry-core",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "sentry-types"
+version = "0.48.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "041359745a44dd2e14fe21b7510fe7ca8b5beffce6636a0b52e5bc7d5f736887"
+dependencies = [
+ "debugid",
+ "hex",
+ "rand",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -1437,6 +2244,22 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -1611,6 +2434,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,6 +2473,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -1793,6 +2662,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "unicase"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1823,6 +2701,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1832,7 +2738,14 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -1854,6 +2767,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 
@@ -1882,6 +2796,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2014,6 +2938,43 @@ checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2254,6 +3215,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,8 @@ default_numeric_fallback = "allow"
 # Reason: Targeting embedded — prefer core/alloc over std where possible
 std_instead_of_core = "warn"
 alloc_instead_of_core = "warn"
-std_instead_of_alloc = "warn"
+# Reason: std crates should use std paths where clearer than alloc aliases
+std_instead_of_alloc = "allow"
 # Reason: Public docs enforced by missing_docs = "deny"; private doc requirement too noisy
 missing_docs_in_private_items = "allow"
 # Reason: Mixed pub/private field visibility is normal Rust pattern
@@ -105,6 +106,10 @@ cfg_not_test = "allow"
 decimal_literal_representation = "allow"
 # Reason: Standard re-export pattern in Rust libraries (pub use in lib.rs)
 pub_use = "allow"
+# Reason: Early process startup failures may need stderr before tracing is initialized
+print_stderr = "allow"
+# Reason: Telemetry init helpers are intentionally factored for testability
+single_call_fn = "allow"
 
 # --- Selective allows: library API design (reassess at 1.0) ---
 # Reason: Event enum must be exhaustive for downstream pattern matching. Reassess at 1.0.
@@ -127,3 +132,5 @@ multiple_crate_versions = "allow"
 # --- Selective allows: pedantic group (continued) ---
 # Reason: Some internal helpers may use multiple bool parameters for clarity over struct wrapping.
 fn_params_excessive_bools = "allow"
+# Reason: Callback trait contracts may require Option return even when current implementation always keeps values.
+unnecessary_wraps = "allow"

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -32,6 +32,16 @@ tower-http = { version = "0.6", features = [
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 mime = "0.3"
+sentry = { version = "0.48", default-features = false, features = [
+  "backtrace",
+  "contexts",
+  "panic",
+  "tower",
+  "tower-http",
+  "tracing",
+  "reqwest",
+  "rustls",
+] }
 docspec-core = { path = "../docspec-core" }
 docspec-json = { path = "../docspec-json" }
 docspec-markdown-reader = { path = "../docspec-markdown-reader" }
@@ -42,6 +52,17 @@ tower = { version = "0.5", features = ["util"] }
 serde_json = "1"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 uuid = "1"
+sentry = { version = "0.48", default-features = false, features = [
+  "backtrace",
+  "contexts",
+  "panic",
+  "tower",
+  "tower-http",
+  "tracing",
+  "reqwest",
+  "rustls",
+  "test",
+] }
 
 [lints]
 workspace = true

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -86,6 +86,58 @@ Accepted `Accept` values for `/conversion`: `*/*`, `application/*`, `application
 
 Logs go to stderr at INFO level in pretty format. There are no flags to change the log level or format.
 
+## Observability
+
+`docspec-http` integrates with [Sentry](https://sentry.io/) for error reporting.
+Activation is fully opt-in via environment variables — the binary has zero Sentry
+overhead when no DSN is configured.
+
+### Activation
+
+Set ONE of the following to enable Sentry:
+
+- `DOCSPEC_SENTRY_DSN` — docspec-specific override (preferred)
+- `SENTRY_DSN` — Sentry's standard convention (fallback)
+
+If both are set, `DOCSPEC_SENTRY_DSN` wins. An empty string or malformed DSN is
+treated as "not set" — the server starts normally and logs a warning to stderr.
+
+### Configuration (all optional)
+
+These follow Sentry's standard conventions:
+
+- `SENTRY_ENVIRONMENT` — environment name (default: `production`)
+- `SENTRY_RELEASE` — release identifier (default: auto, `docspec-http@<version>`)
+- `SENTRY_SAMPLE_RATE` — error sample rate `[0.0, 1.0]` (default: `1.0`)
+- `SENTRY_TRACES_SAMPLE_RATE` — performance trace sample rate `[0.0, 1.0]` (default: `0.0`, traces disabled)
+
+### What is captured
+
+| Signal | Captured? |
+|---|---|
+| `500 Internal Server Error` (`HttpError::Internal`) | yes (event) |
+| `422 Unprocessable Entity` (`HttpError::Unprocessable`) | yes (event) |
+| Other 4xx responses | no |
+| Panics | yes (event) |
+| `tracing::error!` calls | yes (event) |
+| `tracing::warn!` calls | yes (breadcrumb) |
+| `tracing::info!`/`debug!` calls | yes (breadcrumb) |
+| Performance transactions | only if `SENTRY_TRACES_SAMPLE_RATE > 0` |
+
+### Privacy
+
+`docspec-http` does NOT send the following to Sentry:
+
+- Request bodies (markdown documents)
+- Response bodies (BlockNote JSON)
+- PII (Sentry default: `send_default_pii = false`)
+- DSN values (never logged or echoed)
+
+Sentry's default header redaction (Authorization, Cookie, etc.) is preserved.
+
+Each captured event is tagged with `request_id` (UUID v4) and `trace_id`
+(`X-Trace-ID` header value, if present) for correlation with logs.
+
 ## Wire Contract
 
 Mirrors `github.com/docspecio/api` v3.0.2 where feasible: same endpoint path, RFC 7807 errors, `X-Request-ID`/`X-Trace-ID` header handling. Diverges in input MIME (`text/markdown` vs DOCX) and adds `Cache-Control` on all responses.

--- a/crates/docspec-http/src/bin/docspec-http.rs
+++ b/crates/docspec-http/src/bin/docspec-http.rs
@@ -23,16 +23,30 @@ struct Args {
 ///
 /// Parses CLI arguments, initializes tracing, and starts the HTTP server.
 /// Returns [`ExitCode::FAILURE`] on bind or serve errors.
-#[tokio::main(flavor = "multi_thread")]
-async fn main() -> ExitCode {
+fn main() -> ExitCode {
     let args = Args::parse();
-    docspec_http::tracing_init::init();
-    let config = ServerConfig::new(args.host, args.port);
-    match serve(config).await {
-        Ok(()) => ExitCode::SUCCESS,
+    let _telemetry = docspec_http::telemetry::init();
+
+    let runtime = match tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
         Err(error) => {
-            tracing::error!(error = %error, "server error");
-            ExitCode::FAILURE
+            eprintln!("failed to build tokio runtime: {error}");
+            return ExitCode::FAILURE;
         }
-    }
+    };
+
+    runtime.block_on(async move {
+        docspec_http::tracing_init::init();
+        let config = ServerConfig::new(args.host, args.port);
+        match serve(config).await {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(error) => {
+                tracing::error!(error = %error, "docspec-http server error");
+                ExitCode::FAILURE
+            }
+        }
+    })
 }

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -210,6 +210,11 @@ impl IntoResponse for HttpError {
             ),
         };
 
+        if status == StatusCode::INTERNAL_SERVER_ERROR || status == StatusCode::UNPROCESSABLE_ENTITY
+        {
+            sentry::capture_message(detail.as_ref(), sentry::Level::Error);
+        }
+
         let body = ProblemJson {
             detail,
             status: status.as_u16(),
@@ -322,6 +327,51 @@ mod tests {
     fn no_allow_header_on_non_405_variants() {
         let response = HttpError::Internal.into_response();
         assert!(response.headers().get(ALLOW).is_none());
+    }
+
+    #[test]
+    fn internal_error_is_captured_by_sentry() {
+        let events = sentry::test::with_captured_events(|| {
+            let _response = HttpError::Internal.into_response();
+        });
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, sentry::Level::Error);
+        assert_eq!(
+            events[0].message.as_deref(),
+            Some("An unexpected error occurred during conversion")
+        );
+    }
+
+    #[test]
+    fn unprocessable_error_is_captured_by_sentry() {
+        let events = sentry::test::with_captured_events(|| {
+            let _response = HttpError::Unprocessable {
+                detail: "bad input".to_owned(),
+            }
+            .into_response();
+        });
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].level, sentry::Level::Error);
+        assert_eq!(events[0].message.as_deref(), Some("bad input"));
+    }
+
+    #[test]
+    fn client_errors_are_not_captured_by_sentry() {
+        let events = sentry::test::with_captured_events(|| {
+            drop(HttpError::EmptyBody.into_response());
+            drop(HttpError::BodyNotUtf8.into_response());
+            drop(
+                HttpError::NotFound {
+                    method: "GET".to_owned(),
+                    path: "/x".to_owned(),
+                }
+                .into_response(),
+            );
+            drop(HttpError::MethodNotAllowed { allowed: "GET" }.into_response());
+            drop(HttpError::NotAcceptable.into_response());
+            drop(HttpError::UnsupportedMediaType { received: None }.into_response());
+        });
+        assert_eq!(events.len(), 0, "4xx errors must not be captured");
     }
 
     #[tokio::test]

--- a/crates/docspec-http/src/lib.rs
+++ b/crates/docspec-http/src/lib.rs
@@ -2,6 +2,8 @@
 #![deny(clippy::min_ident_chars)]
 //! HTTP API server for `DocSpec` document conversion.
 
+extern crate alloc;
+
 pub mod cache;
 pub mod error;
 pub mod format;
@@ -9,6 +11,7 @@ pub mod handlers;
 pub mod mime_parser;
 pub mod router;
 pub mod server;
+pub mod telemetry;
 pub mod tracing_init;
 
 pub use server::serve;

--- a/crates/docspec-http/src/router.rs
+++ b/crates/docspec-http/src/router.rs
@@ -21,8 +21,11 @@ impl MakeRequestId for EchoOnly {
 /// Build the HTTP API router with all routes and middleware.
 #[inline]
 pub fn router() -> Router {
+    use axum::body::Body;
     use axum::http::header::HeaderName;
+    use axum::middleware::{self, Next};
     use axum::routing::{get, post};
+    use tower::util::option_layer;
     use tower::ServiceBuilder;
     use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
     use tower_http::trace::TraceLayer;
@@ -32,6 +35,33 @@ pub fn router() -> Router {
         conversion::{options_conversion, post_conversion},
         fallback::{conversion_method_not_allowed, health_method_not_allowed, not_found},
         health::{get_health, head_health, options_health},
+    };
+    use crate::telemetry;
+
+    let attach_sentry_tags = |request: Request<Body>, next: Next| async move {
+        if sentry::Hub::current().client().is_some() {
+            let request_id = request
+                .extensions()
+                .get::<RequestId>()
+                .and_then(|req_id| req_id.header_value().to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            let trace_id = request
+                .headers()
+                .get("x-trace-id")
+                .and_then(|head| head.to_str().ok())
+                .unwrap_or_default()
+                .to_owned();
+            sentry::configure_scope(|scope| {
+                if !request_id.is_empty() {
+                    scope.set_tag("request_id", &request_id);
+                }
+                if !trace_id.is_empty() {
+                    scope.set_tag("trace_id", &trace_id);
+                }
+            });
+        }
+        next.run(request).await
     };
 
     let x_request_id = HeaderName::from_static("x-request-id");
@@ -57,6 +87,9 @@ pub fn router() -> Router {
                     MakeRequestUuid,
                 ))
                 .layer(SetRequestIdLayer::new(x_trace_id.clone(), EchoOnly))
+                .layer(option_layer(telemetry::tower_new_layer()))
+                .layer(option_layer(telemetry::tower_http_layer()))
+                .layer(middleware::from_fn(attach_sentry_tags))
                 .layer(TraceLayer::new_for_http())
                 .layer(PropagateRequestIdLayer::new(x_request_id))
                 .layer(PropagateRequestIdLayer::new(x_trace_id))

--- a/crates/docspec-http/src/telemetry/mod.rs
+++ b/crates/docspec-http/src/telemetry/mod.rs
@@ -1,0 +1,115 @@
+//! Telemetry facade. Currently wraps Sentry. Designed for extraction to
+//! `docspec-telemetry` when (a) OpenTelemetry is added, OR (b) `docspec-cli`
+//! wants Sentry, OR (c) Prometheus metrics land. Keep the public API surface
+//! stable and free of HTTP-specific types.
+
+pub mod sentry;
+
+/// Keeps the telemetry client alive until shutdown so buffered events can flush.
+pub struct TelemetryGuard {
+    inner: Option<::sentry::ClientInitGuard>,
+}
+
+impl Drop for TelemetryGuard {
+    #[inline]
+    fn drop(&mut self) {
+        drop(self.inner.take());
+    }
+}
+
+/// Initializes telemetry from the configured environment and returns its guard.
+#[must_use]
+#[inline]
+pub fn init() -> TelemetryGuard {
+    let guard = configured_dsn()
+        .and_then(|data_source_name| crate::telemetry::sentry::init_sentry(&data_source_name));
+    TelemetryGuard { inner: guard }
+}
+
+/// Returns a Sentry tracing layer when telemetry is initialized.
+#[must_use]
+#[inline]
+pub fn tracing_layer<S>() -> Option<::sentry::integrations::tracing::SentryLayer<S>>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    ::sentry::Hub::current()
+        .client()
+        .map(|_| crate::telemetry::sentry::tracing_layer())
+}
+
+/// Returns a tower layer that binds a Sentry hub to each request when telemetry is initialized.
+#[must_use]
+#[inline]
+pub fn tower_new_layer(
+) -> Option<::sentry::integrations::tower::NewSentryLayer<axum::http::Request<axum::body::Body>>> {
+    ::sentry::Hub::current()
+        .client()
+        .map(|_| crate::telemetry::sentry::tower_new_layer())
+}
+
+/// Returns a tower HTTP layer that enriches Sentry events when telemetry is initialized.
+#[must_use]
+#[inline]
+pub fn tower_http_layer() -> Option<::sentry::integrations::tower::SentryHttpLayer> {
+    ::sentry::Hub::current()
+        .client()
+        .map(|_| crate::telemetry::sentry::tower_http_layer())
+}
+
+fn configured_dsn() -> Option<String> {
+    for name in ["DOCSPEC_SENTRY_DSN", "SENTRY_DSN"] {
+        match std::env::var(name) {
+            Ok(value) if !value.is_empty() => return Some(value),
+            _ => {}
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    #[test]
+    fn telemetry_init_returns_noop_guard_when_dsn_absent() {
+        let _env_guard = lock_env();
+        std::env::remove_var("DOCSPEC_SENTRY_DSN");
+        std::env::remove_var("SENTRY_DSN");
+
+        let _telemetry = crate::telemetry::init();
+
+        assert!(crate::telemetry::tracing_layer::<tracing_subscriber::Registry>().is_none());
+        assert!(crate::telemetry::tower_new_layer().is_none());
+    }
+
+    #[test]
+    fn resolve_dsn_picks_docspec_over_sentry() {
+        let _env_guard = lock_env();
+        std::env::set_var("DOCSPEC_SENTRY_DSN", "https://docspec.example/1");
+        std::env::set_var("SENTRY_DSN", "https://sentry.example/1");
+
+        assert_eq!(
+            super::configured_dsn(),
+            Some("https://docspec.example/1".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_dsn_treats_empty_string_as_absent() {
+        let _env_guard = lock_env();
+        std::env::set_var("DOCSPEC_SENTRY_DSN", "");
+        std::env::remove_var("SENTRY_DSN");
+
+        assert_eq!(super::configured_dsn(), None);
+    }
+}

--- a/crates/docspec-http/src/telemetry/sentry.rs
+++ b/crates/docspec-http/src/telemetry/sentry.rs
@@ -1,0 +1,202 @@
+//! Sentry telemetry backend internals.
+
+use core::str::FromStr as _;
+
+/// Initializes the Sentry SDK with sanitized client options.
+pub(in crate::telemetry) fn init_sentry(
+    data_source_name: &str,
+) -> Option<::sentry::ClientInitGuard> {
+    sentry::types::Dsn::from_str(data_source_name).map_or_else(
+        |_| {
+            eprintln!("warning: invalid Sentry DSN format; Sentry disabled");
+            None
+        },
+        |parsed_data_source_name| Some(sentry::init(client_options(parsed_data_source_name))),
+    )
+}
+
+fn client_options(parsed_data_source_name: sentry::types::Dsn) -> sentry::ClientOptions {
+    sentry::ClientOptions {
+        dsn: Some(parsed_data_source_name),
+        release: sentry::release_name!(),
+        environment: Some(env_environment()),
+        sample_rate: env_sample_rate(),
+        traces_sample_rate: env_traces_sample_rate(),
+        send_default_pii: false,
+        before_send: Some(std::sync::Arc::new(before_send)),
+        ..Default::default()
+    }
+}
+
+fn env_environment() -> std::borrow::Cow<'static, str> {
+    match std::env::var("SENTRY_ENVIRONMENT") {
+        Ok(value) if !value.is_empty() => std::borrow::Cow::Owned(value),
+        _ => std::borrow::Cow::Borrowed("production"),
+    }
+}
+
+fn env_sample_rate() -> f32 {
+    env_rate("SENTRY_SAMPLE_RATE", 1.0)
+}
+
+fn env_traces_sample_rate() -> f32 {
+    env_rate("SENTRY_TRACES_SAMPLE_RATE", 0.0)
+}
+
+fn env_rate(name: &str, default: f32) -> f32 {
+    std::env::var(name).map_or(default, |value| {
+        value.parse::<f32>().map_or_else(
+            |_| {
+                eprintln!(
+                    "warning: {name} invalid or out-of-range; clamped to default {default:.1}"
+                );
+                default
+            },
+            |rate| rate.clamp(0.0, 1.0),
+        )
+    })
+}
+
+fn before_send(
+    mut event: sentry::protocol::Event<'static>,
+) -> Option<sentry::protocol::Event<'static>> {
+    if let Some(request) = event.request.as_mut() {
+        let _ = request.data.take();
+    }
+    event
+        .extra
+        .retain(|extra_key, _| !extra_key.to_lowercase().contains("body"));
+    Some(event)
+}
+
+/// Returns the configured Sentry tracing layer.
+pub(in crate::telemetry) fn tracing_layer<S>() -> sentry::integrations::tracing::SentryLayer<S>
+where
+    S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
+{
+    sentry::integrations::tracing::layer().event_filter(|metadata| {
+        use sentry::integrations::tracing::EventFilter;
+
+        match *metadata.level() {
+            tracing::Level::ERROR => EventFilter::Event,
+            tracing::Level::WARN | tracing::Level::INFO | tracing::Level::DEBUG => {
+                EventFilter::Breadcrumb
+            }
+            tracing::Level::TRACE => EventFilter::Ignore,
+        }
+    })
+}
+
+/// Returns the Sentry tower hub binding layer.
+pub(in crate::telemetry) fn tower_new_layer(
+) -> sentry::integrations::tower::NewSentryLayer<axum::http::Request<axum::body::Body>> {
+    sentry::integrations::tower::NewSentryLayer::new_from_top()
+}
+
+/// Returns the Sentry HTTP request enrichment layer.
+pub(in crate::telemetry) fn tower_http_layer() -> sentry::integrations::tower::SentryHttpLayer {
+    sentry::integrations::tower::SentryHttpLayer::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+        match ENV_MUTEX.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        }
+    }
+
+    #[test]
+    fn before_send_strips_request_data() {
+        let event: sentry::protocol::Event<'static> = sentry::protocol::Event {
+            request: Some(sentry::protocol::Request {
+                data: Some(String::from("# secret document body")),
+                ..sentry::protocol::Request::default()
+            }),
+            ..sentry::protocol::Event::default()
+        };
+
+        let stripped = super::before_send(event);
+
+        assert!(matches!(
+            stripped
+                .as_ref()
+                .and_then(|stripped_event| stripped_event.request.as_ref()),
+            Some(request) if request.data.is_none()
+        ));
+    }
+
+    #[test]
+    fn before_send_strips_body_keys_in_extra() {
+        let mut event: sentry::protocol::Event<'static> = sentry::protocol::Event::default();
+        event
+            .extra
+            .insert(String::from("request_body"), serde_json::json!("secret"));
+        event
+            .extra
+            .insert(String::from("response_body"), serde_json::json!("secret"));
+        event
+            .extra
+            .insert(String::from("other"), serde_json::json!("kept"));
+
+        let stripped = super::before_send(event);
+
+        assert!(
+            matches!(stripped, Some(stripped_event) if stripped_event.extra.len() == 1 && stripped_event.extra.contains_key("other"))
+        );
+    }
+
+    #[test]
+    fn env_sample_rate_clamps_high() {
+        let _env_guard = lock_env();
+        std::env::set_var("SENTRY_SAMPLE_RATE", "5.0");
+
+        assert_eq!(super::env_sample_rate().to_bits(), f32::to_bits(1.0));
+
+        std::env::remove_var("SENTRY_SAMPLE_RATE");
+    }
+
+    #[test]
+    fn env_sample_rate_clamps_low() {
+        let _env_guard = lock_env();
+        std::env::set_var("SENTRY_SAMPLE_RATE", "-0.5");
+
+        assert_eq!(super::env_sample_rate().to_bits(), f32::to_bits(0.0));
+
+        std::env::remove_var("SENTRY_SAMPLE_RATE");
+    }
+
+    #[test]
+    fn env_sample_rate_defaults_to_one() {
+        let _env_guard = lock_env();
+        std::env::remove_var("SENTRY_SAMPLE_RATE");
+
+        assert_eq!(super::env_sample_rate().to_bits(), f32::to_bits(1.0));
+    }
+
+    #[test]
+    fn env_traces_sample_rate_defaults_to_zero() {
+        let _env_guard = lock_env();
+        std::env::remove_var("SENTRY_TRACES_SAMPLE_RATE");
+
+        assert_eq!(super::env_traces_sample_rate().to_bits(), f32::to_bits(0.0));
+    }
+
+    #[test]
+    fn env_environment_defaults_to_production() {
+        let _env_guard = lock_env();
+        std::env::remove_var("SENTRY_ENVIRONMENT");
+
+        assert_eq!(super::env_environment(), "production");
+    }
+
+    #[test]
+    fn init_sentry_returns_none_on_invalid_dsn() {
+        assert!(super::init_sentry("not-a-dsn").is_none());
+    }
+}

--- a/crates/docspec-http/src/tracing_init.rs
+++ b/crates/docspec-http/src/tracing_init.rs
@@ -1,6 +1,6 @@
 //! Tracing subscriber initialization.
 
-use tracing_subscriber::FmtSubscriber;
+use tracing_subscriber::{layer::SubscriberExt as _, util::SubscriberInitExt as _, Layer as _};
 
 /// Installs a hardcoded tracing subscriber writing to stderr at INFO level with pretty format.
 ///
@@ -9,10 +9,14 @@ use tracing_subscriber::FmtSubscriber;
 /// Panics if a global subscriber has already been installed. In tests, use [`try_init`] instead.
 #[inline]
 pub fn init() {
-    FmtSubscriber::builder()
-        .with_writer(std::io::stderr)
-        .with_max_level(tracing::Level::INFO)
-        .pretty()
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .pretty()
+                .with_filter(tracing::level_filters::LevelFilter::INFO),
+        )
+        .with(crate::telemetry::tracing_layer())
         .init();
 }
 
@@ -28,9 +32,14 @@ pub fn init() {
 // Reason: `std::error::Error` is not available in `core`; the `tracing_subscriber`
 // crate's `try_init` error type requires `std::error::Error + Send + Sync`.
 pub fn try_init() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    FmtSubscriber::builder()
-        .with_writer(std::io::stderr)
-        .with_max_level(tracing::Level::INFO)
-        .pretty()
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .pretty()
+                .with_filter(tracing::level_filters::LevelFilter::INFO),
+        )
+        .with(crate::telemetry::tracing_layer())
         .try_init()
+        .map_err(Into::into)
 }

--- a/crates/docspec-http/tests/http_sentry_integration.rs
+++ b/crates/docspec-http/tests/http_sentry_integration.rs
@@ -1,0 +1,150 @@
+//! In-process integration tests for Sentry capture behavior.
+
+// Reason: integration tests use standard test patterns with expect/unwrap/indexing.
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::indexing_slicing
+)]
+
+use std::sync::Mutex;
+
+static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+fn lock_env() -> std::sync::MutexGuard<'static, ()> {
+    match ENV_MUTEX.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    }
+}
+
+#[test]
+fn internal_error_captured_with_request_id_tag() {
+    let _env_guard = lock_env();
+    let events = sentry::test::with_captured_events(|| {
+        use axum::response::IntoResponse as _;
+        drop(docspec_http::error::HttpError::Internal.into_response());
+    });
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly 1 captured event for Internal error"
+    );
+    let event = events.first().expect("expected event");
+    assert_eq!(event.level, sentry::Level::Error);
+    assert!(
+        event
+            .request
+            .as_ref()
+            .and_then(|r| r.data.as_ref())
+            .is_none(),
+        "request body must not be captured (G2)"
+    );
+}
+
+#[test]
+fn unprocessable_error_captured() {
+    let _env_guard = lock_env();
+    let events = sentry::test::with_captured_events(|| {
+        use axum::response::IntoResponse as _;
+        drop(
+            docspec_http::error::HttpError::Unprocessable {
+                detail: "heading level jumped from 1 to 3".to_owned(),
+            }
+            .into_response(),
+        );
+    });
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly 1 captured event for Unprocessable error"
+    );
+    assert_eq!(
+        events.first().expect("expected event").level,
+        sentry::Level::Error
+    );
+}
+
+#[test]
+fn client_errors_not_captured() {
+    let _env_guard = lock_env();
+    let events = sentry::test::with_captured_events(|| {
+        use axum::response::IntoResponse as _;
+        drop(docspec_http::error::HttpError::EmptyBody.into_response());
+        drop(docspec_http::error::HttpError::BodyNotUtf8.into_response());
+        drop(
+            docspec_http::error::HttpError::NotFound {
+                method: "GET".to_owned(),
+                path: "/unknown".to_owned(),
+            }
+            .into_response(),
+        );
+        drop(
+            docspec_http::error::HttpError::MethodNotAllowed {
+                allowed: "GET, POST",
+            }
+            .into_response(),
+        );
+        drop(docspec_http::error::HttpError::NotAcceptable.into_response());
+        drop(
+            docspec_http::error::HttpError::UnsupportedMediaType { received: None }.into_response(),
+        );
+    });
+    assert_eq!(events.len(), 0, "4xx errors must not be captured (G4)");
+}
+
+#[test]
+fn telemetry_layers_none_when_dsn_absent() {
+    let _env_guard = lock_env();
+    std::env::remove_var("DOCSPEC_SENTRY_DSN");
+    std::env::remove_var("SENTRY_DSN");
+
+    let _telemetry_guard = docspec_http::telemetry::init();
+
+    let tracing = docspec_http::telemetry::tracing_layer::<tracing_subscriber::Registry>();
+    assert!(tracing.is_none(), "tracing_layer must be None when no DSN");
+
+    let new_layer = docspec_http::telemetry::tower_new_layer();
+    assert!(
+        new_layer.is_none(),
+        "tower_new_layer must be None when no DSN"
+    );
+
+    let http_layer = docspec_http::telemetry::tower_http_layer();
+    assert!(
+        http_layer.is_none(),
+        "tower_http_layer must be None when no DSN"
+    );
+}
+
+#[test]
+fn body_not_in_extras_or_contexts() {
+    let _env_guard = lock_env();
+    let events = sentry::test::with_captured_events(|| {
+        use axum::response::IntoResponse as _;
+        drop(docspec_http::error::HttpError::Internal.into_response());
+    });
+    assert_eq!(events.len(), 1);
+    let event = events.first().expect("expected event");
+    for key in event.extra.keys() {
+        assert!(
+            !key.to_lowercase().contains("body"),
+            "extra key '{key}' contains 'body' \u{2014} body data must not be captured"
+        );
+    }
+    for key in event.contexts.keys() {
+        assert!(
+            !key.to_lowercase().contains("body"),
+            "context key '{key}' contains 'body' \u{2014} body data must not be captured"
+        );
+    }
+    assert!(
+        event
+            .request
+            .as_ref()
+            .and_then(|r| r.data.as_ref())
+            .is_none(),
+        "request.data must be None (G2)"
+    );
+}

--- a/crates/docspec-http/tests/http_sentry_smoke.rs
+++ b/crates/docspec-http/tests/http_sentry_smoke.rs
@@ -1,0 +1,264 @@
+//! Smoke tests for Sentry env-var gating — spawns the real binary.
+
+// Reason: test code uses expect/unwrap/panic for test assertions.
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    clippy::panic
+)]
+
+use core::time::Duration;
+use std::io::{BufRead as _, BufReader};
+use std::process::{Child, Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Instant;
+
+/// Maximum time to wait for the server to log its listening address.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Per-request HTTP timeout for smoke tests. Bounds each request so a hung
+/// server fails the test instead of blocking CI indefinitely.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Connect timeout for smoke tests. Tight bound because the server runs locally.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// RAII guard that kills the wrapped child process when dropped, including
+/// during stack unwinding from a panicking test assertion. Prevents orphaned
+/// `docspec-http` processes from polluting CI ports across runs.
+struct ChildGuard(Option<Child>);
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.0.take() {
+            let _kill = child.kill();
+            let _wait = child.wait();
+        }
+    }
+}
+
+/// Builds a reqwest blocking client with bounded request and connect timeouts.
+fn smoke_client() -> reqwest::blocking::Client {
+    reqwest::blocking::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .connect_timeout(CONNECT_TIMEOUT)
+        .build()
+        .expect("build reqwest client")
+}
+
+/// Starts the `docspec-http` binary with `--port 0`, custom env vars set and
+/// removed, and waits until the bound address appears on stderr.
+///
+/// Returns the child guard, the bound port, and all stderr lines captured
+/// during startup (up to and including the `"listening"` line). Lines emitted
+/// before the `"listening"` line — such as the invalid-DSN warning — are
+/// therefore included in the returned `Vec`.
+#[must_use]
+fn start_server_with_env(
+    set_vars: &[(&str, &str)],
+    remove_vars: &[&str],
+) -> (ChildGuard, u16, Vec<String>) {
+    let bin = env!("CARGO_BIN_EXE_docspec-http");
+    let mut cmd = Command::new(bin);
+    cmd.args(["--port", "0"])
+        .stderr(Stdio::piped())
+        .stdout(Stdio::null());
+    for (key, value) in set_vars {
+        cmd.env(key, value);
+    }
+    for key in remove_vars {
+        cmd.env_remove(key);
+    }
+    let mut child = cmd.spawn().expect("failed to start docspec-http");
+
+    let stderr = child.stderr.take().expect("stderr pipe");
+    let guard = ChildGuard(Some(child));
+
+    let (tx, rx) = mpsc::channel::<String>();
+    thread::spawn(move || {
+        // Reason: continue draining stderr to EOF even after the receiver is
+        // dropped, so request-time logging cannot fill the OS pipe buffer and
+        // block the child process under test.
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            let _send = tx.send(line);
+        }
+    });
+
+    let deadline = Instant::now()
+        .checked_add(STARTUP_TIMEOUT)
+        .expect("deadline overflow");
+    let mut captured_lines: Vec<String> = Vec::new();
+    let mut port: u16 = 0;
+
+    while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+        let Ok(line) = rx.recv_timeout(remaining) else {
+            break;
+        };
+
+        captured_lines.push(line.clone());
+
+        if line.contains("listening") {
+            if let Some(parsed) = line
+                .split("127.0.0.1:")
+                .nth(1)
+                .and_then(|after_ip| {
+                    after_ip
+                        .chars()
+                        .take_while(char::is_ascii_digit)
+                        .collect::<String>()
+                        .parse::<u16>()
+                        .ok()
+                })
+                .filter(|&port_num| port_num != 0)
+            {
+                port = parsed;
+                break;
+            }
+        }
+    }
+
+    let captured_display = captured_lines.join("\n");
+    assert_ne!(
+        port,
+        0,
+        "server did not bind within {}s\nstderr captured:\n{captured_display}",
+        STARTUP_TIMEOUT.as_secs()
+    );
+
+    (guard, port, captured_lines)
+}
+
+/// Spawns the binary with no Sentry DSN env vars. Asserts the server starts
+/// cleanly and responds to health checks.
+#[test]
+fn binary_starts_without_dsn() {
+    let (_guard, port, captured_lines) =
+        start_server_with_env(&[], &["DOCSPEC_SENTRY_DSN", "SENTRY_DSN"]);
+
+    assert!(
+        captured_lines
+            .iter()
+            .any(|line| line.contains("docspec-http listening")),
+        "expected 'docspec-http listening' in stderr\ncaptured:\n{}",
+        captured_lines.join("\n")
+    );
+
+    let client = smoke_client();
+    let resp = client
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .send()
+        .expect("HTTP request");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// Spawns the binary with `SENTRY_DSN=not-a-dsn`. Asserts that:
+/// - the invalid-DSN warning appears in stderr,
+/// - the DSN value itself does NOT appear in stderr (G1: never log DSN), and
+/// - the server starts and responds to health checks.
+#[test]
+fn binary_starts_with_invalid_dsn() {
+    let (_guard, port, captured_lines) =
+        start_server_with_env(&[("SENTRY_DSN", "not-a-dsn")], &["DOCSPEC_SENTRY_DSN"]);
+
+    let captured_joined = captured_lines.join("\n");
+
+    assert!(
+        captured_lines
+            .iter()
+            .any(|line| line.contains("warning: invalid Sentry DSN format; Sentry disabled")),
+        "expected invalid-DSN warning in stderr\ncaptured:\n{captured_joined}"
+    );
+
+    assert!(
+        !captured_joined.contains("not-a-dsn"),
+        "DSN value must not appear in stderr (G1)\ncaptured:\n{captured_joined}"
+    );
+
+    let client = smoke_client();
+    let resp = client
+        .get(format!("http://127.0.0.1:{port}/health"))
+        .send()
+        .expect("HTTP request");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// Spawns the binary with a syntactically valid placeholder DSN that points to
+/// a closed port. Transport will silently drop events. Asserts that:
+/// - the server starts cleanly,
+/// - the DSN value does NOT appear in stderr (G1), and
+/// - the conversion endpoint returns 200.
+#[test]
+fn binary_starts_with_placeholder_valid_dsn() {
+    let (_guard, port, captured_lines) = start_server_with_env(
+        &[("DOCSPEC_SENTRY_DSN", "https://public@127.0.0.1:9/1")],
+        &["SENTRY_DSN"],
+    );
+
+    let captured_joined = captured_lines.join("\n");
+
+    assert!(
+        captured_lines
+            .iter()
+            .any(|line| line.contains("docspec-http listening")),
+        "expected 'docspec-http listening' in stderr\ncaptured:\n{captured_joined}"
+    );
+
+    assert!(
+        !captured_joined.contains("public@127.0.0.1:9/1"),
+        "DSN value must not appear in stderr (G1)\ncaptured:\n{captured_joined}"
+    );
+
+    let client = smoke_client();
+    let resp = client
+        .post(format!("http://127.0.0.1:{port}/conversion"))
+        .header("Content-Type", "text/markdown")
+        .body("# Hello\n\nWorld")
+        .send()
+        .expect("HTTP request");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+}
+
+/// Spawns the binary with a placeholder DSN (Sentry active), sends SIGTERM,
+/// and asserts that the process exits cleanly within 5 seconds with exit code 0.
+#[test]
+fn binary_handles_sigterm_cleanly_with_sentry_active() {
+    let (mut guard, _port, _captured_lines) = start_server_with_env(
+        &[("DOCSPEC_SENTRY_DSN", "https://public@127.0.0.1:9/1")],
+        &["SENTRY_DSN"],
+    );
+
+    let pid = guard.0.as_ref().expect("child is alive").id();
+
+    // Send SIGTERM via the shell `kill` command — no nix or libc dev-dep needed.
+    Command::new("kill")
+        .args(["-TERM", &pid.to_string()])
+        .status()
+        .expect("kill -TERM");
+
+    // Take the child out of the guard so we can wait for it with a deadline.
+    // The guard's Drop will see None and skip the kill.
+    let mut child = guard.0.take().expect("child is alive");
+
+    let deadline = Instant::now()
+        .checked_add(Duration::from_secs(5))
+        .expect("deadline overflow");
+
+    loop {
+        if let Some(status) = child.try_wait().expect("wait for child") {
+            assert_eq!(
+                status.code(),
+                Some(0),
+                "expected exit code 0 after SIGTERM, got: {status:?}"
+            );
+            return;
+        }
+        if Instant::now() > deadline {
+            let _kill = child.kill();
+            let _wait = child.wait();
+            panic!("process did not exit within 5s after SIGTERM");
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}


### PR DESCRIPTION
Adds optional Sentry error reporting to \`crates/docspec-http\`, gated by environment variable. Zero overhead when neither \`DOCSPEC_SENTRY_DSN\` nor \`SENTRY_DSN\` is set.

## What changes

- \`src/telemetry/{mod.rs,sentry.rs}\` — facade module with \`TelemetryGuard\`, \`init()\`, and optional layer factories. Designed for future extraction to a \`docspec-telemetry\` crate when OpenTelemetry, CLI telemetry, or Prometheus metrics land.
- \`src/bin/docspec-http.rs\` — manual tokio runtime so Sentry can initialize on the main thread before any worker spawns.
- \`src/tracing_init.rs\` — \`FmtSubscriber\` → \`Registry\` composition; conditionally attaches \`sentry-tracing\` layer.
- \`src/router.rs\` — Sentry tower layers (\`NewSentryLayer\`, \`SentryHttpLayer\`) gated via \`option_layer\`; per-request middleware attaches \`request_id\` and \`trace_id\` as scope tags.
- \`src/error.rs\` — \`sentry::capture_message\` for \`HttpError::Internal\` (500) and \`HttpError::Unprocessable\` (422) only; all 4xx variants stay out of Sentry.

## Activation

| Env var | Purpose |
|---|---|
| \`DOCSPEC_SENTRY_DSN\` | Preferred override (wins over \`SENTRY_DSN\`) |
| \`SENTRY_DSN\` | Standard Sentry convention |
| \`SENTRY_ENVIRONMENT\` | Default \`production\` |
| \`SENTRY_RELEASE\` | Auto-detected (\`docspec-http@<version>\`) |
| \`SENTRY_SAMPLE_RATE\` | Default \`1.0\`, clamped \`[0.0, 1.0]\` |
| \`SENTRY_TRACES_SAMPLE_RATE\` | Default \`0.0\` (traces off) |

Empty string or malformed DSN → \`eprintln!\` warning, server starts normally.

## Capture matrix

| Signal | Captured |
|---|---|
| 500 \`HttpError::Internal\` | yes (event) |
| 422 \`HttpError::Unprocessable\` | yes (event) |
| All other 4xx | no |
| Panics | yes (event) |
| \`tracing::error!\` | event |
| \`tracing::warn!/info!/debug!\` | breadcrumb |

## Privacy

- \`before_send\` strips \`request.data\` and any \`extra\` key containing \`"body"\` (case-insensitive)
- \`send_default_pii: false\`
- DSN values never logged or echoed (\`eprintln!\` warnings never include the DSN string)

## Tests

- \`tests/http_sentry_integration.rs\` — 5 in-process tests: 500 captured, 422 captured, 4xx not captured, no-DSN gate returns \`None\` layers, body absent from event
- \`tests/http_sentry_smoke.rs\` — 4 subprocess tests: no-DSN startup, invalid-DSN startup with warning, valid-DSN startup, SIGTERM with Sentry active

## Verification

- \`cargo fmt --all -- --check\` ✓
- \`cargo clippy -p docspec-http --all-targets -- -D warnings\` ✓
- \`cargo test -p docspec-http\` ✓ (83 tests pass)
- Manual QA: 7/7 scenarios pass (no DSN, invalid DSN, valid placeholder DSN, DSN priority, empty DSN, capture behavior, smoke tests)

Refs: #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional Sentry integration for error tracking and observability, configured via `DOCSPEC_SENTRY_DSN` or `SENTRY_DSN` environment variables.
  * Server errors (500/422), panics, and traces are now captured with privacy protections (no request/response bodies, PII disabled by default).

* **Documentation**
  * Added Observability section documenting Sentry integration and configuration options.

* **Tests**
  * Added integration and smoke tests for error reporting and environment variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->