### PR TITLE
`Event::SoftBreak` variant

### DIFF
--- a/EVENTS.md
+++ b/EVENTS.md
@@ -143,12 +143,13 @@ All events in the `Event` enum, grouped by category.
 
 **Inline (self-contained):**
 
-| Event         | Fields                                                                                                                                                                 |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `Text`        | `content: String`, `bold: bool`, `italic: bool`, `code: bool`, `strikethrough: bool`, `underline: bool`, `subscript: bool`, `superscript: bool`, `mark: Option<Color>` |
-| `Image`       | `source: ImageSource`, `alt: Option<String>`, `title: Option<String>`, `decorative: bool`                                                                              |
-| `FootnoteRef` | `id: u32`                                                                                                                                                              |
-| `LineBreak`   | —                                                                                                                                                                      |
+| Event         | Fields                                                                           |
+| ------------- | -------------------------------------------------------------------------------- |
+| `Text`        | `content: String`, `style: TextStyle`                                            |
+| `Image`       | `source: ImageSource`, `alt: Option<String>`, `title: Option<String>`, `decorative: bool` |
+| `FootnoteRef` | `id: u32`                                                                        |
+| `LineBreak`   | —                                                                                |
+| `SoftBreak`   | —                                                                                |
 
 ---
 
@@ -174,13 +175,15 @@ Every `Start*` has a matching `End*`. They nest but never overlap.
 
 **Link.** An inline container (uses Start/End because it carries `href`). Valid inside paragraphs, headings, list items, cells, definition details. Cannot nest.
 
-**Text.** Formatting changes produce new events. Default: all bools `false`, mark `None`. Empty content is valid but meaningless. `subscript` and `superscript` may both be true; writers that can't represent both prefer `superscript`. Whitespace is significant. Outside preformatted blocks, newlines in content are collapsed to whitespace; readers emit `LineBreak` for semantically meaningful line breaks.
+**Text.** Formatting changes produce new events. Default: `TextStyle::default()` — all formatting flags disabled and `mark` is `None`. Empty content is valid but meaningless. `subscript` and `superscript` may both be true; writers that can't represent both prefer `superscript`. Whitespace is significant. Outside preformatted blocks, newlines in content are collapsed to whitespace; readers emit `LineBreak` for explicit hard breaks (e.g., markdown two-space-newline, HTML `<br>`) and `SoftBreak` for soft breaks (e.g., source line wraps within a paragraph).
 
 **Image.** Asset bytes resolve lazily via `AssetProvider`. `decorative` means purely visual. May appear inline or directly in block containers.
 
 **FootnoteRef.** Inline marker; corresponding `StartFootnote` appears elsewhere.
 
-**LineBreak.** Soft break within a block.
+**LineBreak.** Explicit hard break within a paragraph (e.g., markdown two-space-newline, HTML `<br>`).
+
+**SoftBreak.** Soft line break in source markup, such as a markdown line wrap. Writers choose rendering policy (space, newline, `<br>`, etc.).
 
 **ThematicBreak.** Horizontal rule / section separator.
 

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -25,7 +25,7 @@
 //! - `StartTableHeader` / `EndTableHeader` — table cells (header, emitted identically to data cells)
 //! - `Text` — inline text content with bold/italic/code/strikethrough/underline styles
 //! - `Image` — image blocks
-//! - `LineBreak` — line breaks within content blocks
+//! - `LineBreak` / `SoftBreak` — line breaks within content blocks
 //! - `ThematicBreak` — divider blocks
 //! - `StartOrderedListItem` / `EndOrderedListItem` — `numberedListItem` blocks with optional `start` prop
 //! - `StartUnorderedListItem` / `EndUnorderedListItem` — `bulletListItem` blocks
@@ -36,7 +36,7 @@
 //! `EVENTS.md` declares that `DocSpec` cells may contain any block element, so this writer
 //! flattens block-level events that appear inside a cell:
 //!
-//! - **Preserved**: [`Text`](docspec_core::Event::Text) (with all inline styles), [`LineBreak`](docspec_core::Event::LineBreak)
+//! - **Preserved**: [`Text`](docspec_core::Event::Text) (with all inline styles), [`LineBreak`](docspec_core::Event::LineBreak), [`SoftBreak`](docspec_core::Event::SoftBreak)
 //! - **Absorbed silently**: [`StartParagraph`](docspec_core::Event::StartParagraph) / [`EndParagraph`](docspec_core::Event::EndParagraph) (paragraph boundaries are dropped — adjacent paragraphs concatenate without separator)
 //! - **Dropped**: [`Image`](docspec_core::Event::Image), [`StartBlockQuote`](docspec_core::Event::StartBlockQuote), [`StartPreformatted`](docspec_core::Event::StartPreformatted), [`StartHeading`](docspec_core::Event::StartHeading), [`ThematicBreak`](docspec_core::Event::ThematicBreak), nested [`StartTable`](docspec_core::Event::StartTable) and their children — silently discarded
 //!
@@ -1016,7 +1016,7 @@ impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
             Event::Image {
                 source, alt, id, ..
             } => self.handle_image(source, alt, id.as_ref()),
-            Event::LineBreak => self.handle_line_break(),
+            Event::LineBreak | Event::SoftBreak => self.handle_line_break(),
             Event::StartOrderedListItem {
                 id, level, start, ..
             } => self.handle_start_list_item(ListKind::Ordered, id.as_ref(), level, start),

--- a/crates/docspec-blocknote-writer/tests/markdown_pipeline.rs
+++ b/crates/docspec-blocknote-writer/tests/markdown_pipeline.rs
@@ -146,6 +146,14 @@ mod tests {
     }
 
     #[test]
+    fn pipeline_soft_break() {
+        let markdown = include_str!("../../../tests/fixtures/markdown/soft_break.md");
+        let expected = include_str!("../../../tests/fixtures/blocknote/soft_break.json");
+        let actual = run_pipeline(markdown);
+        assert_json_eq(&actual, expected);
+    }
+
+    #[test]
     fn pipeline_list_inside_blockquote_inside_list_item_is_well_formed() {
         // Regression for cmark-gfm/test.md edge case.
         // A list nested inside a blockquote that is itself inside a list item

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -211,6 +211,229 @@ mod tests {
     }
 
     #[test]
+    fn soft_break_renders_as_newline() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Line one".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::SoftBreak,
+            Event::Text {
+                content: "Line two".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Line one","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"Line two","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn soft_break_inside_heading() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartHeading { level: 2, id: None },
+            Event::Text {
+                content: "Title one".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::SoftBreak,
+            Event::Text {
+                content: "Title two".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndHeading,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"heading","props":{"level":2,"textAlignment":"left"},"content":[{"type":"text","text":"Title one","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"Title two","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn soft_break_inside_table_cell() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartTable { id: None },
+            Event::StartTableRow { id: None },
+            Event::StartTableCell {
+                colspan: None,
+                rowspan: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Cell line one".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::SoftBreak,
+            Event::Text {
+                content: "Cell line two".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","props":{"textColor":"default"},"content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","props":{"backgroundColor":"default","textColor":"default","textAlignment":"left"},"content":[{"type":"text","text":"Cell line one","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"Cell line two","styles":{}}]}]}]},"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn soft_break_inside_list_item() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            Event::Text {
+                content: "Bullet line one".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::SoftBreak,
+            Event::Text {
+                content: "Bullet line two".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","props":{"backgroundColor":"default","textColor":"default","textAlignment":"left"},"content":[{"type":"text","text":"Bullet line one","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"Bullet line two","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn soft_break_inside_link_display_text() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                id: None,
+                title: None,
+            },
+            Event::Text {
+                content: "Click line one".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::SoftBreak,
+            Event::Text {
+                content: "click line two".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"link","href":"https://example.com","content":[{"type":"text","text":"Click line one","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"click line two","styles":{}}]}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn soft_break_inside_blockquote() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartBlockQuote { id: None },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Quote line one".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::SoftBreak,
+            Event::Text {
+                content: "Quote line two".to_string(),
+                style: TextStyle::default(),
+            },
+            Event::EndParagraph,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[{"type":"text","text":"Quote line one","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"Quote line two","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn soft_break_between_styled_spans() {
+        let json = run_events(&[
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            },
+            Event::StartParagraph {
+                alignment: None,
+                id: None,
+            },
+            Event::Text {
+                content: "Bold line one".to_string(),
+                style: TextStyle::default().bold(),
+            },
+            Event::SoftBreak,
+            Event::Text {
+                content: "Bold line two".to_string(),
+                style: TextStyle::default().bold(),
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        // Three text nodes: bold "Bold line one", default-style "\n", bold "Bold line two"
+        // The "\n" node has empty styles because handle_line_break calls handle_text with TextStyle::default()
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Bold line one","styles":{"bold":true}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"Bold line two","styles":{"bold":true}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
     fn italic_text() {
         let json = run_events(&[
             Event::StartDocument {

--- a/crates/docspec-core/src/event.rs
+++ b/crates/docspec-core/src/event.rs
@@ -146,6 +146,13 @@ pub enum Event {
     /// A hard line break within a paragraph.
     LineBreak,
 
+    /// A soft line break in source markup, such as a markdown line wrap.
+    ///
+    /// Soft breaks correspond to source line wraps that do not enforce a
+    /// visible break. Writers choose rendering policy: space, newline,
+    /// `<br>`, etc.
+    SoftBreak,
+
     /// Begin a block quote.
     StartBlockQuote {
         /// Optional block identifier.

--- a/crates/docspec-core/tests/event.rs
+++ b/crates/docspec-core/tests/event.rs
@@ -182,6 +182,12 @@ mod tests {
     }
 
     #[test]
+    fn soft_break() {
+        let event = Event::SoftBreak;
+        assert_eq!(event, Event::SoftBreak);
+    }
+
+    #[test]
     fn partial_eq_different_fields() {
         let event1 = Event::StartHeading { level: 1, id: None };
         let event2 = Event::StartHeading { level: 2, id: None };

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -31,7 +31,7 @@
 //! - Strikethrough → `Text { style: TextStyle { strikethrough: true, .. }, .. }`
 //! - Images → `Image { source: Uri, alt, title, decorative }`
 //! - Hard line breaks → `LineBreak`
-//! - Soft line breaks → space `Text`
+//! - Soft line breaks → `SoftBreak`
 //! - Thematic breaks → `ThematicBreak`
 //! - Tables → `StartTable` / `EndTable`, `StartTableRow` / `EndTableRow`,
 //!   `StartTableHeader` / `EndTableHeader`, `StartTableCell` / `EndTableCell`
@@ -602,10 +602,7 @@ impl<'a> MarkdownReader<'a> {
                     img.alt_buf.push(' ');
                 } else {
                     self.emit_pending_link_start();
-                    self.queue.push_back(Event::Text {
-                        content: " ".to_string(),
-                        style: self.current_text_style(),
-                    });
+                    self.queue.push_back(Event::SoftBreak);
                 }
             }
             pulldown_cmark::Event::Rule => {

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -65,6 +65,7 @@ mod helpers {
             | Event::FootnoteRef { .. }
             | Event::Image { .. }
             | Event::LineBreak
+            | Event::SoftBreak
             | Event::StartBlockQuote { .. }
             | Event::StartCaption { .. }
             | Event::StartDefinitionDetail { .. }
@@ -542,16 +543,63 @@ mod tests {
     }
 
     #[test]
-    fn soft_break_becomes_space_text() {
+    fn soft_break_emits_soft_break_event() {
         let mut reader = MarkdownReader::new("Line one\nLine two");
         let events = collect_events(&mut reader);
 
-        assert!(
-            events
-                .iter()
-                .any(|e| matches!(e, Event::Text { content, .. } if content == " ")),
-            "SoftBreak should emit a space Text event"
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                Event::StartParagraph {
+                    alignment: None,
+                    id: None
+                },
+                Event::Text {
+                    content: "Line one".to_string(),
+                    style: TextStyle::default(),
+                },
+                Event::SoftBreak,
+                Event::Text {
+                    content: "Line two".to_string(),
+                    style: TextStyle::default(),
+                },
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
         );
+    }
+
+    #[test]
+    fn soft_break_in_image_alt_appends_space() {
+        let mut reader = MarkdownReader::new("![alt one\nalt two](image.png)");
+        let events = collect_events(&mut reader);
+
+        // The image alt text flattens the soft break to a single space.
+        // No SoftBreak event should be emitted — the soft break is absorbed
+        // into the image's alt buffer.
+        let image_count = events
+            .iter()
+            .filter(|e| matches!(e, Event::Image { .. }))
+            .count();
+        assert_eq!(image_count, 1, "exactly one Image event expected");
+
+        let soft_break_count = events
+            .iter()
+            .filter(|e| matches!(e, Event::SoftBreak))
+            .count();
+        assert_eq!(
+            soft_break_count, 0,
+            "no SoftBreak event should be emitted inside image alt"
+        );
+
+        let image_alt = events.iter().find_map(|e| {
+            let Event::Image { alt: Some(a), .. } = e else {
+                return None;
+            };
+            Some(a.clone())
+        });
+        assert_eq!(image_alt, Some("alt one alt two".to_string()));
     }
 
     #[test]
@@ -583,18 +631,6 @@ mod tests {
 
         assert!(matches!(events.first(), Some(Event::StartDocument { .. })));
         assert!(matches!(events.last(), Some(Event::EndDocument)));
-    }
-
-    #[test]
-    fn soft_break_in_image_alt_appends_space() {
-        let mut reader = MarkdownReader::new("![alt\ntext](https://example.com/img.png)");
-        let events = collect_events(&mut reader);
-
-        let image_event = events.iter().find(|e| matches!(e, Event::Image { .. }));
-        assert!(matches!(
-            image_event,
-            Some(Event::Image { alt: Some(alt), .. }) if alt == "alt text"
-        ));
     }
 
     #[test]

--- a/tests/fixtures/blocknote/soft_break.json
+++ b/tests/fixtures/blocknote/soft_break.json
@@ -1,0 +1,1 @@
+[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Line one","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"Line two","styles":{}}],"children":[]}]

--- a/tests/fixtures/markdown/soft_break.md
+++ b/tests/fixtures/markdown/soft_break.md
@@ -1,0 +1,2 @@
+Line one
+Line two


### PR DESCRIPTION
Introduces `Event::SoftBreak` to preserve the soft-vs-hard line break distinction.

- **docspec-core**: new `SoftBreak` unit variant (between `LineBreak` and `StartBlockQuote`)
- **docspec-markdown-reader**: routes `pulldown_cmark::Event::SoftBreak` to `Event::SoftBreak` outside images
- **docspec-blocknote-writer**: renders `SoftBreak` as `"\n"` text via existing `handle_line_break()`
- **EVENTS.md**: documents the new variant; clarifies `LineBreak` as explicit hard break

**Breaking change**: soft line breaks in markdown now emit `Event::SoftBreak` instead of `Event::Text { content: " ", ... }`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for soft line breaks in markdown documents, now properly distinguished from explicit hard line breaks
  * Soft line breaks from source line wrapping are now emitted and rendered as newline characters in document output

* **Tests**
  * Added comprehensive test coverage for soft break handling across various document elements and styling contexts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->