### PR TITLE
ci(release-please): clean up warnings and align docker build with docspec-http

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,8 +12,9 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      releases_created: ${{ steps.release.outputs.releases_created }}
-      tag_name: ${{ steps.release.outputs['crates/docspec-core--tag_name'] }}
+      http_released: ${{ steps.release.outputs['crates/docspec-http--release_created'] }}
+      http_tag: ${{ steps.release.outputs['crates/docspec-http--tag_name'] }}
+      http_version: ${{ steps.release.outputs['crates/docspec-http--version'] }}
     steps:
       - id: release
         uses: googleapis/release-please-action@v4
@@ -25,7 +26,7 @@ jobs:
     name: Docker Build + Push + Sign (release)
     runs-on: ubuntu-latest
     needs: release-please
-    if: needs.release-please.outputs.releases_created == 'true'
+    if: needs.release-please.outputs.http_released == 'true'
     permissions:
       contents: read
       packages: write
@@ -33,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
+          ref: ${{ needs.release-please.outputs.http_tag }}
 
       - uses: docker/setup-buildx-action@v3
 
@@ -50,10 +51,10 @@ jobs:
         with:
           images: ghcr.io/docspec/api
           tags: |
-            type=semver,pattern={{version}},value=${{ needs.release-please.outputs.tag_name }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.release-please.outputs.tag_name }}
-            type=semver,pattern={{major}},value=${{ needs.release-please.outputs.tag_name }}
-            type=raw,value=latest,enable=${{ !contains(needs.release-please.outputs.tag_name, '-') }}
+            type=semver,pattern={{version}},value=v${{ needs.release-please.outputs.http_version }}
+            type=semver,pattern={{major}}.{{minor}},value=v${{ needs.release-please.outputs.http_version }}
+            type=semver,pattern={{major}},value=v${{ needs.release-please.outputs.http_version }}
+            type=raw,value=latest,enable=${{ !contains(needs.release-please.outputs.http_version, '-') }}
           labels: |
             org.opencontainers.image.title=docspec-http
             org.opencontainers.image.description=HTTP API server for DocSpec markdown to BlockNote JSON conversion
@@ -64,7 +65,7 @@ jobs:
         run: |
           VERSION="${{ steps.meta.outputs.version }}"
           if [ -z "${VERSION}" ]; then
-            echo "ERROR: docker/metadata-action produced empty version (tag_name=${{ needs.release-please.outputs.tag_name }})" >&2
+            echo "ERROR: docker/metadata-action produced empty version (http_tag=${{ needs.release-please.outputs.http_tag }})" >&2
             exit 1
           fi
           echo "Building image version: ${VERSION}"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "rust",
-  "include-component-in-tag": false,
+  "include-component-in-tag": true,
+  "pull-request-title-pattern": "chore(${component}): release ${version}",
+  "group-pull-request-title-pattern": "chore: release docspec ${version}",
   "packages": {
     "crates/docspec-core": { "component": "docspec-core" },
     "crates/docspec-markdown-reader": { "component": "docspec-markdown-reader" },


### PR DESCRIPTION
## Summary

Follow-up to #47. Cleans up the release-please warnings that started appearing in the CI logs once the workflow began producing real candidate PRs, and fixes a latent misalignment in the Docker release job.

## Changes

### `release-please-config.json`

| Change | Reason |
|---|---|
| `include-component-in-tag: false` → `true` | Each crate now gets its own tag (`docspec-http-v0.2.0`, etc.) instead of all 7 crates collapsing onto a single `v0.x.y` tag. Silences the `Multiple paths for : crates/A, crates/B` warnings caused by tag-name collisions. |
| Add `pull-request-title-pattern` | Gives release-please an explicit `${component}` + `${version}` slot for per-crate PR titles. |
| Add `group-pull-request-title-pattern` | Same for the merged group PR produced by `linked-versions`. Together these silence the `pullRequestTitlePattern miss the part of '${component/version/scope}'` warnings. |

`linked-versions` plugin is **retained** — monolithic versioning continues. All 7 crates still bump together. Per-crate tags add identity without changing version semantics. Reassess before flipping `workspace.publish` to `true`.

### `.github/workflows/release-please.yml`

The `docker-release` job was previously wired to `crates/docspec-core--tag_name`, but the image identity (`ghcr.io/docspec/api`, labels `docspec-http`) packages the HTTP server, not the core crate. This only worked by accident because `linked-versions` keeps all tags at the same version.

| Change | Reason |
|---|---|
| Outputs `releases_created` + `tag_name` → `http_released` + `http_tag` + `http_version` (all sourced from `crates/docspec-http--*`) | Image identity now matches its workflow source of truth. |
| Docker job `if:` reads `http_released` | Explicit gating on the HTTP crate's release flag. Functionally identical under `linked-versions` today; correct if we ever go independent. |
| `docker/metadata-action` `value=...` switched from `tag_name` to `v${http_version}` | Clean semver input. The previous full-tag value (`docspec-http-v0.2.0`) would fail to parse as semver. |
| `latest` tag gate switched from `!contains(tag_name, '-')` to `!contains(http_version, '-')` | **Latent bug fix.** Once tags contain a component prefix they always contain `-`, so the `latest` tag would have stopped applying on every release. Gating on the clean version string preserves the original "only stable releases get `latest`" intent. |

## Warnings Resolved

| Warning | Status |
|---|---|
| `Multiple paths for : crates/X, crates/Y` (×6) | ✅ Resolved via per-crate tags |
| `pullRequestTitlePattern miss the part of '${component/version/scope}'` (×5) | ✅ Resolved via title patterns |
| `Could not find releases` / `No latest release pull request found` (×7) | 🟢 First-run noise — disappears after first merged release |
| `Unable to find root candidate pull request` | 🟢 Cosmetic — workspace root is intentionally not a package |
| `package manifest at Cargo.toml is missing [package.name]` | 🟢 Cosmetic — `[workspace]`-only root is the correct shape |
| `file crates/X/Cargo.lock did not exist` (×7) | 🟢 Cosmetic — Cargo workspaces keep a single root `Cargo.lock` |

## Validation

- `python3 -c "import json; json.load(open('release-please-config.json'))"` → `JSON OK`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-please.yml'))"` → `YAML OK`
- Confirmed against release-please-action v17.3.0 behavior and `cargo-workspace` + `linked-versions` plugin semantics.

## Out of Scope

- No Rust code changes; no `Cargo.toml` edits.
- `CHANGELOG.md` files are not pre-created; release-please will generate them on the next successful release PR merge.

Refs: #47


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined release automation workflow to improve Docker image build and deployment consistency
  * Enhanced release configuration for improved version tagging and release management processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->