### PR TITLE
feat(http): add Prometheus /metrics endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,6 +386,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -476,10 +491,13 @@ dependencies = [
  "docspec-core",
  "docspec-json",
  "docspec-markdown-reader",
+ "metrics",
+ "metrics-exporter-prometheus",
  "mime",
  "reqwest 0.12.28",
  "sentry",
  "serde_json",
+ "thiserror",
  "tokio",
  "tower",
  "tower-http",
@@ -557,6 +575,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "evmap"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8874945f036109c72242964c1174cf99434e30cfa45bf45fedc983f50046f8"
+dependencies = [
+ "hashbag",
+ "left-right",
+ "smallvec",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +617,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -669,6 +704,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
+]
+
+[[package]]
 name = "getopts"
 version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,12 +793,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbag"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7040a10f52cba493ddb09926e15d10a9d8a28043708a405931fe4c6f19fac064"
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1126,6 +1191,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "left-right"
+version = "0.11.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0c21e4c8ff95f487fb34e6f9182875f42c84cef966d29216bf115d9bba835a"
+dependencies = [
+ "crossbeam-utils",
+ "loom",
+ "slab",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1150,10 +1226,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matchit"
@@ -1166,6 +1264,48 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "metrics"
+version = "0.24.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
+dependencies = [
+ "portable-atomic",
+ "rapidhash",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.18.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db0d8f1fc9e62caebd0319e11eaec5822b0186c171568f0480b46a0137f9108"
+dependencies = [
+ "base64",
+ "evmap",
+ "indexmap",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96f8722f8562635f92f8ed992f26df0532266eb03d5202607c20c0d7e9745e13"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.16.1",
+ "metrics",
+ "quanta",
+ "rand",
+ "rand_xoshiro",
+ "rapidhash",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -1530,6 +1670,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1632,6 +1778,21 @@ name = "pulldown-cmark-escape"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "quinn"
@@ -1737,6 +1898,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rapidhash"
+version = "4.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2012,6 +2200,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2258,6 +2452,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6f73aeb92d671e0cc4dca167e59b2deb6387c375391bc99ee743f326994a2b"
 
 [[package]]
 name = "slab"
@@ -2645,10 +2845,14 @@ version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -2967,6 +3171,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,6 +3194,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -32,6 +32,9 @@ tower-http = { version = "0.6", features = [
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 mime = "0.3"
+metrics = "0.24"
+metrics-exporter-prometheus = { version = "0.18", default-features = false }
+thiserror = "2"
 sentry = { version = "0.48", default-features = false, features = [
   "backtrace",
   "contexts",

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -207,3 +207,79 @@ The container runs as non-root UID/GID `10001` (user `docspec`). No capabilities
 ### Reverse proxy
 
 TLS termination, CORS headers, authentication, and rate limiting are intentionally absent from the binary. Place a reverse proxy (nginx, Caddy, etc.) in front of the container for these concerns. See [Deployment Notes](#deployment-notes) for details.
+
+## Metrics
+
+`docspec-http` exposes a Prometheus metrics endpoint on the same port as the main API.
+
+**Endpoint**: `GET /metrics`
+
+**Format**: Prometheus exposition format 0.0.4 (`text/plain; version=0.0.4; charset=utf-8`)
+
+**Auth**: None. The endpoint is internal-only. See [Security](#security) below.
+
+### Metric Catalog
+
+| Name | Type | Labels | Description | Buckets |
+|------|------|--------|-------------|---------|
+| `docspec_http_requests_total` | counter | `method`, `path`, `status` | Total HTTP requests received | — |
+| `docspec_http_request_duration_seconds` | histogram | `method`, `path`, `status` | HTTP request latency in seconds | 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 |
+| `docspec_http_request_body_bytes` | histogram | (none) | HTTP request body size in bytes | 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800 |
+| `docspec_conversions_total` | counter | `result`, `error_class` | Total document conversions | — |
+| `docspec_conversion_duration_seconds` | histogram | `result` | Document conversion duration in seconds | 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 |
+
+### Label Values
+
+**`result`**: `success`, `client_error`, `server_error`
+
+**`error_class`**: `body_not_utf8`, `empty_body`, `internal`, `method_not_allowed`, `not_acceptable`, `not_found`, `unprocessable`, `unsupported_media_type`, `none` (only when `result=success`)
+
+**`path`**: matched route template (`/conversion`, `/health`) or `unknown` for fallback handlers
+
+**`status`**: numeric HTTP status code as a string (e.g., `"200"`, `"422"`)
+
+**`method`**: HTTP method as a string (e.g., `"GET"`, `"POST"`)
+
+### Cardinality Guarantees
+
+`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels.
+
+### Scrape Model
+
+Each pod maintains its own in-memory metrics. Prometheus scrapes each pod independently. No inter-pod communication is required. Aggregate across pods using PromQL.
+
+Upkeep runs every 5 seconds, keeping histogram internal state bounded.
+
+The `/metrics` route is mounted outside the API middleware stack, so it does not include the global `Cache-Control` header used by API responses.
+
+The body-size histogram (`docspec_http_request_body_bytes`) only records bodies that passed Content-Type and Accept validation. Rejected requests are not counted.
+
+### Example PromQL Queries
+
+Per-pod request rate:
+
+```promql
+rate(docspec_http_requests_total[5m])
+```
+
+Aggregate p99 latency across all pods:
+
+```promql
+histogram_quantile(0.99, sum by (le) (rate(docspec_http_request_duration_seconds_bucket[5m])))
+```
+
+Error rate broken down by error class:
+
+```promql
+rate(docspec_conversions_total{result!="success"}[5m])
+```
+
+Body-size p95:
+
+```promql
+histogram_quantile(0.95, sum by (le) (rate(docspec_http_request_body_bytes_bucket[5m])))
+```
+
+### Security
+
+`/metrics` has no authentication. It's intended for internal scraping only. Deploy behind a private overlay network or a Kubernetes `NetworkPolicy` that restricts access to your Prometheus pods.

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -237,6 +237,42 @@ impl IntoResponse for HttpError {
     }
 }
 
+impl HttpError {
+    /// Returns a stable, low-cardinality string identifying the error class.
+    /// Safe to use as a Prometheus label value — never contains per-request data.
+    #[inline]
+    #[must_use]
+    pub fn error_class(&self) -> &'static str {
+        match self {
+            Self::BodyNotUtf8 => "body_not_utf8",
+            Self::EmptyBody => "empty_body",
+            Self::Internal => "internal",
+            Self::MethodNotAllowed { .. } => "method_not_allowed",
+            Self::NotAcceptable => "not_acceptable",
+            Self::NotFound { .. } => "not_found",
+            Self::Unprocessable { .. } => "unprocessable",
+            Self::UnsupportedMediaType { .. } => "unsupported_media_type",
+        }
+    }
+
+    /// Returns the result class for Prometheus labels: `"client_error"` for 4xx, `"server_error"` for 5xx.
+    #[inline]
+    #[must_use]
+    pub fn result_class(&self) -> &'static str {
+        use crate::metrics::{RESULT_CLIENT_ERROR, RESULT_SERVER_ERROR};
+        match self {
+            Self::BodyNotUtf8
+            | Self::EmptyBody
+            | Self::MethodNotAllowed { .. }
+            | Self::NotAcceptable
+            | Self::NotFound { .. }
+            | Self::Unprocessable { .. }
+            | Self::UnsupportedMediaType { .. } => RESULT_CLIENT_ERROR,
+            Self::Internal => RESULT_SERVER_ERROR,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // Reason: test code legitimately panics on assertion failures; unwrap, expect,
@@ -474,6 +510,124 @@ mod tests {
         assert_eq!(
             bytes.as_slice(),
             br#"{"type":"about:blank","title":"Unprocessable Entity","status":422,"detail":"bad\u0001input"}"#
+        );
+    }
+
+    #[test]
+    fn body_not_utf8_error_class_returns_body_not_utf8() {
+        assert_eq!(HttpError::BodyNotUtf8.error_class(), "body_not_utf8");
+    }
+
+    #[test]
+    fn empty_body_error_class_returns_empty_body() {
+        assert_eq!(HttpError::EmptyBody.error_class(), "empty_body");
+    }
+
+    #[test]
+    fn internal_error_class_returns_internal() {
+        assert_eq!(HttpError::Internal.error_class(), "internal");
+    }
+
+    #[test]
+    fn method_not_allowed_error_class_returns_method_not_allowed() {
+        assert_eq!(
+            HttpError::MethodNotAllowed { allowed: "GET" }.error_class(),
+            "method_not_allowed"
+        );
+    }
+
+    #[test]
+    fn not_acceptable_error_class_returns_not_acceptable() {
+        assert_eq!(HttpError::NotAcceptable.error_class(), "not_acceptable");
+    }
+
+    #[test]
+    fn not_found_error_class_returns_not_found() {
+        assert_eq!(
+            HttpError::NotFound {
+                method: "GET".to_owned(),
+                path: "/foo".to_owned()
+            }
+            .error_class(),
+            "not_found"
+        );
+    }
+
+    #[test]
+    fn unprocessable_error_class_returns_unprocessable() {
+        assert_eq!(
+            HttpError::Unprocessable {
+                detail: "bad".to_owned()
+            }
+            .error_class(),
+            "unprocessable"
+        );
+    }
+
+    #[test]
+    fn unsupported_media_type_error_class_returns_unsupported_media_type() {
+        assert_eq!(
+            HttpError::UnsupportedMediaType { received: None }.error_class(),
+            "unsupported_media_type"
+        );
+    }
+
+    #[test]
+    fn body_not_utf8_result_class_returns_client_error() {
+        assert_eq!(HttpError::BodyNotUtf8.result_class(), "client_error");
+    }
+
+    #[test]
+    fn empty_body_result_class_returns_client_error() {
+        assert_eq!(HttpError::EmptyBody.result_class(), "client_error");
+    }
+
+    #[test]
+    fn internal_result_class_returns_server_error() {
+        assert_eq!(HttpError::Internal.result_class(), "server_error");
+    }
+
+    #[test]
+    fn method_not_allowed_result_class_returns_client_error() {
+        assert_eq!(
+            HttpError::MethodNotAllowed { allowed: "GET" }.result_class(),
+            "client_error"
+        );
+    }
+
+    #[test]
+    fn not_acceptable_result_class_returns_client_error() {
+        assert_eq!(HttpError::NotAcceptable.result_class(), "client_error");
+    }
+
+    #[test]
+    fn not_found_result_class_returns_client_error() {
+        assert_eq!(
+            HttpError::NotFound {
+                method: "GET".to_owned(),
+                path: "/foo".to_owned()
+            }
+            .result_class(),
+            "client_error"
+        );
+    }
+
+    #[test]
+    fn unprocessable_result_class_returns_client_error() {
+        assert_eq!(
+            HttpError::Unprocessable {
+                detail: "bad".to_owned()
+            }
+            .result_class(),
+            "client_error"
+        );
+    }
+
+    #[test]
+    fn unsupported_media_type_result_class_returns_client_error() {
+        assert_eq!(
+            HttpError::UnsupportedMediaType { received: None }.result_class(),
+            "client_error"
         );
     }
 }

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -29,12 +29,50 @@ pub async fn options_conversion() -> impl IntoResponse {
 /// surface as 422 (parse / sink errors) or 500 (finalize errors) **before**
 /// any response body is sent — no truncated `200 OK` on failure.
 ///
+/// Conversion outcome metrics (`docspec_conversions_total` and
+/// `docspec_conversion_duration_seconds`) are recorded for **every** request
+/// to this endpoint — including early validation failures — so that all
+/// outcomes are visible in dashboards without dead-code paths.
+///
 /// # Errors
 ///
 /// Returns [`HttpError`] when request headers or body are invalid, the
 /// conversion fails, or the response cannot be constructed.
 #[inline]
 pub async fn post_conversion(headers: HeaderMap, body: Bytes) -> Result<Response<Body>, HttpError> {
+    let conversion_start = std::time::Instant::now();
+    let outcome = do_conversion(headers, body).await;
+    let conversion_duration = conversion_start.elapsed().as_secs_f64();
+
+    let (result_label, error_class_label) = match &outcome {
+        Ok(_) => (
+            crate::metrics::RESULT_SUCCESS,
+            crate::metrics::ERROR_CLASS_NONE,
+        ),
+        Err(http_error) => (http_error.result_class(), http_error.error_class()),
+    };
+
+    metrics::counter!(
+        crate::metrics::METRIC_CONVERSIONS_TOTAL,
+        crate::metrics::LABEL_RESULT => result_label,
+        crate::metrics::LABEL_ERROR_CLASS => error_class_label,
+    )
+    .increment(1);
+
+    metrics::histogram!(
+        crate::metrics::METRIC_CONVERSION_DURATION_SECONDS,
+        crate::metrics::LABEL_RESULT => result_label,
+    )
+    .record(conversion_duration);
+
+    outcome
+}
+
+/// Perform the actual validation and conversion without recording outcome metrics.
+///
+/// Body size is recorded here because it is only known after header validation
+/// succeeds and the body is confirmed non-empty.
+async fn do_conversion(headers: HeaderMap, body: Bytes) -> Result<Response<Body>, HttpError> {
     mime_parser::validate_content_type(headers.get(header::CONTENT_TYPE))?;
     mime_parser::negotiate_accept(headers.get(header::ACCEPT))?;
 
@@ -42,12 +80,21 @@ pub async fn post_conversion(headers: HeaderMap, body: Bytes) -> Result<Response
         return Err(HttpError::EmptyBody);
     }
 
+    // Reason: Body sizes are bounded by request memory and never approach the 2^53
+    // f64 precision limit, so the cast is exact in practice. The Prometheus histogram
+    // API requires f64; usize has no native lossless f64 conversion. Workspace
+    // clippy bans both lints below as a general policy; this is the single
+    // documented false-positive exception for bounded numeric metric recording.
+    #[allow(clippy::cast_precision_loss, clippy::as_conversions)]
+    let body_len_bytes = body.len() as f64;
+    metrics::histogram!(crate::metrics::METRIC_HTTP_REQUEST_BODY_BYTES).record(body_len_bytes);
+
     let markdown = String::from_utf8(body.into()).map_err(|error| {
         tracing::debug!(error = %error, "request body is not valid UTF-8");
         HttpError::BodyNotUtf8
     })?;
 
-    let output = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, HttpError> {
+    let join_result = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, HttpError> {
         let mut output_buffer = Vec::new();
         let mut reader = MarkdownReader::new(&markdown);
         let mut sink = StackTrackingSink::new(BlockNoteWriter::new(&mut output_buffer));
@@ -77,21 +124,24 @@ pub async fn post_conversion(headers: HeaderMap, body: Bytes) -> Result<Response
 
         Ok(output_buffer)
     })
-    .await
-    .map_err(|error| {
-        tracing::error!(error = %error, "spawn_blocking join failed");
-        HttpError::Internal
-    })??;
+    .await;
 
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(
-            header::CONTENT_TYPE,
-            HeaderValue::from_static("application/vnd.docspec.blocknote+json; charset=utf-8"),
-        )
-        .body(Body::from(output))
-        .map_err(|error| {
-            tracing::error!(error = %error, "failed to build conversion response");
-            HttpError::Internal
-        })
+    match join_result {
+        Ok(Ok(output)) => Response::builder()
+            .status(StatusCode::OK)
+            .header(
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/vnd.docspec.blocknote+json; charset=utf-8"),
+            )
+            .body(Body::from(output))
+            .map_err(|error| {
+                tracing::error!(error = %error, "failed to build conversion response");
+                HttpError::Internal
+            }),
+        Ok(Err(http_error)) => Err(http_error),
+        Err(join_error) => {
+            tracing::error!(error = %join_error, "spawn_blocking join failed");
+            Err(HttpError::Internal)
+        }
+    }
 }

--- a/crates/docspec-http/src/lib.rs
+++ b/crates/docspec-http/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cache;
 pub mod error;
 pub mod format;
 pub mod handlers;
+pub mod metrics;
 pub mod mime_parser;
 pub mod router;
 pub mod server;

--- a/crates/docspec-http/src/metrics/middleware.rs
+++ b/crates/docspec-http/src/metrics/middleware.rs
@@ -1,0 +1,133 @@
+//! Tower middleware for recording HTTP-level Prometheus metrics.
+//!
+//! This middleware records [`crate::metrics::METRIC_HTTP_REQUESTS_TOTAL`] and
+//! [`crate::metrics::METRIC_HTTP_REQUEST_DURATION_SECONDS`] for every request
+//! EXCEPT requests to `/metrics` itself (which would create a feedback loop).
+
+use std::time::Instant;
+
+use axum::{body::Body, extract::MatchedPath, http::Request, middleware::Next, response::Response};
+
+use crate::metrics::{
+    LABEL_METHOD, LABEL_PATH, LABEL_STATUS, METRIC_HTTP_REQUESTS_TOTAL,
+    METRIC_HTTP_REQUEST_DURATION_SECONDS, PATH_UNKNOWN,
+};
+
+/// The route path for the Prometheus metrics endpoint.
+/// Requests to this path are excluded from HTTP metrics recording
+/// to prevent a feedback loop on every scrape.
+const METRICS_ROUTE_PATH: &str = "/metrics";
+
+/// Tower middleware that records HTTP request metrics.
+///
+/// Records [`METRIC_HTTP_REQUESTS_TOTAL`] and [`METRIC_HTTP_REQUEST_DURATION_SECONDS`]
+/// for every request except those to `/metrics` (to avoid a scrape feedback loop).
+///
+/// The `path` label uses [`axum::extract::MatchedPath`] (route template, never raw URI).
+/// Fallback routes (404, 405) that have no matched path use the literal `"unknown"`.
+#[inline]
+pub async fn record_http_metrics(request: Request<Body>, next: Next) -> Response {
+    // Extract matched path BEFORE consuming the request
+    let matched_path = request
+        .extensions()
+        .get::<MatchedPath>()
+        .map(|matched: &MatchedPath| matched.as_str().to_owned());
+
+    // Skip recording for /metrics itself to prevent feedback loop
+    if matched_path.as_deref() == Some(METRICS_ROUTE_PATH) {
+        return next.run(request).await;
+    }
+
+    let method = request.method().to_string();
+    let path_label = matched_path.unwrap_or_else(|| PATH_UNKNOWN.to_owned());
+
+    let started_at = Instant::now();
+    let response = next.run(request).await;
+    let duration_seconds = started_at.elapsed().as_secs_f64();
+
+    let status_label = response.status().as_u16().to_string();
+
+    metrics::counter!(
+        METRIC_HTTP_REQUESTS_TOTAL,
+        LABEL_METHOD => method.clone(),
+        LABEL_PATH => path_label.clone(),
+        LABEL_STATUS => status_label.clone()
+    )
+    .increment(1);
+
+    metrics::histogram!(
+        METRIC_HTTP_REQUEST_DURATION_SECONDS,
+        LABEL_METHOD => method,
+        LABEL_PATH => path_label,
+        LABEL_STATUS => status_label
+    )
+    .record(duration_seconds);
+
+    response
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::tests_outside_test_module,
+        clippy::unwrap_used,
+        clippy::expect_used
+    )]
+
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        routing::get,
+        Router,
+    };
+    use tower::ServiceExt as _;
+
+    #[test]
+    fn metrics_route_path_is_metrics() {
+        assert_eq!(METRICS_ROUTE_PATH, "/metrics");
+    }
+
+    /// Verify that the `/metrics` early-return guard (line 38) fires when the
+    /// middleware is mounted ON the `/metrics` route.
+    ///
+    /// In production, `router_with_metrics` adds `/metrics` OUTSIDE the
+    /// middleware layer stack, so the guard is never reached — it is
+    /// defense-in-depth. This test exercises the guard directly by placing
+    /// the route inside the stack, which is the only way to reach that branch.
+    #[test]
+    fn metrics_path_early_return_skips_recording() {
+        let (recorder, handle) = crate::metrics::build_recorder().expect("test recorder builds");
+
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime builds");
+
+        // Mount /metrics INSIDE the middleware so the guard is exercised.
+        let router = Router::new()
+            .route("/metrics", get(|| async { "ok" }))
+            .layer(middleware::from_fn(record_http_metrics));
+
+        let request = Request::builder()
+            .method("GET")
+            .uri("/metrics")
+            .body(Body::empty())
+            .expect("request builds");
+
+        let response = metrics::with_local_recorder(&recorder, || {
+            runtime
+                .block_on(router.oneshot(request))
+                .expect("oneshot succeeds")
+        });
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let rendered = handle.render();
+        assert!(
+            !rendered.contains(crate::metrics::METRIC_HTTP_REQUESTS_TOTAL),
+            "Expected no request counter for /metrics path; got:\n{rendered}"
+        );
+    }
+}

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -1,0 +1,237 @@
+//! Prometheus metrics for the `docspec-http` server.
+//!
+//! Each pod exposes its own `/metrics` endpoint. The Prometheus server
+//! scrapes each pod independently — no aggregation happens in-process.
+//!
+//! # Design
+//!
+//! This module owns all metric-name and label constants. Middleware (see
+//! [`middleware`]) records values; this module only declares and describes
+//! them. Call [`install_global`] once at startup before accepting requests,
+//! then mount the closure returned by [`metrics_handler`] at `/metrics`.
+
+pub mod middleware;
+
+use axum::http::header::CONTENT_TYPE;
+use metrics::{describe_counter, describe_histogram};
+use metrics_exporter_prometheus::{
+    BuildError, Matcher, PrometheusBuilder, PrometheusHandle, PrometheusRecorder,
+};
+
+// ─── Metric-name constants ─────────────────────────────────────────────────
+
+/// Counter: total number of HTTP requests received.
+pub const METRIC_HTTP_REQUESTS_TOTAL: &str = "docspec_http_requests_total";
+
+/// Histogram: HTTP request latency in seconds.
+pub const METRIC_HTTP_REQUEST_DURATION_SECONDS: &str = "docspec_http_request_duration_seconds";
+
+/// Histogram: HTTP request body size in bytes.
+pub const METRIC_HTTP_REQUEST_BODY_BYTES: &str = "docspec_http_request_body_bytes";
+
+/// Counter: total number of document conversions.
+pub const METRIC_CONVERSIONS_TOTAL: &str = "docspec_conversions_total";
+
+/// Histogram: document conversion duration in seconds.
+pub const METRIC_CONVERSION_DURATION_SECONDS: &str = "docspec_conversion_duration_seconds";
+
+// ─── Label key constants ───────────────────────────────────────────────────
+
+/// Label key for the HTTP request method (GET, POST, …).
+pub const LABEL_METHOD: &str = "method";
+
+/// Label key for the matched route path pattern.
+pub const LABEL_PATH: &str = "path";
+
+/// Label key for the HTTP response status code.
+pub const LABEL_STATUS: &str = "status";
+
+/// Label key for the conversion outcome category.
+pub const LABEL_RESULT: &str = "result";
+
+/// Label key for the error class when a conversion fails.
+pub const LABEL_ERROR_CLASS: &str = "error_class";
+
+// ─── Label value constants ─────────────────────────────────────────────────
+
+/// Value for [`LABEL_PATH`] when no route was matched by the router.
+pub const PATH_UNKNOWN: &str = "unknown";
+
+/// Value for [`LABEL_RESULT`] when a conversion succeeds.
+pub const RESULT_SUCCESS: &str = "success";
+
+/// Value for [`LABEL_RESULT`] when a conversion fails due to a client error.
+pub const RESULT_CLIENT_ERROR: &str = "client_error";
+
+/// Value for [`LABEL_RESULT`] when a conversion fails due to a server error.
+pub const RESULT_SERVER_ERROR: &str = "server_error";
+
+/// Value for [`LABEL_ERROR_CLASS`] when no error occurred.
+pub const ERROR_CLASS_NONE: &str = "none";
+
+// ─── Histogram bucket arrays ───────────────────────────────────────────────
+
+/// Latency histogram buckets for HTTP request duration, in seconds.
+pub const HTTP_LATENCY_BUCKETS: [f64; 11] = [
+    0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+/// Body-size histogram buckets for HTTP request bodies, in bytes.
+pub const HTTP_BODY_SIZE_BUCKETS: [f64; 12] = [
+    100.0, 200.0, 400.0, 800.0, 1_600.0, 3_200.0, 6_400.0, 12_800.0, 25_600.0, 51_200.0, 102_400.0,
+    204_800.0,
+];
+
+/// Latency histogram buckets for document conversion duration, in seconds.
+///
+/// Shares the same breakpoints as [`HTTP_LATENCY_BUCKETS`].
+pub const CONVERSION_DURATION_BUCKETS: [f64; 11] = HTTP_LATENCY_BUCKETS;
+
+// ─── Recorder builder ──────────────────────────────────────────────────────
+
+fn configure_buckets(builder: PrometheusBuilder) -> Result<PrometheusBuilder, BuildError> {
+    builder
+        .set_buckets_for_metric(
+            Matcher::Full(METRIC_HTTP_REQUEST_DURATION_SECONDS.to_owned()),
+            &HTTP_LATENCY_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(METRIC_HTTP_REQUEST_BODY_BYTES.to_owned()),
+            &HTTP_BODY_SIZE_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(METRIC_CONVERSION_DURATION_SECONDS.to_owned()),
+            &CONVERSION_DURATION_BUCKETS,
+        )
+}
+
+/// Builds a configured [`PrometheusRecorder`] and its [`PrometheusHandle`]
+/// **without** installing it globally.
+///
+/// Use this in tests together with [`metrics::with_local_recorder`] to keep
+/// test runs isolated from one another and from the global recorder.
+///
+/// # Errors
+///
+/// Returns [`BuildError`] when bucket values are empty or otherwise invalid.
+#[inline]
+pub fn build_recorder() -> Result<(PrometheusRecorder, PrometheusHandle), BuildError> {
+    let recorder = configure_buckets(PrometheusBuilder::new())?.build_recorder();
+    let handle = recorder.handle();
+    Ok((recorder, handle))
+}
+
+/// Installs the Prometheus recorder globally and registers HELP text for every
+/// metric.
+///
+/// Call **once** at server startup before accepting requests. Returns the
+/// [`PrometheusHandle`] needed to scrape the `/metrics` endpoint.
+///
+/// # Errors
+///
+/// Returns [`BuildError`] when bucket configuration or recorder installation
+/// fails (e.g., a global recorder is already installed).
+#[inline]
+pub fn install_global() -> Result<PrometheusHandle, BuildError> {
+    let handle = configure_buckets(PrometheusBuilder::new())?.install_recorder()?;
+
+    describe_counter!(METRIC_HTTP_REQUESTS_TOTAL, "Total HTTP requests received.");
+    describe_histogram!(
+        METRIC_HTTP_REQUEST_DURATION_SECONDS,
+        "HTTP request latency in seconds."
+    );
+    describe_histogram!(
+        METRIC_HTTP_REQUEST_BODY_BYTES,
+        "HTTP request body size in bytes."
+    );
+    describe_counter!(METRIC_CONVERSIONS_TOTAL, "Total document conversions.");
+    describe_histogram!(
+        METRIC_CONVERSION_DURATION_SECONDS,
+        "Document conversion duration in seconds."
+    );
+
+    Ok(handle)
+}
+
+// ─── Metrics endpoint handler ──────────────────────────────────────────────
+
+/// Returns a clone-safe handler closure that renders Prometheus metrics as an
+/// HTTP response with the correct Content-Type.
+///
+/// Mount the returned closure at `/metrics`. The response Content-Type is
+/// `text/plain; version=0.0.4; charset=utf-8` as required by the Prometheus
+/// exposition format specification.
+#[inline]
+pub fn metrics_handler(
+    handle: PrometheusHandle,
+) -> impl Fn() -> core::future::Ready<axum::response::Response> + Clone + Send + 'static {
+    move || {
+        let output = handle.render();
+        core::future::ready(
+            axum::http::Response::builder()
+                .header(CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8")
+                .body(axum::body::Body::from(output))
+                .unwrap_or_else(|_| {
+                    let mut response = axum::response::Response::new(axum::body::Body::from(
+                        "failed to render metrics response",
+                    ));
+                    *response.status_mut() = axum::http::StatusCode::INTERNAL_SERVER_ERROR;
+                    response
+                }),
+        )
+    }
+}
+
+#[cfg(test)]
+mod handler_tests {
+    #![allow(
+        clippy::tests_outside_test_module,
+        clippy::unwrap_used,
+        clippy::expect_used
+    )]
+
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn metrics_handler_returns_200() {
+        let (recorder, handle) = build_recorder().expect("test recorder builds");
+        let result = metrics::with_local_recorder(&recorder, || {
+            let handler = metrics_handler(handle);
+            handler()
+        });
+        let response = result.await;
+        assert_eq!(response.status(), axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn metrics_handler_content_type_is_prometheus_text() {
+        let (recorder, handle) = build_recorder().expect("test recorder builds");
+        let result = metrics::with_local_recorder(&recorder, || {
+            let handler = metrics_handler(handle);
+            handler()
+        });
+        let response = result.await;
+        let content_type = response
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .expect("content-type header present")
+            .to_str()
+            .expect("content-type is valid str");
+        assert_eq!(content_type, "text/plain; version=0.0.4; charset=utf-8");
+    }
+
+    #[tokio::test]
+    async fn metrics_handler_body_is_valid_utf8() {
+        let (recorder, handle) = build_recorder().expect("test recorder builds");
+        let result = metrics::with_local_recorder(&recorder, || {
+            let handler = metrics_handler(handle);
+            handler()
+        });
+        let response = result.await;
+        let body_bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body readable");
+        let _body_str = String::from_utf8(body_bytes.to_vec()).expect("body is valid UTF-8");
+    }
+}

--- a/crates/docspec-http/src/router.rs
+++ b/crates/docspec-http/src/router.rs
@@ -1,7 +1,10 @@
 //! HTTP router and route definitions.
 
 use axum::{http::Request, Router};
+use metrics_exporter_prometheus::PrometheusHandle;
 use tower_http::request_id::{MakeRequestId, RequestId};
+
+use crate::metrics::{metrics_handler, middleware::record_http_metrics};
 
 /// A [`MakeRequestId`] implementation that never generates a request ID.
 ///
@@ -91,8 +94,27 @@ pub fn router() -> Router {
                 .layer(option_layer(telemetry::tower_http_layer()))
                 .layer(middleware::from_fn(attach_sentry_tags))
                 .layer(TraceLayer::new_for_http())
+                .layer(middleware::from_fn(record_http_metrics))
                 .layer(PropagateRequestIdLayer::new(x_request_id))
                 .layer(PropagateRequestIdLayer::new(x_trace_id))
                 .layer(cache_control_layer()),
         )
+}
+
+/// Builds the public router and additionally registers `GET /metrics`
+/// using the provided Prometheus handle.
+///
+/// The `/metrics` route is intentionally registered **after** the
+/// `ServiceBuilder` layer stack so it does NOT inherit:
+///   - `cache_control_layer` (Prometheus scrapers ignore cache headers,
+///     but a clean exposition response is preferred)
+///   - request-id / trace-id propagation
+///   - sentry hub binding
+///   - the HTTP metrics middleware (double-skip protection — even if
+///     someone removes the `MatchedPath == "/metrics"` guard in
+///     `record_http_metrics`, the router topology still prevents the
+///     scrape from incrementing counters).
+#[inline]
+pub fn router_with_metrics(handle: PrometheusHandle) -> Router {
+    router().route("/metrics", axum::routing::get(metrics_handler(handle)))
 }

--- a/crates/docspec-http/src/server.rs
+++ b/crates/docspec-http/src/server.rs
@@ -1,6 +1,21 @@
 //! HTTP server implementation.
 
+use core::time::Duration;
+
+use metrics_exporter_prometheus::BuildError;
 use tokio::net::TcpListener;
+
+/// Errors that can occur while starting or running the HTTP server.
+#[derive(Debug, thiserror::Error)]
+pub enum ServerError {
+    /// A TCP bind or Axum serve I/O failure.
+    #[error(transparent)]
+    Listen(#[from] std::io::Error),
+
+    /// Failed to install the Prometheus metrics recorder.
+    #[error("failed to initialize Prometheus metrics recorder: {0}")]
+    MetricsInit(#[source] BuildError),
+}
 
 /// Configuration for the HTTP server.
 pub struct ServerConfig {
@@ -46,23 +61,47 @@ pub async fn bind(config: &ServerConfig) -> std::io::Result<TcpListener> {
 
 /// Bind and start the HTTP server, shutting down gracefully on SIGINT/SIGTERM.
 ///
-/// Delegates binding to [`bind`]. Logs the actual bound address using
-/// [`TcpListener::local_addr`] rather than the configured port, so that port
-/// `0` (OS-assigned) shows the real port.
+/// Delegates binding to [`bind`], installs the Prometheus metrics recorder
+/// globally, then spawns an upkeep task that is aborted when the server future
+/// completes. Logs the actual bound address using [`TcpListener::local_addr`]
+/// rather than the configured port, so that port `0` (OS-assigned) shows the
+/// real port.
 ///
 /// # Errors
 ///
-/// Returns [`Err`] if the host cannot be resolved, the port is already in use,
-/// or listening fails.
+/// Returns [`Err`] if the Prometheus recorder cannot be installed, the host
+/// cannot be resolved, the port is already in use, or listening fails.
 #[inline]
-pub async fn serve(config: ServerConfig) -> std::io::Result<()> {
+pub async fn serve(config: ServerConfig) -> Result<(), ServerError> {
     let listener = bind(&config).await?;
     let bound_addr = listener.local_addr()?;
+
+    let handle = crate::metrics::install_global().map_err(ServerError::MetricsInit)?;
+    let upkeep_handle = handle.clone();
+    let upkeep_task = tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(5));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            upkeep_handle.run_upkeep();
+        }
+    });
+
     tracing::info!(addr = %bound_addr, "docspec-http listening");
 
-    axum::serve(listener, crate::router::router())
+    let server_result = axum::serve(listener, crate::router::router_with_metrics(handle))
         .with_graceful_shutdown(shutdown_signal())
-        .await
+        .await;
+
+    upkeep_task.abort();
+    match upkeep_task.await {
+        Err(error) if error.is_cancelled() => {}
+        Err(error) => tracing::error!(%error, "metrics upkeep task failed during shutdown"),
+        Ok(()) => {}
+    }
+    server_result?;
+
+    Ok(())
 }
 
 /// Resolves when SIGINT (Ctrl+C) or SIGTERM is received.

--- a/crates/docspec-http/tests/common/mod.rs
+++ b/crates/docspec-http/tests/common/mod.rs
@@ -1,0 +1,33 @@
+//! Shared test utilities for docspec-http integration tests.
+//!
+//! Tests that exercise Prometheus metrics use [`with_test_recorder`] to
+//! scope a fresh, isolated recorder for the duration of a closure.
+//!
+//! Importantly: `metrics::with_local_recorder` is THREAD-LOCAL and does
+//! NOT propagate into `tokio::task::spawn_blocking`. Tests that exercise
+//! blocking work must record metrics in the async context (this matches
+//! the production pattern established in the conversion handler).
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used,
+    dead_code
+)]
+
+use metrics_exporter_prometheus::PrometheusHandle;
+
+/// Runs `body` inside a thread-local Prometheus recorder; returns
+/// `(handle, body_result)`. Callers use `handle.render()` to inspect the
+/// exposition-format scrape body.
+///
+/// # Panics
+///
+/// Panics if the test recorder cannot be built (should never happen in tests).
+pub fn with_test_recorder<R, F>(body: F) -> (PrometheusHandle, R)
+where
+    F: FnOnce() -> R,
+{
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("test recorder builds");
+    let result = metrics::with_local_recorder(&recorder, body);
+    (handle, result)
+}

--- a/crates/docspec-http/tests/common_helpers_smoke.rs
+++ b/crates/docspec-http/tests/common_helpers_smoke.rs
@@ -1,0 +1,29 @@
+//! Smoke tests for the `with_test_recorder` helper.
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+mod common;
+
+#[test]
+fn with_test_recorder_returns_usable_handle() {
+    let (handle, ()) = common::with_test_recorder(|| {});
+    let _body = handle.render();
+}
+
+#[test]
+fn with_test_recorder_counter_appears_in_render() {
+    let (handle, ()) = common::with_test_recorder(|| {
+        metrics::counter!("docspec_test_counter_total").increment(1);
+    });
+    let body = handle.render();
+    let lines: Vec<&str> = body.lines().collect();
+    // Assert exact line equality — no substring matching
+    let type_line = "# TYPE docspec_test_counter_total counter".to_string();
+    assert!(
+        lines.iter().any(|l| *l == type_line),
+        "Expected exact line '{type_line}' in rendered output:\n{body}"
+    );
+}

--- a/crates/docspec-http/tests/http_smoke.rs
+++ b/crates/docspec-http/tests/http_smoke.rs
@@ -259,3 +259,71 @@ fn smoke_error_response_has_cache_control() {
         })
     );
 }
+
+#[test]
+fn smoke_metrics_endpoint_returns_prometheus_format() {
+    let (_guard, port) = start_server();
+    let base = format!("http://127.0.0.1:{port}");
+    let client = smoke_client();
+
+    let health = client
+        .get(format!("{base}/health"))
+        .send()
+        .expect("health request");
+    assert_eq!(health.status(), reqwest::StatusCode::OK);
+
+    let conversion = client
+        .post(format!("{base}/conversion"))
+        .header("content-type", "text/markdown")
+        .header("accept", "application/vnd.docspec.blocknote+json")
+        .body("# Hello World")
+        .send()
+        .expect("conversion request");
+    assert_eq!(conversion.status(), reqwest::StatusCode::OK);
+
+    let response = client
+        .get(format!("{base}/metrics"))
+        .send()
+        .expect("metrics request");
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("content-type")
+            .expect("content-type header")
+            .to_str()
+            .expect("content-type header value"),
+        "text/plain; version=0.0.4; charset=utf-8"
+    );
+
+    let body = response.text().expect("metrics body");
+    for metric_name in [
+        "docspec_http_requests_total",
+        "docspec_http_request_duration_seconds",
+        "docspec_http_request_body_bytes",
+        "docspec_conversions_total",
+        "docspec_conversion_duration_seconds",
+    ] {
+        let help_prefix = format!("# HELP {metric_name} ");
+        assert!(
+            body.lines().any(|line| line.starts_with(&help_prefix)),
+            "missing HELP line for {metric_name} in:\n{body}"
+        );
+    }
+    let body_after_second_scrape = client
+        .get(format!("{base}/metrics"))
+        .send()
+        .expect("second metrics request")
+        .text()
+        .expect("second metrics body");
+
+    let metrics_in_counter = body_after_second_scrape
+        .lines()
+        .filter(|line| line.starts_with("docspec_http_requests_total{"))
+        .any(|line| line.contains(r#"path="/metrics""#));
+
+    assert!(
+        !metrics_in_counter,
+        "/metrics appeared in docspec_http_requests_total:\n{body_after_second_scrape}"
+    );
+}

--- a/crates/docspec-http/tests/metrics_cardinality.rs
+++ b/crates/docspec-http/tests/metrics_cardinality.rs
@@ -1,0 +1,340 @@
+//! Cardinality regression tests for Prometheus metric label values.
+//!
+//! Pins the exact or bounded set of values each label can take. Any future
+//! code change that introduces a new label value fails here, requiring explicit
+//! acknowledgment and a deliberate plan update.
+
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+mod common;
+
+use std::collections::BTreeSet;
+
+use axum::{body::Body, http::Request};
+use docspec_http::{
+    metrics::{build_recorder, METRIC_CONVERSIONS_TOTAL, METRIC_HTTP_REQUESTS_TOTAL},
+    router::router_with_metrics,
+};
+use tower::ServiceExt as _;
+
+fn extract_label_values(rendered: &str, metric_name: &str, label_key: &str) -> BTreeSet<String> {
+    rendered
+        .lines()
+        .filter(|l| l.starts_with(metric_name) && !l.starts_with('#'))
+        .filter_map(|l| {
+            let key_eq = format!("{label_key}=\"");
+            let start = l.find(&key_eq)?.checked_add(key_eq.len())?;
+            let rest = l.get(start..)?;
+            let end = rest.find('"')?.checked_add(start)?;
+            Some(l.get(start..end)?.to_owned())
+        })
+        .collect()
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn path_label_cardinality_is_bounded_to_known_routes() {
+    let (recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle.clone());
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("HEAD")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .body(Body::from("# Hello"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/does-not-exist")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    // Extra segments beyond the registered template do not extend it — still "unknown"
+    {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/conversion/with/extra/segments")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+
+    let rendered = handle.render();
+    let observed = extract_label_values(&rendered, METRIC_HTTP_REQUESTS_TOTAL, "path");
+
+    let expected: BTreeSet<String> = ["/conversion", "/health", "unknown"]
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect();
+
+    assert_eq!(
+        observed, expected,
+        "path label set must be exactly {{/conversion, /health, unknown}}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn query_string_not_in_path_label() {
+    let (recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle.clone());
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/health?secret=token&another=value")
+        .body(Body::empty())
+        .unwrap();
+    router.oneshot(req).await.unwrap();
+
+    let rendered = handle.render();
+
+    assert!(
+        !rendered.contains("secret=token"),
+        "query param 'secret=token' must not appear in rendered metrics:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains("another=value"),
+        "query param 'another=value' must not appear in rendered metrics:\n{rendered}"
+    );
+    assert!(
+        !rendered.contains('?'),
+        "query string delimiter '?' must not appear in rendered metrics:\n{rendered}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn error_class_cardinality_bounded() {
+    let (recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle.clone());
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .body(Body::from("# Hello"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .header("accept", "text/plain")
+            .body(Body::from("# Hello"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+
+    let rendered = handle.render();
+    let observed = extract_label_values(&rendered, METRIC_CONVERSIONS_TOTAL, "error_class");
+
+    let allowed: BTreeSet<String> = [
+        "empty_body",
+        "body_not_utf8",
+        "internal",
+        "method_not_allowed",
+        "not_acceptable",
+        "not_found",
+        "unprocessable",
+        "unsupported_media_type",
+        "none",
+    ]
+    .iter()
+    .map(|s| (*s).to_owned())
+    .collect();
+
+    let unexpected: BTreeSet<_> = observed.difference(&allowed).collect();
+    assert!(
+        unexpected.is_empty(),
+        "unexpected error_class values observed: {unexpected:?}\nallowed set: {allowed:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn result_label_cardinality_bounded() {
+    let (recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle.clone());
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .body(Body::from("# Hello"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+
+    let rendered = handle.render();
+    let observed = extract_label_values(&rendered, METRIC_CONVERSIONS_TOTAL, "result");
+
+    let allowed: BTreeSet<String> = ["success", "client_error", "server_error"]
+        .iter()
+        .map(|s| (*s).to_owned())
+        .collect();
+
+    let unexpected: BTreeSet<_> = observed.difference(&allowed).collect();
+    assert!(
+        unexpected.is_empty(),
+        "unexpected result values observed: {unexpected:?}\nallowed set: {allowed:?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn status_label_only_observed_codes() {
+    let (recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle.clone());
+    let _guard = metrics::set_default_local_recorder(&recorder);
+
+    {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    // HEAD /health is an explicitly registered handler returning 204, not the default 200
+    {
+        let req = Request::builder()
+            .method("HEAD")
+            .uri("/health")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .body(Body::from("# Hello"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/does-not-exist")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/conversion")
+            .body(Body::empty())
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "text/markdown")
+            .header("accept", "text/plain")
+            .body(Body::from("# Hello"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+    {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/conversion")
+            .header("content-type", "application/json")
+            .body(Body::from("{}"))
+            .unwrap();
+        router.clone().oneshot(req).await.unwrap()
+    };
+
+    let rendered = handle.render();
+    let observed = extract_label_values(&rendered, METRIC_HTTP_REQUESTS_TOTAL, "status");
+
+    let allowed: BTreeSet<String> = [
+        "200", "204", "400", "404", "405", "406", "415", "422", "500",
+    ]
+    .iter()
+    .map(|s| (*s).to_owned())
+    .collect();
+
+    let unexpected: BTreeSet<_> = observed.difference(&allowed).collect();
+    assert!(
+        unexpected.is_empty(),
+        "unexpected status values observed: {unexpected:?}\nallowed set: {allowed:?}"
+    );
+}

--- a/crates/docspec-http/tests/metrics_conversion.rs
+++ b/crates/docspec-http/tests/metrics_conversion.rs
@@ -1,0 +1,244 @@
+//! Integration tests for conversion outcome metrics.
+//!
+//! Each test uses a fresh, isolated Prometheus recorder via
+//! [`docspec_http::metrics::build_recorder`] and [`metrics::with_local_recorder`].
+//! No global recorder is installed.
+//!
+//! Tests are synchronous: each test creates its own
+//! `tokio::runtime::Runtime` and drives the HTTP request inside
+//! [`metrics::with_local_recorder`], so the thread-local recorder is active
+//! throughout the full request — including after any `spawn_blocking` join.
+
+// Reason: integration tests use standard test patterns with expect/unwrap.
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+use axum::{body::Body, http::Request};
+use tower::ServiceExt as _;
+
+// ─── Test helpers ─────────────────────────────────────────────────────────────
+
+fn make_runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime builds")
+}
+
+fn valid_markdown_request(body: impl Into<Body>) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "text/markdown")
+        .header("accept", "application/vnd.docspec.blocknote+json")
+        .body(body.into())
+        .unwrap()
+}
+
+/// Asserts that the Prometheus exposition text `rendered` contains a line that
+/// is an exact string match of `expected_line`.
+fn assert_metric_line(rendered: &str, expected_line: &str) {
+    let found = rendered.lines().any(|line| line == expected_line);
+    assert!(
+        found,
+        "Expected metric line not found.\n  expected: {expected_line}\n  rendered:\n{rendered}",
+    );
+}
+
+// ─── Test 1: success ─────────────────────────────────────────────────────────
+
+/// A successful conversion increments `docspec_conversions_total` with
+/// `result="success"` and `error_class="none"`.
+#[test]
+fn success_increments_with_none_error_class() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(valid_markdown_request("# Hello World")))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="success",error_class="none"} 1"#,
+    );
+}
+
+// ─── Test 2: empty body ───────────────────────────────────────────────────────
+
+/// An empty request body increments `docspec_conversions_total` with
+/// `result="client_error"` and `error_class="empty_body"`.
+#[test]
+fn empty_body_records_client_error() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(valid_markdown_request("")))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="client_error",error_class="empty_body"} 1"#,
+    );
+}
+
+// ─── Test 3: invalid UTF-8 ────────────────────────────────────────────────────
+
+/// A request body with invalid UTF-8 bytes increments `docspec_conversions_total`
+/// with `result="client_error"` and `error_class="body_not_utf8"`.
+#[test]
+fn invalid_utf8_records_client_error() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "text/markdown")
+        .header("accept", "application/vnd.docspec.blocknote+json")
+        .body(Body::from(b"\xFF\xFE\x00".to_vec()))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="client_error",error_class="body_not_utf8"} 1"#,
+    );
+}
+
+// ─── Test 4: unsupported media type ──────────────────────────────────────────
+
+/// A request with an unsupported `Content-Type` increments
+/// `docspec_conversions_total` with `result="client_error"` and
+/// `error_class="unsupported_media_type"`.
+#[test]
+fn unsupported_media_type_records_client_error() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "application/json")
+        .header("accept", "application/vnd.docspec.blocknote+json")
+        .body(Body::from(r#"{"hello": "world"}"#))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="client_error",error_class="unsupported_media_type"} 1"#,
+    );
+}
+
+// ─── Test 5: not acceptable ───────────────────────────────────────────────────
+
+/// A request with a non-matching `Accept` header increments
+/// `docspec_conversions_total` with `result="client_error"` and
+/// `error_class="not_acceptable"`.
+#[test]
+fn not_acceptable_records_client_error() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "text/markdown")
+        .header("accept", "application/json")
+        .body(Body::from("# Hello"))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="client_error",error_class="not_acceptable"} 1"#,
+    );
+}
+
+// ─── Test 6: duration on success ─────────────────────────────────────────────
+
+/// A successful conversion records one observation in
+/// `docspec_conversion_duration_seconds` with `result="success"`.
+#[test]
+fn conversion_duration_recorded_on_success() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(valid_markdown_request("# Hello")))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversion_duration_seconds_count{result="success"} 1"#,
+    );
+}
+
+// ─── Test 7: duration on error ───────────────────────────────────────────────
+
+/// A failed conversion (empty body) records one observation in
+/// `docspec_conversion_duration_seconds` with `result="client_error"`.
+#[test]
+fn conversion_duration_recorded_on_error() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(valid_markdown_request("")))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversion_duration_seconds_count{result="client_error"} 1"#,
+    );
+}
+
+// ─── Test 8: body size ───────────────────────────────────────────────────────
+
+/// The body size histogram records the exact byte count of the request body.
+/// `b"# Hello"` is 7 bytes (`#`, ` `, `H`, `e`, `l`, `l`, `o`), so the
+/// `docspec_http_request_body_bytes_sum` line must equal `7`.
+#[test]
+fn body_size_histogram_records_correct_byte_count() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    // "# Hello" = '#' + ' ' + 'H' + 'e' + 'l' + 'l' + 'o' = 7 bytes
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(valid_markdown_request("# Hello")))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(&rendered, "docspec_http_request_body_bytes_sum 7");
+}

--- a/crates/docspec-http/tests/metrics_endpoint.rs
+++ b/crates/docspec-http/tests/metrics_endpoint.rs
@@ -1,0 +1,152 @@
+//! Integration tests for the `/metrics` endpoint.
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+mod common;
+
+use axum::{
+    body::{to_bytes, Body},
+    http::{header::CONTENT_TYPE, Request, StatusCode},
+};
+use docspec_http::{
+    metrics::{
+        build_recorder, METRIC_CONVERSIONS_TOTAL, METRIC_CONVERSION_DURATION_SECONDS,
+        METRIC_HTTP_REQUESTS_TOTAL, METRIC_HTTP_REQUEST_BODY_BYTES,
+        METRIC_HTTP_REQUEST_DURATION_SECONDS,
+    },
+    router::router_with_metrics,
+};
+use metrics::{describe_counter, describe_histogram};
+use tower::ServiceExt as _;
+
+#[tokio::test]
+async fn get_metrics_returns_200() {
+    let (_recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle);
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.expect("oneshot succeeds");
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn get_metrics_content_type_is_prometheus_text() {
+    let (_recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle);
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.expect("oneshot succeeds");
+    let content_type = response
+        .headers()
+        .get(CONTENT_TYPE)
+        .expect("content-type header present")
+        .to_str()
+        .expect("content-type is valid UTF-8");
+    assert_eq!(content_type, "text/plain; version=0.0.4; charset=utf-8");
+}
+
+#[tokio::test]
+async fn get_metrics_body_contains_help_and_type_lines_for_all_five_metrics() {
+    let (recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle);
+
+    // build_recorder() does not call describe_* — only install_global() does.
+    // Register descriptions AND record a data point for each metric:
+    // metrics-exporter-prometheus 0.18 only emits # HELP / # TYPE lines for
+    // metrics that have at least one recorded data point.
+    metrics::with_local_recorder(&recorder, || {
+        describe_counter!(METRIC_HTTP_REQUESTS_TOTAL, "Total HTTP requests received.");
+        describe_histogram!(
+            METRIC_HTTP_REQUEST_DURATION_SECONDS,
+            "HTTP request latency in seconds."
+        );
+        describe_histogram!(
+            METRIC_HTTP_REQUEST_BODY_BYTES,
+            "HTTP request body size in bytes."
+        );
+        describe_counter!(METRIC_CONVERSIONS_TOTAL, "Total document conversions.");
+        describe_histogram!(
+            METRIC_CONVERSION_DURATION_SECONDS,
+            "Document conversion duration in seconds."
+        );
+        metrics::counter!(METRIC_HTTP_REQUESTS_TOTAL).increment(1);
+        metrics::histogram!(METRIC_HTTP_REQUEST_DURATION_SECONDS).record(0.001);
+        metrics::histogram!(METRIC_HTTP_REQUEST_BODY_BYTES).record(100.0);
+        metrics::counter!(METRIC_CONVERSIONS_TOTAL).increment(1);
+        metrics::histogram!(METRIC_CONVERSION_DURATION_SECONDS).record(0.001);
+    });
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.expect("oneshot succeeds");
+
+    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+    let lines: Vec<&str> = body.lines().collect();
+
+    for metric_name in [
+        METRIC_HTTP_REQUESTS_TOTAL,
+        METRIC_HTTP_REQUEST_DURATION_SECONDS,
+        METRIC_HTTP_REQUEST_BODY_BYTES,
+        METRIC_CONVERSIONS_TOTAL,
+        METRIC_CONVERSION_DURATION_SECONDS,
+    ] {
+        let help_prefix = format!("# HELP {metric_name} ");
+        assert!(
+            lines.iter().any(|line| line.starts_with(&help_prefix)),
+            "Missing # HELP line for metric '{metric_name}'"
+        );
+        let type_prefix = format!("# TYPE {metric_name} ");
+        assert!(
+            lines.iter().any(|line| line.starts_with(&type_prefix)),
+            "Missing # TYPE line for metric '{metric_name}'"
+        );
+    }
+}
+
+#[tokio::test]
+async fn get_metrics_body_contains_no_request_id_label_keys() {
+    let (_recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle);
+    let request = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.expect("oneshot succeeds");
+
+    let body_bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let body = String::from_utf8(body_bytes.to_vec()).unwrap();
+
+    for forbidden in ["x_request_id", "x_trace_id", "request_id", "trace_id"] {
+        assert!(
+            !body.contains(forbidden),
+            "Metrics body must not contain label key '{forbidden}'"
+        );
+    }
+}
+
+#[tokio::test]
+async fn delete_metrics_returns_405() {
+    let (_recorder, handle) = build_recorder().expect("recorder builds");
+    let router = router_with_metrics(handle);
+    let request = Request::builder()
+        .method("DELETE")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let response = router.oneshot(request).await.expect("oneshot succeeds");
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}

--- a/crates/docspec-http/tests/metrics_http.rs
+++ b/crates/docspec-http/tests/metrics_http.rs
@@ -1,0 +1,286 @@
+//! Integration tests for the HTTP metrics middleware.
+//!
+//! Each test installs an isolated recorder via [`common::with_test_recorder`]
+//! and sends requests using [`tower::ServiceExt::oneshot`].
+//!
+//! `metrics::with_local_recorder` is thread-local, so tests use a manually
+//! created `current_thread` runtime and call `rt.block_on(...)` **inside**
+//! the closure so the recorder is active for the entire request lifecycle.
+
+// Reason: integration tests use standard test patterns with expect/unwrap.
+#![allow(
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used,
+    clippy::expect_used
+)]
+
+mod common;
+
+use axum::{
+    body::Body,
+    http::{header, Request, StatusCode},
+    Router,
+};
+use docspec_http::{
+    metrics::{
+        HTTP_LATENCY_BUCKETS, METRIC_HTTP_REQUESTS_TOTAL, METRIC_HTTP_REQUEST_DURATION_SECONDS,
+    },
+    router::router_with_metrics,
+};
+use tower::ServiceExt as _;
+
+fn parse_metric_lines<'a>(rendered: &'a str, metric_name: &str) -> Vec<&'a str> {
+    rendered
+        .lines()
+        .filter(|l| l.starts_with(metric_name))
+        .collect()
+}
+
+fn make_rt() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+}
+
+/// Builds a router with a throw-away handle for the `/metrics` route.
+///
+/// Metric values are captured by the thread-local recorder active at request
+/// time — the dummy handle only satisfies `router_with_metrics`'s signature.
+fn make_router() -> Router {
+    let (_, dummy_handle) = docspec_http::metrics::build_recorder().expect("dummy recorder");
+    router_with_metrics(dummy_handle)
+}
+
+#[test]
+fn get_health_increments_requests_total() {
+    let rt = make_rt();
+    let router = make_router();
+    let request = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let (handle, _) = common::with_test_recorder(|| {
+        rt.block_on(router.oneshot(request))
+            .expect("request succeeds")
+    });
+
+    let rendered = handle.render();
+    let expected = r#"docspec_http_requests_total{method="GET",path="/health",status="200"} 1"#;
+    assert!(
+        rendered.lines().any(|l| l == expected),
+        "Expected line not found in rendered output:\n{rendered}"
+    );
+}
+
+#[test]
+fn post_conversion_increments_requests_total() {
+    let rt = make_rt();
+    let router = make_router();
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header(header::CONTENT_TYPE, "text/markdown")
+        .body(Body::from("# Hello"))
+        .unwrap();
+
+    let (handle, _) = common::with_test_recorder(|| {
+        rt.block_on(router.oneshot(request))
+            .expect("request succeeds")
+    });
+
+    let rendered = handle.render();
+    let expected =
+        r#"docspec_http_requests_total{method="POST",path="/conversion",status="200"} 1"#;
+    assert!(
+        rendered.lines().any(|l| l == expected),
+        "Expected line not found in rendered output:\n{rendered}"
+    );
+}
+
+#[test]
+fn post_conversion_error_status_label() {
+    let rt = make_rt();
+    let router = make_router();
+    // Empty body → 400 Bad Request from the conversion handler.
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header(header::CONTENT_TYPE, "text/markdown")
+        .body(Body::empty())
+        .unwrap();
+
+    let (handle, response) = common::with_test_recorder(|| {
+        rt.block_on(router.oneshot(request))
+            .expect("request succeeds")
+    });
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "expected 400 for empty body"
+    );
+
+    let rendered = handle.render();
+    let expected =
+        r#"docspec_http_requests_total{method="POST",path="/conversion",status="400"} 1"#;
+    assert!(
+        rendered.lines().any(|l| l == expected),
+        "Expected status=400 counter line not found in rendered output:\n{rendered}"
+    );
+}
+
+#[test]
+fn request_duration_histogram_records_observation() {
+    let rt = make_rt();
+    let router = make_router();
+    let request = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let (handle, _) = common::with_test_recorder(|| {
+        rt.block_on(router.oneshot(request))
+            .expect("request succeeds")
+    });
+
+    let rendered = handle.render();
+    let expected = r#"docspec_http_request_duration_seconds_count{method="GET",path="/health",status="200"} 1"#;
+    assert!(
+        rendered.lines().any(|l| l == expected),
+        "Expected histogram _count line not found in rendered output:\n{rendered}"
+    );
+}
+
+#[test]
+fn histogram_buckets_match_spec() {
+    let rt = make_rt();
+    let router = make_router();
+    let request = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let (handle, _) = common::with_test_recorder(|| {
+        rt.block_on(router.oneshot(request))
+            .expect("request succeeds")
+    });
+
+    let rendered = handle.render();
+    let bucket_prefix = format!("{METRIC_HTTP_REQUEST_DURATION_SECONDS}_bucket");
+
+    // Collect the le= string values from every _bucket line.
+    let le_strings: Vec<String> = rendered
+        .lines()
+        .filter(|l| l.starts_with(bucket_prefix.as_str()))
+        .filter_map(|l| {
+            let (_, after_le) = l.split_once(r#"le=""#)?;
+            let (le_value, _) = after_le.split_once('"')?;
+            Some(le_value.to_owned())
+        })
+        .collect();
+
+    // +Inf must always be present.
+    assert!(
+        le_strings.iter().any(|s| s == "+Inf"),
+        "Expected +Inf bucket; got le= values: {le_strings:?}"
+    );
+
+    // Parse finite le= values as f64 and compare numerically against the
+    // spec to avoid string-formatting sensitivity (e.g. "1" vs "1.0").
+    let mut observed: Vec<f64> = le_strings
+        .iter()
+        .filter(|s| s.as_str() != "+Inf")
+        .map(|s| s.parse::<f64>().expect("le value is a valid float"))
+        .collect();
+    observed.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    let mut expected: Vec<f64> = HTTP_LATENCY_BUCKETS.to_vec();
+    expected.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+    assert_eq!(
+        observed, expected,
+        "Histogram bucket boundaries don't match HTTP_LATENCY_BUCKETS"
+    );
+}
+
+#[test]
+fn metrics_route_skipped() {
+    let rt = make_rt();
+    // Use an explicit recorder/handle pair so the router's /metrics route is
+    // properly registered (needed for MatchedPath to be "/metrics").
+    let (_, dummy_handle) = docspec_http::metrics::build_recorder().expect("dummy recorder");
+    let router = router_with_metrics(dummy_handle);
+
+    let health_req = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+    let metrics_req1 = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+    let metrics_req2 = Request::builder()
+        .method("GET")
+        .uri("/metrics")
+        .body(Body::empty())
+        .unwrap();
+
+    let (handle, ()) = common::with_test_recorder(|| {
+        let _ = rt
+            .block_on(router.clone().oneshot(health_req))
+            .expect("health request succeeds");
+        let _ = rt
+            .block_on(router.clone().oneshot(metrics_req1))
+            .expect("first metrics request succeeds");
+        let _ = rt
+            .block_on(router.clone().oneshot(metrics_req2))
+            .expect("second metrics request succeeds");
+    });
+
+    let rendered = handle.render();
+    let counter_lines = parse_metric_lines(&rendered, METRIC_HTTP_REQUESTS_TOTAL);
+
+    let health_expected =
+        r#"docspec_http_requests_total{method="GET",path="/health",status="200"} 1"#;
+    assert!(
+        counter_lines.contains(&health_expected),
+        "Expected /health counter line; rendered output:\n{rendered}"
+    );
+
+    assert!(
+        !counter_lines
+            .iter()
+            .any(|l| l.contains(r#"path="/metrics""#)),
+        r#"Unexpected path="/metrics" found in counter lines; rendered output:{rendered}"#
+    );
+}
+
+#[test]
+fn fallback_404_uses_unknown_path_label() {
+    let rt = make_rt();
+    let router = make_router();
+    let request = Request::builder()
+        .method("GET")
+        .uri("/does-not-exist")
+        .body(Body::empty())
+        .unwrap();
+
+    let (handle, _) = common::with_test_recorder(|| {
+        rt.block_on(router.oneshot(request))
+            .expect("request succeeds")
+    });
+
+    let rendered = handle.render();
+    let expected = r#"docspec_http_requests_total{method="GET",path="unknown",status="404"} 1"#;
+    assert!(
+        rendered.lines().any(|l| l == expected),
+        "Expected line not found in rendered output:\n{rendered}"
+    );
+}

--- a/crates/docspec-http/tests/server_bind.rs
+++ b/crates/docspec-http/tests/server_bind.rs
@@ -4,7 +4,10 @@
 
 use tokio::net::TcpListener;
 
-use docspec_http::server::{bind, serve, ServerConfig};
+use docspec_http::{
+    metrics::install_global,
+    server::{bind, serve, ServerConfig, ServerError},
+};
 
 #[tokio::test]
 async fn bind_succeeds_on_port_zero() {
@@ -18,7 +21,7 @@ async fn bind_succeeds_on_port_zero() {
 }
 
 #[tokio::test]
-async fn unresolvable_host_returns_error() {
+async fn unresolvable_host_returns_listen_error_before_global_metrics_install() {
     let result = serve(ServerConfig::new(
         "definitely-not-a-real-host.invalid",
         9999,
@@ -26,8 +29,21 @@ async fn unresolvable_host_returns_error() {
     .await;
 
     match result {
-        Err(_) => {}
+        Err(ServerError::Listen(_)) => {}
+        Err(error) => panic!("expected listen error, got {error:?}"),
         Ok(()) => panic!("unresolvable host should return an error"),
+    }
+
+    install_global().expect("bind failure should not install global metrics recorder");
+
+    let metrics_result = serve(ServerConfig::new("127.0.0.1", 0)).await;
+    match metrics_result {
+        Err(error @ ServerError::MetricsInit(_)) => assert!(
+            core::error::Error::source(&error).is_some(),
+            "metrics init error should preserve the BuildError source"
+        ),
+        Err(error) => panic!("expected metrics init error, got {error:?}"),
+        Ok(()) => panic!("global recorder conflict should return an error"),
     }
 }
 


### PR DESCRIPTION
Adds a Prometheus `/metrics` endpoint to `docspec-http` exposing 5 metrics:

- `docspec_http_requests_total{method,path,status}` (counter)
- `docspec_http_request_duration_seconds{method,path,status}` (histogram)
- `docspec_http_request_body_bytes` (histogram)
- `docspec_conversions_total{result,error_class}` (counter)
- `docspec_conversion_duration_seconds{result}` (histogram)

Uses `metrics` + `metrics-exporter-prometheus`. Same port as main API, no auth. `path` label uses `MatchedPath` (bounded to `/conversion`, `/health`, `unknown`); per-request identifiers are never labels. `/metrics` itself is excluded from request counters to prevent a scrape feedback loop.

See `crates/docspec-http/README.md` for the metric catalog, label catalogs, and example PromQL queries.

Closes the metrics tracking issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /metrics Prometheus endpoint and automatic HTTP instrumentation (request counts, latency, body-size, conversion totals/durations); /metrics scrapes are excluded from counting and server installs a background metrics upkeep loop.

* **Documentation**
  * README: metrics usage, labels, cardinality guidance, example queries, and security recommendations.

* **Tests**
  * Extensive integration and regression tests for metrics exposition, cardinality, middleware behavior, and conversion metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->