### PR TITLE
Remove redundant code style from preformatted text events

### DIFF
--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -234,7 +234,7 @@ impl<'a> MarkdownReader<'a> {
             if !content.is_empty() {
                 self.queue.push_back(Event::Text {
                     content,
-                    style: TextStyle::default().code(),
+                    style: TextStyle::default(),
                 });
             }
         }

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -706,7 +706,7 @@ mod tests {
             vec![
                 helpers::start_document(),
                 helpers::start_preformatted(Some("rust")),
-                helpers::text("fn main() {}", TextStyle::default().code()),
+                helpers::text("fn main() {}", TextStyle::default()),
                 Event::EndPreformatted,
                 Event::EndDocument,
             ]
@@ -724,7 +724,7 @@ mod tests {
             vec![
                 helpers::start_document(),
                 helpers::start_preformatted(None),
-                helpers::text("some code", TextStyle::default().code()),
+                helpers::text("some code", TextStyle::default()),
                 Event::EndPreformatted,
                 Event::EndDocument,
             ]
@@ -742,7 +742,7 @@ mod tests {
             vec![
                 helpers::start_document(),
                 helpers::start_preformatted(None),
-                helpers::text("indented code", TextStyle::default().code()),
+                helpers::text("indented code", TextStyle::default()),
                 Event::EndPreformatted,
                 Event::EndDocument,
             ]
@@ -765,8 +765,76 @@ mod tests {
             vec![
                 helpers::start_document(),
                 helpers::start_preformatted(None),
-                helpers::text("code\n\n", TextStyle::default().code()),
+                helpers::text("code\n\n", TextStyle::default()),
                 Event::EndPreformatted,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn code_block_special_chars_pass_through_literally() {
+        // Markdown special characters inside a fenced code block must arrive
+        // as literal text with no inline styling. pulldown-cmark does not parse
+        // inline markdown inside code blocks, and the reader's code_block_buffer
+        // branch never consults bold/italic depth.
+        let markdown = "```\n*test* **bold** `code` _italic_ ~strike~\n```";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_preformatted(None),
+                helpers::text(
+                    "*test* **bold** `code` _italic_ ~strike~",
+                    TextStyle::default(),
+                ),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn fenced_code_block_empty() {
+        // An empty fenced code block emits StartPreformatted immediately
+        // followed by EndPreformatted with NO Text event in between
+        // (the `if !content.is_empty()` guard at src/lib.rs:234 suppresses it).
+        let markdown = "```\n```";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_preformatted(None),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn code_block_inside_list_item() {
+        let markdown = "- item\n\n  ```\n  code\n  ```";
+        let mut reader = MarkdownReader::new(markdown);
+        let events = collect_events(&mut reader);
+
+        assert_eq!(
+            events,
+            vec![
+                helpers::start_document(),
+                helpers::start_unordered_list_item(0),
+                helpers::start_paragraph(),
+                helpers::text("item", TextStyle::default()),
+                Event::EndParagraph,
+                helpers::start_preformatted(None),
+                helpers::text("code", TextStyle::default()),
+                Event::EndPreformatted,
+                Event::EndUnorderedListItem,
                 Event::EndDocument,
             ]
         );


### PR DESCRIPTION
…ext events

Refs: #37

## Description

<!-- Brief description of the changes -->

## Related Issue(s)

<!-- Link to related issue, e.g., "Fixes #123" or "Related to #456" -->

## Type of Change

<!-- Mark the appropriate option with an [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Testing

<!-- Describe how you tested your changes -->

- [ ] Unit tests pass
- [ ] Integration tests pass (if applicable)
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
