### PR TITLE
Disable publishing for docspec-wasm

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,4 +10,5 @@ git_release_latest = true
 
 [[package]]
 name = "docspec-wasm"
+publish = false
 release = false


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Summary**
This change updates the `release-plz.toml` configuration to explicitly prevent the **docspec-wasm** package from being published or released by the Release‑Plz automation.

**What was changed**
- In the `[[package]]` entry for `docspec-wasm`, two new fields were added:
  - `publish = false`
  - `release = false`

**Why**
The CI release workflow (Release‑Plz) previously treated `docspec-wasm` like other publishable packages. By setting both `publish` and `release` to `false`, the package is excluded from automatic publishing and release processes, ensuring that only intended packages are published during CI runs. This avoids unnecessary or erroneous releases of the WebAssembly variant of docspec.
<!-- kody-pr-summary:end -->