### PR TITLE
Defer `StartParagraph` emission to elide empty wrappers

### DIFF
--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -74,6 +74,8 @@ enum BlockState {
     Explicit,
     /// Not inside any block context.
     None,
+    /// Explicit block whose `StartParagraph` is deferred until the first real event.
+    PendingExplicit,
 }
 
 /// Document processing phase.
@@ -195,6 +197,7 @@ impl<'a> MarkdownReader<'a> {
     /// Emits `StartLink` for the buffered link if it hasn't been emitted yet.
     /// Called before any inline event that would belong inside a link.
     fn emit_pending_link_start(&mut self) {
+        self.flush_pending_paragraph_start();
         if let Some(link) = self.link.as_mut() {
             if !link.started {
                 self.queue.push_back(Event::StartLink {
@@ -204,6 +207,18 @@ impl<'a> MarkdownReader<'a> {
                 });
                 link.started = true;
             }
+        }
+    }
+
+    /// Emits `StartParagraph` for the deferred paragraph if it hasn't been emitted yet.
+    /// Called before any committing event that would belong inside a paragraph.
+    fn flush_pending_paragraph_start(&mut self) {
+        if self.block_state == BlockState::PendingExplicit {
+            self.queue.push_back(Event::StartParagraph {
+                alignment: None,
+                id: None,
+            });
+            self.block_state = BlockState::Explicit;
         }
     }
 
@@ -246,6 +261,7 @@ impl<'a> MarkdownReader<'a> {
     /// in-progress image state; does nothing if no image is in progress.
     fn handle_end_image(&mut self) {
         let Some(img) = self.image.take() else { return };
+        self.flush_pending_paragraph_start();
         let trimmed = img.alt_buf.trim();
         let alt = if trimmed.is_empty() {
             None
@@ -278,6 +294,7 @@ impl<'a> MarkdownReader<'a> {
         if link.started {
             self.queue.push_back(Event::EndLink);
         } else {
+            self.flush_pending_paragraph_start();
             self.queue.push_back(Event::StartLink {
                 href: link.href,
                 id: None,
@@ -325,7 +342,13 @@ impl<'a> MarkdownReader<'a> {
             TagEnd::Item => self.handle_end_item(),
             TagEnd::Link => self.handle_end_link(),
             TagEnd::List(_) => self.handle_end_list(),
-            TagEnd::Paragraph => self.push_event_end(Event::EndParagraph),
+            TagEnd::Paragraph => {
+                if self.block_state == BlockState::PendingExplicit {
+                    self.block_state = BlockState::None;
+                } else {
+                    self.push_event_end(Event::EndParagraph);
+                }
+            }
             TagEnd::Strikethrough => self.strikethrough_depth.dec(),
             TagEnd::Strong => self.bold_depth.dec(),
             TagEnd::Table => self.push_event_end(Event::EndTable),
@@ -414,6 +437,7 @@ impl<'a> MarkdownReader<'a> {
         // empty `StartLink`/`EndLink` pair so the URL is preserved. `TagEnd::Image` fires
         // `Event::Image` before `TagEnd::Paragraph`, so downstream writers close the
         // surrounding paragraph before serialising the image as a sibling block.
+        self.flush_pending_paragraph_start();
         if let Some(link) = self.link.take() {
             if link.started {
                 self.queue.push_back(Event::EndLink);
@@ -499,10 +523,7 @@ impl<'a> MarkdownReader<'a> {
                 dest_url, title, ..
             } => self.handle_start_link(dest_url, title),
             Tag::List(start_opt) => self.handle_list_start(start_opt),
-            Tag::Paragraph => self.push_event_start(Event::StartParagraph {
-                alignment: None,
-                id: None,
-            }),
+            Tag::Paragraph => self.block_state = BlockState::PendingExplicit,
             Tag::Strikethrough => self.strikethrough_depth.inc(),
             Tag::Strong => self.bold_depth.inc(),
             Tag::Table(_) => self.push_event_start(Event::StartTable { id: None }),
@@ -592,6 +613,8 @@ impl<'a> MarkdownReader<'a> {
             pulldown_cmark::Event::HardBreak => {
                 if let Some(img) = &mut self.image {
                     img.alt_buf.push(' ');
+                } else if self.block_state == BlockState::PendingExplicit {
+                    // emitting a break before StartParagraph would be malformed — discard
                 } else {
                     self.emit_pending_link_start();
                     self.queue.push_back(Event::LineBreak);
@@ -600,6 +623,8 @@ impl<'a> MarkdownReader<'a> {
             pulldown_cmark::Event::SoftBreak => {
                 if let Some(img) = &mut self.image {
                     img.alt_buf.push(' ');
+                } else if self.block_state == BlockState::PendingExplicit {
+                    // emitting a break before StartParagraph would be malformed — discard
                 } else {
                     self.emit_pending_link_start();
                     self.queue.push_back(Event::SoftBreak);
@@ -677,6 +702,28 @@ mod tests {
             Some(&Event::Text {
                 content: "code".to_string(),
                 style: TextStyle::default().code(),
+            })
+        );
+    }
+
+    #[test]
+    fn handle_text_without_open_block_auto_opens_paragraph() {
+        let mut reader = MarkdownReader::new("");
+        reader.handle_text("hello".to_string());
+
+        assert_eq!(reader.queue.len(), 2);
+        assert_eq!(
+            reader.queue.front(),
+            Some(&Event::StartParagraph {
+                alignment: None,
+                id: None,
+            })
+        );
+        assert_eq!(
+            reader.queue.get(1),
+            Some(&Event::Text {
+                content: "hello".to_string(),
+                style: TextStyle::default(),
             })
         );
     }

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -1493,4 +1493,131 @@ mod tests {
             ]
         );
     }
+
+    #[test]
+    fn inline_html_only_paragraph_emits_nothing() {
+        let mut reader = MarkdownReader::new("<span id=\"ferris\"></span>");
+        let events = collect_events(&mut reader);
+        assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
+    }
+
+    #[test]
+    fn inline_html_between_paragraphs_preserves_surrounding() {
+        let markdown = "Before\n\n<span id=\"ferris\"></span>\n\nAfter";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_paragraph(),
+                helpers::text("Before", TextStyle::default()),
+                Event::EndParagraph,
+                helpers::start_paragraph(),
+                helpers::text("After", TextStyle::default()),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_html_with_text_still_emits_paragraph() {
+        let markdown = "text <span></span> more";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_paragraph(),
+                helpers::text("text ", TextStyle::default()),
+                helpers::text(" more", TextStyle::default()),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_html_inside_emphasis_emits_nothing() {
+        // pulldown-cmark emits: Start(Paragraph), Start(Emphasis), InlineHtml(...), InlineHtml(...), End(Emphasis), End(Paragraph)
+        // No Text events are emitted, so the paragraph should be deferred and ultimately not emitted.
+        let mut reader = MarkdownReader::new("*<span></span>*");
+        let events = collect_events(&mut reader);
+        assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
+    }
+
+    #[test]
+    fn softbreak_only_after_html_filter_emits_nothing() {
+        let mut reader = MarkdownReader::new("<span></span>\n<span></span>");
+        let events = collect_events(&mut reader);
+        assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
+    }
+
+    #[test]
+    fn image_only_paragraph_emits_paragraph_wrapper() {
+        let mut reader = MarkdownReader::new("![alt](img.png)");
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_paragraph(),
+                helpers::image_uri("img.png", Some("alt"), None, false),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hardbreak_only_paragraph_emits_nothing() {
+        let mut reader = MarkdownReader::new("  \n");
+        let events = collect_events(&mut reader);
+        assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
+    }
+
+    #[test]
+    fn inline_html_with_hardbreak_emits_nothing() {
+        let mut reader = MarkdownReader::new("<span></span>  \n<span></span>");
+        let events = collect_events(&mut reader);
+        assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
+    }
+
+    #[test]
+    fn list_item_with_only_softbreak_emits_softbreak() {
+        let mut reader = MarkdownReader::new("- <span></span>\n  <span></span>");
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_unordered_list_item(0),
+                Event::SoftBreak,
+                Event::EndUnorderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_item_with_text_and_softbreak_emits_text_and_break() {
+        let mut reader = MarkdownReader::new("- text\n  more");
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_unordered_list_item(0),
+                helpers::text("text", TextStyle::default()),
+                Event::SoftBreak,
+                helpers::text("more", TextStyle::default()),
+                Event::EndUnorderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
 }


### PR DESCRIPTION
See title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved malformed event sequences when parsing paragraphs in Markdown
  * Improved handling of inline HTML, hard breaks, and soft breaks in paragraph contexts
  * Fixed event emission ordering for images and links

* **Tests**
  * Added comprehensive unit tests covering edge cases with HTML and line breaks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->