### PR TITLE
feat(http): add mime-type labels and output-bytes tracking to metrics

### DIFF
--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -224,15 +224,20 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 |------|------|--------|-------------|---------|
 | `docspec_http_requests_total` | counter | `method`, `path`, `status` | Total HTTP requests received | — |
 | `docspec_http_request_duration_seconds` | histogram | `method`, `path`, `status` | HTTP request latency in seconds | 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 |
-| `docspec_http_request_body_bytes` | histogram | (none) | HTTP request body size in bytes | 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800 |
-| `docspec_conversions_total` | counter | `result`, `error_class` | Total document conversions | — |
-| `docspec_conversion_duration_seconds` | histogram | `result` | Document conversion duration in seconds | 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 |
+| `docspec_http_request_body_bytes` | histogram | `input_mime_type` | HTTP request body size in bytes, labeled by input MIME type | 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800 |
+| `docspec_conversions_total` | counter | `result`, `error_class`, `input_mime_type`, `output_mime_type` | Total document conversions, labeled by result, error class, and input/output MIME type | — |
+| `docspec_conversion_duration_seconds` | histogram | `result`, `input_mime_type`, `output_mime_type` | Document conversion duration in seconds, labeled by result and input/output MIME type | 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0 |
+| **`docspec_conversion_output_bytes`** (NEW) | histogram | `input_mime_type`, `output_mime_type` | Document conversion output size in bytes (success only) | 100, 200, 400, 800, 1600, 3200, 6400, 12800, 25600, 51200, 102400, 204800 |
 
 ### Label Values
 
 **`result`**: `success`, `client_error`, `server_error`
 
 **`error_class`**: `body_not_utf8`, `empty_body`, `internal`, `method_not_allowed`, `not_acceptable`, `not_found`, `unprocessable`, `unsupported_media_type`, `none` (only when `result=success`)
+
+**`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
+
+**`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `none` (no output produced — any error path).
 
 **`path`**: matched route template (`/conversion`, `/health`) or `unknown` for fallback handlers
 
@@ -242,7 +247,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 ### Cardinality Guarantees
 
-`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels.
+`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 3 values. `output_mime_type` is bounded to 2 values. Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
 
 ### Scrape Model
 
@@ -253,6 +258,8 @@ Upkeep runs every 5 seconds, keeping histogram internal state bounded.
 The `/metrics` route is mounted outside the API middleware stack, so it does not include the global `Cache-Control` header used by API responses.
 
 The body-size histogram (`docspec_http_request_body_bytes`) only records bodies that passed Content-Type and Accept validation. Rejected requests are not counted.
+
+The output-bytes histogram (`docspec_conversion_output_bytes`) only records observations for successful conversions. Failed conversions do not produce output, so no observation is recorded.
 
 ### Example PromQL Queries
 
@@ -278,6 +285,19 @@ Body-size p95:
 
 ```promql
 histogram_quantile(0.95, sum by (le) (rate(docspec_http_request_body_bytes_bucket[5m])))
+```
+
+Body-size p95 by input format:
+
+```promql
+histogram_quantile(0.95, sum by (le, input_mime_type) (rate(docspec_http_request_body_bytes_bucket[5m])))
+```
+
+Conversion success rate by input format:
+
+```promql
+sum by (input_mime_type) (rate(docspec_conversions_total{result="success"}[5m]))
+  / sum by (input_mime_type) (rate(docspec_conversions_total[5m]))
 ```
 
 ### Security

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -29,22 +29,58 @@ pub async fn options_conversion() -> impl IntoResponse {
 /// surface as 422 (parse / sink errors) or 500 (finalize errors) **before**
 /// any response body is sent — no truncated `200 OK` on failure.
 ///
-/// Conversion outcome metrics (`docspec_conversions_total` and
-/// `docspec_conversion_duration_seconds`) are recorded for **every** request
-/// to this endpoint — including early validation failures — so that all
-/// outcomes are visible in dashboards without dead-code paths.
+/// `request_id` is accepted as `Option<Extension<RequestId>>` so the handler
+/// remains usable for downstream consumers that mount it standalone without
+/// the [`tower_http::request_id::SetRequestIdLayer`]. When the extension is
+/// absent, the `request_id` field is **omitted** from the structured
+/// `conversion_completed` event rather than logged as an empty string —
+/// "no correlation id supplied" is a distinct state from "supplied empty".
+/// The same treatment applies to `trace_id`, which is only set when the
+/// upstream `X-Trace-ID` header is present.
+///
+/// Conversion outcome metrics are recorded with intentionally different scopes:
+///
+/// - `docspec_conversions_total` and `docspec_conversion_duration_seconds` are
+///   recorded for **every** request to this endpoint — including early
+///   validation failures — so that all outcomes are visible in dashboards.
+/// - `docspec_http_request_body_bytes` is recorded only after `Content-Type`
+///   and `Accept` validation pass and the body is confirmed non-empty.
+/// - `docspec_conversion_output_bytes` is recorded only on successful
+///   conversions (failed conversions produce no output).
 ///
 /// # Errors
 ///
 /// Returns [`HttpError`] when request headers or body are invalid, the
 /// conversion fails, or the response cannot be constructed.
 #[inline]
-pub async fn post_conversion(headers: HeaderMap, body: Bytes) -> Result<Response<Body>, HttpError> {
-    let conversion_start = std::time::Instant::now();
-    let outcome = do_conversion(headers, body).await;
-    let conversion_duration = conversion_start.elapsed().as_secs_f64();
+pub async fn post_conversion(
+    request_id: Option<axum::extract::Extension<tower_http::request_id::RequestId>>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<Response<Body>, HttpError> {
+    let input_mime_label = crate::mime_parser::bucket_input_mime(headers.get(header::CONTENT_TYPE));
+    let trace_id_owned: Option<String> = headers
+        .get(axum::http::HeaderName::from_static("x-trace-id"))
+        .and_then(|header_value| header_value.to_str().ok())
+        .map(str::to_owned);
+    let body_len_for_logging = body.len();
 
-    let (result_label, error_class_label) = match &outcome {
+    let conversion_start = std::time::Instant::now();
+    let outcome = do_conversion(input_mime_label, headers, body).await;
+    let conversion_duration = conversion_start.elapsed();
+    let conversion_duration_secs = conversion_duration.as_secs_f64();
+    let conversion_duration_ms =
+        u64::try_from(conversion_duration.as_millis().min(u128::from(u64::MAX)))
+            .unwrap_or(u64::MAX);
+
+    let (response_or_error, output_bytes) = match outcome {
+        Ok((response, bytes)) => (Ok(response), bytes),
+        Err(http_error) => (Err(http_error), 0),
+    };
+    let conversion_ok = response_or_error.is_ok();
+    let output_mime_label = crate::mime_parser::bucket_output_mime(conversion_ok);
+
+    let (result_label, error_class_label) = match &response_or_error {
         Ok(_) => (
             crate::metrics::RESULT_SUCCESS,
             crate::metrics::ERROR_CLASS_NONE,
@@ -56,23 +92,59 @@ pub async fn post_conversion(headers: HeaderMap, body: Bytes) -> Result<Response
         crate::metrics::METRIC_CONVERSIONS_TOTAL,
         crate::metrics::LABEL_RESULT => result_label,
         crate::metrics::LABEL_ERROR_CLASS => error_class_label,
+        crate::metrics::LABEL_INPUT_MIME_TYPE => input_mime_label,
+        crate::metrics::LABEL_OUTPUT_MIME_TYPE => output_mime_label,
     )
     .increment(1);
 
     metrics::histogram!(
         crate::metrics::METRIC_CONVERSION_DURATION_SECONDS,
         crate::metrics::LABEL_RESULT => result_label,
+        crate::metrics::LABEL_INPUT_MIME_TYPE => input_mime_label,
+        crate::metrics::LABEL_OUTPUT_MIME_TYPE => output_mime_label,
     )
-    .record(conversion_duration);
+    .record(conversion_duration_secs);
 
-    outcome
+    if conversion_ok {
+        // Reason: u64 → f64 is lossy at extreme values but bounded by realistic output sizes.
+        #[allow(clippy::cast_precision_loss, clippy::as_conversions)]
+        let output_bytes_f64 = output_bytes as f64;
+        metrics::histogram!(
+            crate::metrics::METRIC_CONVERSION_OUTPUT_BYTES,
+            crate::metrics::LABEL_INPUT_MIME_TYPE => input_mime_label,
+            crate::metrics::LABEL_OUTPUT_MIME_TYPE => output_mime_label,
+        )
+        .record(output_bytes_f64);
+    }
+
+    let request_id_opt: Option<&str> = request_id
+        .as_ref()
+        .and_then(|axum::extract::Extension(req_id)| req_id.header_value().to_str().ok());
+    tracing::info!(
+        event = "conversion_completed",
+        result = result_label,
+        error_class = error_class_label,
+        input_mime_type = input_mime_label,
+        output_mime_type = output_mime_label,
+        input_bytes = body_len_for_logging,
+        output_bytes,
+        duration_ms = conversion_duration_ms,
+        request_id = request_id_opt,
+        trace_id = trace_id_owned.as_deref(),
+    );
+
+    response_or_error
 }
 
 /// Perform the actual validation and conversion without recording outcome metrics.
 ///
 /// Body size is recorded here because it is only known after header validation
 /// succeeds and the body is confirmed non-empty.
-async fn do_conversion(headers: HeaderMap, body: Bytes) -> Result<Response<Body>, HttpError> {
+async fn do_conversion(
+    input_mime_label: &'static str,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<(Response<Body>, u64), HttpError> {
     mime_parser::validate_content_type(headers.get(header::CONTENT_TYPE))?;
     mime_parser::negotiate_accept(headers.get(header::ACCEPT))?;
 
@@ -87,14 +159,18 @@ async fn do_conversion(headers: HeaderMap, body: Bytes) -> Result<Response<Body>
     // documented false-positive exception for bounded numeric metric recording.
     #[allow(clippy::cast_precision_loss, clippy::as_conversions)]
     let body_len_bytes = body.len() as f64;
-    metrics::histogram!(crate::metrics::METRIC_HTTP_REQUEST_BODY_BYTES).record(body_len_bytes);
+    metrics::histogram!(
+        crate::metrics::METRIC_HTTP_REQUEST_BODY_BYTES,
+        crate::metrics::LABEL_INPUT_MIME_TYPE => input_mime_label,
+    )
+    .record(body_len_bytes);
 
     let markdown = String::from_utf8(body.into()).map_err(|error| {
         tracing::debug!(error = %error, "request body is not valid UTF-8");
         HttpError::BodyNotUtf8
     })?;
 
-    let join_result = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, HttpError> {
+    let join_result = tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64), HttpError> {
         let mut output_buffer = Vec::new();
         let mut reader = MarkdownReader::new(&markdown);
         let mut sink = StackTrackingSink::new(BlockNoteWriter::new(&mut output_buffer));
@@ -122,18 +198,23 @@ async fn do_conversion(headers: HeaderMap, body: Bytes) -> Result<Response<Body>
             HttpError::Internal
         })?;
 
-        Ok(output_buffer)
+        // Capture byte count before output_buffer is consumed by Body::from.
+        // u64::try_from is lossless on 64-bit targets (usize ≤ u64::MAX).
+        let output_bytes =
+            u64::try_from(output_buffer.len()).map_err(|_conversion_error| HttpError::Internal)?;
+        Ok((output_buffer, output_bytes))
     })
     .await;
 
     match join_result {
-        Ok(Ok(output)) => Response::builder()
+        Ok(Ok((output, output_bytes))) => Response::builder()
             .status(StatusCode::OK)
             .header(
                 header::CONTENT_TYPE,
                 HeaderValue::from_static("application/vnd.docspec.blocknote+json; charset=utf-8"),
             )
             .body(Body::from(output))
+            .map(|response| (response, output_bytes))
             .map_err(|error| {
                 tracing::error!(error = %error, "failed to build conversion response");
                 HttpError::Internal

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -35,6 +35,9 @@ pub const METRIC_CONVERSIONS_TOTAL: &str = "docspec_conversions_total";
 /// Histogram: document conversion duration in seconds.
 pub const METRIC_CONVERSION_DURATION_SECONDS: &str = "docspec_conversion_duration_seconds";
 
+/// Histogram: document conversion output size in bytes.
+pub const METRIC_CONVERSION_OUTPUT_BYTES: &str = "docspec_conversion_output_bytes";
+
 // ─── Label key constants ───────────────────────────────────────────────────
 
 /// Label key for the HTTP request method (GET, POST, …).
@@ -52,6 +55,12 @@ pub const LABEL_RESULT: &str = "result";
 /// Label key for the error class when a conversion fails.
 pub const LABEL_ERROR_CLASS: &str = "error_class";
 
+/// Label key for the input MIME type of the conversion request.
+pub const LABEL_INPUT_MIME_TYPE: &str = "input_mime_type";
+
+/// Label key for the output MIME type produced by the conversion.
+pub const LABEL_OUTPUT_MIME_TYPE: &str = "output_mime_type";
+
 // ─── Label value constants ─────────────────────────────────────────────────
 
 /// Value for [`LABEL_PATH`] when no route was matched by the router.
@@ -68,6 +77,21 @@ pub const RESULT_SERVER_ERROR: &str = "server_error";
 
 /// Value for [`LABEL_ERROR_CLASS`] when no error occurred.
 pub const ERROR_CLASS_NONE: &str = "none";
+
+/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was text/markdown (current sole supported reader).
+pub const INPUT_MIME_MARKDOWN: &str = "text/markdown";
+
+/// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was present but not a supported reader format.
+pub const INPUT_MIME_UNSUPPORTED: &str = "unsupported";
+
+/// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was absent.
+pub const INPUT_MIME_NONE: &str = "none";
+
+/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `BlockNote` JSON (current sole supported writer).
+pub const OUTPUT_MIME_BLOCKNOTE: &str = "application/vnd.docspec.blocknote+json";
+
+/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when no output was produced (any error path).
+pub const OUTPUT_MIME_NONE: &str = "none";
 
 // ─── Histogram bucket arrays ───────────────────────────────────────────────
 
@@ -87,6 +111,12 @@ pub const HTTP_BODY_SIZE_BUCKETS: [f64; 12] = [
 /// Shares the same breakpoints as [`HTTP_LATENCY_BUCKETS`].
 pub const CONVERSION_DURATION_BUCKETS: [f64; 11] = HTTP_LATENCY_BUCKETS;
 
+/// Size histogram buckets for conversion output bytes.
+///
+/// Shares the same breakpoints as [`HTTP_BODY_SIZE_BUCKETS`] for symmetry
+/// between request body size and conversion output size in dashboards.
+pub const CONVERSION_OUTPUT_BYTES_BUCKETS: [f64; 12] = HTTP_BODY_SIZE_BUCKETS;
+
 // ─── Recorder builder ──────────────────────────────────────────────────────
 
 fn configure_buckets(builder: PrometheusBuilder) -> Result<PrometheusBuilder, BuildError> {
@@ -102,6 +132,10 @@ fn configure_buckets(builder: PrometheusBuilder) -> Result<PrometheusBuilder, Bu
         .set_buckets_for_metric(
             Matcher::Full(METRIC_CONVERSION_DURATION_SECONDS.to_owned()),
             &CONVERSION_DURATION_BUCKETS,
+        )?
+        .set_buckets_for_metric(
+            Matcher::Full(METRIC_CONVERSION_OUTPUT_BYTES.to_owned()),
+            &CONVERSION_OUTPUT_BYTES_BUCKETS,
         )
 }
 
@@ -142,12 +176,19 @@ pub fn install_global() -> Result<PrometheusHandle, BuildError> {
     );
     describe_histogram!(
         METRIC_HTTP_REQUEST_BODY_BYTES,
-        "HTTP request body size in bytes."
+        "HTTP request body size in bytes, labeled by input MIME type."
     );
-    describe_counter!(METRIC_CONVERSIONS_TOTAL, "Total document conversions.");
+    describe_counter!(
+        METRIC_CONVERSIONS_TOTAL,
+        "Total document conversions, labeled by result, error class, and input/output MIME type."
+    );
     describe_histogram!(
         METRIC_CONVERSION_DURATION_SECONDS,
-        "Document conversion duration in seconds."
+        "Document conversion duration in seconds, labeled by result and input/output MIME type."
+    );
+    describe_histogram!(
+        METRIC_CONVERSION_OUTPUT_BYTES,
+        "Document conversion output size in bytes (recorded only on successful conversions), labeled by input/output MIME type."
     );
 
     Ok(handle)

--- a/crates/docspec-http/src/mime_parser.rs
+++ b/crates/docspec-http/src/mime_parser.rs
@@ -97,3 +97,144 @@ pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<(), H
     }
     Ok(())
 }
+
+/// Returns the bounded `input_mime_type` label value for a `Content-Type` header.
+///
+/// This function is intentionally MORE permissive than [`validate_content_type`]:
+/// it returns [`crate::metrics::INPUT_MIME_MARKDOWN`] for any `text/markdown`
+/// value regardless of charset or other parameters, because the label answers
+/// "what did the client try to send?" rather than "is it valid?".
+///
+/// # Label values
+///
+/// - [`crate::metrics::INPUT_MIME_NONE`] — header absent
+/// - [`crate::metrics::INPUT_MIME_MARKDOWN`] — `text/markdown` (any params)
+/// - [`crate::metrics::INPUT_MIME_UNSUPPORTED`] — anything else
+#[must_use]
+#[inline]
+pub fn bucket_input_mime(header_value: Option<&HeaderValue>) -> &'static str {
+    let Some(header_val) = header_value else {
+        return crate::metrics::INPUT_MIME_NONE;
+    };
+    let Ok(header_str) = header_val.to_str() else {
+        return crate::metrics::INPUT_MIME_UNSUPPORTED;
+    };
+    let Ok(parsed) = header_str.parse::<mime::Mime>() else {
+        return crate::metrics::INPUT_MIME_UNSUPPORTED;
+    };
+    if parsed.type_() == mime::TEXT && parsed.subtype().as_str() == "markdown" {
+        crate::metrics::INPUT_MIME_MARKDOWN
+    } else {
+        crate::metrics::INPUT_MIME_UNSUPPORTED
+    }
+}
+
+/// Returns the bounded `output_mime_type` label value for a conversion outcome.
+///
+/// When `conversion_ok` is `false`, no output was produced, so the label is
+/// always [`crate::metrics::OUTPUT_MIME_NONE`].
+///
+/// When `conversion_ok` is `true`, the output is always `BlockNote` JSON because
+/// the writer is fixed today.
+///
+/// # Label values
+///
+/// - [`crate::metrics::OUTPUT_MIME_NONE`] — conversion failed (no output)
+/// - [`crate::metrics::OUTPUT_MIME_BLOCKNOTE`] — conversion succeeded
+#[inline]
+#[must_use]
+pub fn bucket_output_mime(conversion_ok: bool) -> &'static str {
+    if conversion_ok {
+        crate::metrics::OUTPUT_MIME_BLOCKNOTE
+    } else {
+        crate::metrics::OUTPUT_MIME_NONE
+    }
+}
+
+#[cfg(test)]
+mod bucket_tests {
+    #![allow(
+        clippy::tests_outside_test_module,
+        clippy::unwrap_used,
+        clippy::expect_used
+    )]
+
+    use super::*;
+    use axum::http::HeaderValue;
+
+    // ─── bucket_input_mime tests ───────────────────────────────────────────
+
+    #[test]
+    fn bucket_input_mime_none_when_header_absent() {
+        assert_eq!(bucket_input_mime(None), crate::metrics::INPUT_MIME_NONE);
+    }
+
+    #[test]
+    fn bucket_input_mime_markdown_when_text_markdown() {
+        let val = HeaderValue::from_static("text/markdown");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_MARKDOWN
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_markdown_when_text_markdown_with_charset() {
+        let val = HeaderValue::from_static("text/markdown; charset=utf-8");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_MARKDOWN
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_markdown_case_insensitive() {
+        let val = HeaderValue::from_static("TEXT/MARKDOWN");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_MARKDOWN
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_unsupported_when_other_format() {
+        let val = HeaderValue::from_static("application/pdf");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_UNSUPPORTED
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_unsupported_when_malformed() {
+        let val = HeaderValue::from_static("not a mime type at all");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_UNSUPPORTED
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_unsupported_when_non_ascii() {
+        let val = HeaderValue::from_bytes(&[0xFF, 0xFE]).unwrap();
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_UNSUPPORTED
+        );
+    }
+
+    // ─── bucket_output_mime tests ──────────────────────────────────────────
+
+    #[test]
+    fn bucket_output_mime_blocknote_when_success() {
+        assert_eq!(
+            bucket_output_mime(true),
+            crate::metrics::OUTPUT_MIME_BLOCKNOTE
+        );
+    }
+
+    #[test]
+    fn bucket_output_mime_none_when_failure() {
+        assert_eq!(bucket_output_mime(false), crate::metrics::OUTPUT_MIME_NONE);
+    }
+}

--- a/crates/docspec-http/tests/metrics_conversion.rs
+++ b/crates/docspec-http/tests/metrics_conversion.rs
@@ -11,9 +11,11 @@
 
 // Reason: integration tests use standard test patterns with expect/unwrap.
 #![allow(
+    clippy::arbitrary_source_item_ordering,
     clippy::tests_outside_test_module,
     clippy::unwrap_used,
-    clippy::expect_used
+    clippy::expect_used,
+    clippy::panic
 )]
 
 use axum::{body::Body, http::Request};
@@ -66,7 +68,7 @@ fn success_increments_with_none_error_class() {
     let rendered = handle.render();
     assert_metric_line(
         &rendered,
-        r#"docspec_conversions_total{result="success",error_class="none"} 1"#,
+        r#"docspec_conversions_total{result="success",error_class="none",input_mime_type="text/markdown",output_mime_type="application/vnd.docspec.blocknote+json"} 1"#,
     );
 }
 
@@ -88,7 +90,7 @@ fn empty_body_records_client_error() {
     let rendered = handle.render();
     assert_metric_line(
         &rendered,
-        r#"docspec_conversions_total{result="client_error",error_class="empty_body"} 1"#,
+        r#"docspec_conversions_total{result="client_error",error_class="empty_body",input_mime_type="text/markdown",output_mime_type="none"} 1"#,
     );
 }
 
@@ -116,7 +118,7 @@ fn invalid_utf8_records_client_error() {
     let rendered = handle.render();
     assert_metric_line(
         &rendered,
-        r#"docspec_conversions_total{result="client_error",error_class="body_not_utf8"} 1"#,
+        r#"docspec_conversions_total{result="client_error",error_class="body_not_utf8",input_mime_type="text/markdown",output_mime_type="none"} 1"#,
     );
 }
 
@@ -145,7 +147,7 @@ fn unsupported_media_type_records_client_error() {
     let rendered = handle.render();
     assert_metric_line(
         &rendered,
-        r#"docspec_conversions_total{result="client_error",error_class="unsupported_media_type"} 1"#,
+        r#"docspec_conversions_total{result="client_error",error_class="unsupported_media_type",input_mime_type="unsupported",output_mime_type="none"} 1"#,
     );
 }
 
@@ -174,7 +176,7 @@ fn not_acceptable_records_client_error() {
     let rendered = handle.render();
     assert_metric_line(
         &rendered,
-        r#"docspec_conversions_total{result="client_error",error_class="not_acceptable"} 1"#,
+        r#"docspec_conversions_total{result="client_error",error_class="not_acceptable",input_mime_type="text/markdown",output_mime_type="none"} 1"#,
     );
 }
 
@@ -196,7 +198,7 @@ fn conversion_duration_recorded_on_success() {
     let rendered = handle.render();
     assert_metric_line(
         &rendered,
-        r#"docspec_conversion_duration_seconds_count{result="success"} 1"#,
+        r#"docspec_conversion_duration_seconds_count{result="success",input_mime_type="text/markdown",output_mime_type="application/vnd.docspec.blocknote+json"} 1"#,
     );
 }
 
@@ -218,7 +220,7 @@ fn conversion_duration_recorded_on_error() {
     let rendered = handle.render();
     assert_metric_line(
         &rendered,
-        r#"docspec_conversion_duration_seconds_count{result="client_error"} 1"#,
+        r#"docspec_conversion_duration_seconds_count{result="client_error",input_mime_type="text/markdown",output_mime_type="none"} 1"#,
     );
 }
 
@@ -240,5 +242,391 @@ fn body_size_histogram_records_correct_byte_count() {
     .expect("oneshot succeeds");
 
     let rendered = handle.render();
-    assert_metric_line(&rendered, "docspec_http_request_body_bytes_sum 7");
+    assert_metric_line(
+        &rendered,
+        r#"docspec_http_request_body_bytes_sum{input_mime_type="text/markdown"} 7"#,
+    );
+}
+
+mod tracing_test_helpers {
+    use core::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing::span::{Attributes, Record};
+    use tracing::{Event, Id, Metadata, Subscriber};
+
+    /// A captured tracing event with its fields as key-value string pairs.
+    #[derive(Debug, Default, Clone)]
+    pub struct CapturedEvent {
+        pub fields: std::collections::HashMap<String, String>,
+    }
+
+    struct FieldVisitor<'a>(&'a mut CapturedEvent);
+
+    impl Visit for FieldVisitor<'_> {
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.0
+                .fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn core::fmt::Debug) {
+            self.0
+                .fields
+                .insert(field.name().to_owned(), format!("{value:?}"));
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.0
+                .fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.0
+                .fields
+                .insert(field.name().to_owned(), value.to_owned());
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.0
+                .fields
+                .insert(field.name().to_owned(), value.to_string());
+        }
+    }
+
+    /// A minimal tracing subscriber that captures INFO-level events.
+    pub struct CapturingSubscriber {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+        next_span_id: AtomicU64,
+    }
+
+    impl CapturingSubscriber {
+        pub fn new(events: Arc<Mutex<Vec<CapturedEvent>>>) -> Self {
+            Self {
+                events,
+                next_span_id: AtomicU64::new(1),
+            }
+        }
+    }
+
+    impl Subscriber for CapturingSubscriber {
+        fn enabled(&self, metadata: &Metadata<'_>) -> bool {
+            metadata.is_event() && *metadata.level() <= tracing::Level::INFO
+        }
+
+        fn enter(&self, _span: &Id) {}
+
+        fn event(&self, event: &Event<'_>) {
+            let mut captured = CapturedEvent::default();
+            event.record(&mut FieldVisitor(&mut captured));
+            self.events.lock().unwrap().push(captured);
+        }
+
+        fn exit(&self, _span: &Id) {}
+
+        fn new_span(&self, _attrs: &Attributes<'_>) -> Id {
+            Id::from_u64(self.next_span_id.fetch_add(1, Ordering::Relaxed))
+        }
+
+        fn record(&self, _span: &Id, _values: &Record<'_>) {}
+
+        fn record_follows_from(&self, _span: &Id, _follows: &Id) {}
+    }
+}
+
+/// Asserts that a Prometheus metric line matching `prefix` has a numeric value
+/// strictly greater than `threshold`.
+fn assert_metric_value_gt(rendered: &str, prefix: &str, threshold: f64) {
+    let line = rendered
+        .lines()
+        .find(|line| line.starts_with(prefix))
+        .unwrap_or_else(|| {
+            panic!(
+                "Metric line with prefix not found.\n  prefix: {prefix}\n  rendered:\n{rendered}"
+            )
+        });
+    let value_str = line.rsplit_once(' ').map_or_else(
+        || panic!("Metric line has no space-separated value.\n  line: {line}"),
+        |(_, v)| v,
+    );
+    let value: f64 = value_str
+        .parse()
+        .unwrap_or_else(|_| panic!("Metric value is not a float.\n  value: {value_str}"));
+    assert!(
+        value > threshold,
+        "Expected metric value > {threshold}, got {value}.\n  line: {line}"
+    );
+}
+
+// ─── Test 9: input_mime_type="unsupported" for non-markdown content type ──────
+
+/// A request with `Content-Type: application/pdf` records
+/// `input_mime_type="unsupported"` on `docspec_conversions_total`.
+#[test]
+fn input_mime_unsupported_when_other_content_type() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "application/pdf")
+        .header("accept", "application/vnd.docspec.blocknote+json")
+        .body(Body::from("foo"))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="client_error",error_class="unsupported_media_type",input_mime_type="unsupported",output_mime_type="none"} 1"#,
+    );
+}
+
+// ─── Test 10: input_mime_type="none" when no Content-Type header ──────────────
+
+/// A request with no `Content-Type` header records
+/// `input_mime_type="none"` on `docspec_conversions_total`.
+#[test]
+fn input_mime_none_when_no_content_type() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("accept", "application/vnd.docspec.blocknote+json")
+        .body(Body::from("# x"))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="client_error",error_class="unsupported_media_type",input_mime_type="none",output_mime_type="none"} 1"#,
+    );
+}
+
+// ─── Test 11: output_bytes recorded on success ────────────────────────────────
+
+/// A successful conversion records one observation in
+/// `docspec_conversion_output_bytes` with a positive sum.
+#[test]
+fn output_bytes_recorded_on_success() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(valid_markdown_request("# Hello")))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversion_output_bytes_count{input_mime_type="text/markdown",output_mime_type="application/vnd.docspec.blocknote+json"} 1"#,
+    );
+    assert_metric_value_gt(
+        &rendered,
+        r#"docspec_conversion_output_bytes_sum{input_mime_type="text/markdown",output_mime_type="application/vnd.docspec.blocknote+json"}"#,
+        0.0,
+    );
+}
+
+// ─── Test 12: output_bytes NOT recorded on empty body error ───────────────────
+
+/// A failed conversion (empty body) does NOT record any observation in
+/// `docspec_conversion_output_bytes`.
+#[test]
+fn output_bytes_not_recorded_on_error() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(valid_markdown_request("")))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert!(
+        !rendered
+            .lines()
+            .any(|l| l.starts_with("docspec_conversion_output_bytes")),
+        "Expected no docspec_conversion_output_bytes lines on error, but found some.\n  rendered:\n{rendered}",
+    );
+}
+
+// ─── Test 13: output_bytes NOT recorded on unsupported media type ─────────────
+
+/// A failed conversion (unsupported media type) does NOT record any observation
+/// in `docspec_conversion_output_bytes`.
+#[test]
+fn output_bytes_not_recorded_on_unsupported_media() {
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "application/pdf")
+        .header("accept", "application/vnd.docspec.blocknote+json")
+        .body(Body::from("foo"))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert!(
+        !rendered
+            .lines()
+            .any(|l| l.starts_with("docspec_conversion_output_bytes")),
+        "Expected no docspec_conversion_output_bytes lines on error, but found some.\n  rendered:\n{rendered}",
+    );
+}
+
+// ─── Test 14: tracing event emitted on success ────────────────────────────────
+
+/// A successful conversion emits a `conversion_completed` tracing event with
+/// all required fields.
+#[test]
+fn tracing_event_emitted_on_success() {
+    use std::sync::{Arc, Mutex};
+    use tracing_test_helpers::{CapturedEvent, CapturingSubscriber};
+
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let events: Arc<Mutex<Vec<CapturedEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = CapturingSubscriber::new(Arc::clone(&events));
+
+    tracing::subscriber::with_default(subscriber, || {
+        metrics::with_local_recorder(&recorder, || {
+            rt.block_on(router.oneshot(valid_markdown_request("# Hello")))
+        })
+        .expect("oneshot succeeds");
+    });
+
+    let captured = events.lock().unwrap();
+    let conversion_event = captured
+        .iter()
+        .find(|e| e.fields.get("event").map(String::as_str) == Some("conversion_completed"))
+        .expect("conversion_completed event was emitted");
+
+    assert_eq!(
+        conversion_event.fields.get("result").map(String::as_str),
+        Some("success"),
+        "result field"
+    );
+    assert_eq!(
+        conversion_event
+            .fields
+            .get("input_mime_type")
+            .map(String::as_str),
+        Some("text/markdown"),
+        "input_mime_type field"
+    );
+    assert_eq!(
+        conversion_event
+            .fields
+            .get("output_mime_type")
+            .map(String::as_str),
+        Some("application/vnd.docspec.blocknote+json"),
+        "output_mime_type field"
+    );
+    assert!(
+        conversion_event.fields.contains_key("output_bytes"),
+        "output_bytes field present"
+    );
+    assert!(
+        conversion_event.fields.contains_key("input_bytes"),
+        "input_bytes field present"
+    );
+    assert!(
+        conversion_event.fields.contains_key("duration_ms"),
+        "duration_ms field present"
+    );
+    assert!(
+        conversion_event.fields.contains_key("request_id"),
+        "request_id field present"
+    );
+}
+
+// ─── Test 15: tracing event emitted on error ──────────────────────────────────
+
+/// A failed conversion (empty body) emits a `conversion_completed` tracing
+/// event with `result="client_error"` and `output_bytes=0`.
+#[test]
+fn tracing_event_emitted_on_error() {
+    use std::sync::{Arc, Mutex};
+    use tracing_test_helpers::{CapturedEvent, CapturingSubscriber};
+
+    let rt = make_runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let events: Arc<Mutex<Vec<CapturedEvent>>> = Arc::new(Mutex::new(Vec::new()));
+    let subscriber = CapturingSubscriber::new(Arc::clone(&events));
+
+    tracing::subscriber::with_default(subscriber, || {
+        metrics::with_local_recorder(&recorder, || {
+            rt.block_on(router.oneshot(valid_markdown_request("")))
+        })
+        .expect("oneshot succeeds");
+    });
+
+    let captured = events.lock().unwrap();
+    let conversion_event = captured
+        .iter()
+        .find(|e| e.fields.get("event").map(String::as_str) == Some("conversion_completed"))
+        .expect("conversion_completed event was emitted");
+
+    assert_eq!(
+        conversion_event.fields.get("result").map(String::as_str),
+        Some("client_error"),
+        "result field"
+    );
+    assert_eq!(
+        conversion_event
+            .fields
+            .get("error_class")
+            .map(String::as_str),
+        Some("empty_body"),
+        "error_class field"
+    );
+    assert_eq!(
+        conversion_event
+            .fields
+            .get("input_mime_type")
+            .map(String::as_str),
+        Some("text/markdown"),
+        "input_mime_type field"
+    );
+    assert_eq!(
+        conversion_event
+            .fields
+            .get("output_mime_type")
+            .map(String::as_str),
+        Some("none"),
+        "output_mime_type field"
+    );
+    assert_eq!(
+        conversion_event
+            .fields
+            .get("output_bytes")
+            .map(String::as_str),
+        Some("0"),
+        "output_bytes=0 on error"
+    );
 }


### PR DESCRIPTION
Adds `mime_type` labels and an `output_bytes` histogram to Prometheus metrics.

Refs #15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metric for conversion output bytes; conversion/request metrics now include input/output MIME-type labels and request/trace identifiers.

* **Documentation**
  * Expanded /metrics docs with the new output-bytes histogram and PromQL examples for body-size p95 and conversion success rate by input format.

* **Tests**
  * Expanded integration tests to validate MIME-type labeling, output-bytes recording, and tracing of conversion completion and errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->