### PR TITLE
feat(oxa-writer): add basic oxa.dev JSON writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -548,6 +548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "docspec-oxa-writer"
+version = "0.1.0"
+dependencies = [
+ "docspec-core",
+ "docspec-json",
+ "serde_json",
+]
+
+[[package]]
 name = "docspec-wasm"
 version = "1.0.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/docspec-json",
   "crates/docspec-cli",
   "crates/docspec-http",
+  "crates/docspec-oxa-writer",
   "crates/docspec-wasm",
 ]
 

--- a/crates/docspec-oxa-writer/Cargo.toml
+++ b/crates/docspec-oxa-writer/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "docspec-oxa-writer"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "DocSpec event stream to oxa.dev JSON writer"
+keywords = ["document", "conversion", "streaming"]
+categories = ["encoding"]
+
+[dependencies]
+docspec-core = { path = "../docspec-core", version = "1.0.0" }
+docspec-json = { path = "../docspec-json", version = "1.0.2" }
+
+[dev-dependencies]
+serde_json = "1"
+
+[lints]
+workspace = true

--- a/crates/docspec-oxa-writer/README.md
+++ b/crates/docspec-oxa-writer/README.md
@@ -1,0 +1,57 @@
+# `docspec-oxa-writer`
+
+Converts a DocSpec event stream into [oxa.dev](https://oxa.dev/) JSON. Implements the `EventSink` trait and emits JSON tokens directly to any `Write` target as events arrive — no intermediate document representation, constant memory regardless of file size.
+
+## Supported Features
+
+| Block type | oxa.dev type |
+| --- | --- |
+| Paragraph | `Paragraph` |
+| Text | `Text` |
+
+## Not Supported
+
+The following DocSpec events are not yet supported and will be silently ignored:
+
+- Headings — `StartHeading` / `EndHeading`
+- Block quotes — `StartBlockQuote` / `EndBlockQuote`
+- Preformatted / code blocks — `StartPreformatted` / `EndPreformatted`
+- Images — `Image`
+- Tables — `StartTable` / `EndTable` and related events
+- Thematic breaks — `ThematicBreak`
+- List items — `StartOrderedListItem` / `StartUnorderedListItem` and related events
+- Inline links — `StartLink` / `EndLink`
+- Footnotes — `StartFootnote` / `EndFootnote` / `FootnoteRef`
+- Definition lists — `StartDefinitionList` / `StartDefinitionTerm` / `StartDefinitionDetail`
+- Captions — `StartCaption` / `EndCaption`
+
+## Usage
+
+```rust
+use docspec_oxa_writer::OxaWriter;
+use docspec_core::{Event, EventSink};
+
+let mut buf = Vec::<u8>::new();
+let mut writer = OxaWriter::new(&mut buf);
+
+writer.handle_event(Event::StartDocument { id: None, language: None, metadata: None })?;
+writer.handle_event(Event::StartParagraph { alignment: None, id: None })?;
+writer.handle_event(Event::Text {
+    content: "Hello, world".to_string(),
+    style: Default::default(),
+})?;
+writer.handle_event(Event::EndParagraph)?;
+writer.handle_event(Event::EndDocument)?;
+writer.finish()?;
+
+let json = String::from_utf8(buf)?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Limitations
+
+This is a minimal scaffold. Full implementation will follow in subsequent tasks.
+
+## License
+
+See the [repository LICENSE](../../LICENSE).

--- a/crates/docspec-oxa-writer/src/lib.rs
+++ b/crates/docspec-oxa-writer/src/lib.rs
@@ -1,0 +1,176 @@
+#![forbid(unsafe_code)]
+//! `DocSpec` event stream to `oxa.dev` JSON writer.
+//!
+//! This crate provides a streaming [`OxaWriter`] that implements [`EventSink`] to convert
+//! `DocSpec` event streams into `oxa.dev` JSON format.
+//!
+//! # Design
+//!
+//! The writer emits JSON tokens directly to the underlying `Write` as events arrive using
+//! `docspec-json` for streaming JSON output. Memory usage is constant regardless of document size.
+//!
+//! # Supported Events
+//!
+//! - `StartDocument` / `EndDocument` — document root
+//! - `StartParagraph` / `EndParagraph` — paragraph blocks
+//! - `Text` — inline text content
+//!
+//! # Example
+//!
+//! ```
+//! use docspec_core::{Event, EventSink, Result, TextStyle};
+//! use docspec_oxa_writer::OxaWriter;
+//!
+//! let mut buf = Vec::<u8>::new();
+//! let mut writer = OxaWriter::new(&mut buf);
+//! writer.handle_event(Event::StartDocument { id: None, language: None, metadata: None })?;
+//! writer.handle_event(Event::StartParagraph { alignment: None, id: None })?;
+//! writer.handle_event(Event::Text {
+//!     content: "Hello".to_string(),
+//!     style: TextStyle::default(),
+//! })?;
+//! writer.handle_event(Event::EndParagraph)?;
+//! writer.handle_event(Event::EndDocument)?;
+//! writer.finish()?;
+//! let json = String::from_utf8(buf).map_err(|err| docspec_core::Error::Other {
+//!     message: err.to_string(),
+//! })?;
+//! assert_eq!(
+//!     json,
+//!     r#"{"type":"Document","children":[{"type":"Paragraph","children":[{"type":"Text","value":"Hello"}]}]}"#
+//! );
+//! # Ok::<(), docspec_core::Error>(())
+//! ```
+
+use std::io::Write;
+
+use docspec_core::{Event, EventSink, Result};
+use docspec_json::{JsonEmitter, StrusonBackend};
+
+/// Streaming writer that converts a `DocSpec` event stream into `oxa.dev` JSON.
+///
+/// # Supported Events
+///
+/// - `StartDocument` / `EndDocument`
+/// - `StartParagraph` / `EndParagraph`
+/// - `Text` (content only, styles dropped)
+///
+/// All other events are silently ignored (no error, no panic).
+pub struct OxaWriter<W: Write> {
+    document_open: bool,
+    in_paragraph: bool,
+    json: JsonEmitter<StrusonBackend<W>>,
+}
+
+impl<W: Write> OxaWriter<W> {
+    /// Close the currently open paragraph, if any. No-op when no paragraph is open.
+    fn close_paragraph(&mut self) -> Result<()> {
+        if !self.in_paragraph {
+            return Ok(());
+        }
+        self.json.close_array()?;
+        self.json.close_object()?;
+        self.in_paragraph = false;
+        Ok(())
+    }
+
+    /// Create a new `OxaWriter` that writes to `writer`.
+    #[inline]
+    #[must_use]
+    pub fn new(writer: W) -> Self {
+        Self {
+            document_open: false,
+            in_paragraph: false,
+            json: JsonEmitter::new(StrusonBackend::new(writer)),
+        }
+    }
+}
+
+impl<W: Write> EventSink for OxaWriter<W> {
+    #[inline]
+    fn finish(self) -> Result<()> {
+        self.json.finish().map(|_| ())
+    }
+
+    #[inline]
+    fn handle_event(&mut self, event: Event) -> Result<()> {
+        match event {
+            Event::StartDocument { .. } => {
+                if self.document_open {
+                    return Ok(());
+                }
+                self.json.open_object()?;
+                self.json.key("type").value("Document")?;
+                self.json.key("children").open_array()?;
+                self.document_open = true;
+                Ok(())
+            }
+            Event::EndDocument => {
+                if !self.document_open {
+                    return Ok(());
+                }
+                self.close_paragraph()?;
+                self.json.close_array()?;
+                self.json.close_object()?;
+                self.document_open = false;
+                Ok(())
+            }
+            Event::StartParagraph { .. } => {
+                if !self.document_open || self.in_paragraph {
+                    return Ok(());
+                }
+                self.json.open_object()?;
+                self.json.key("type").value("Paragraph")?;
+                self.json.key("children").open_array()?;
+                self.in_paragraph = true;
+                Ok(())
+            }
+            Event::EndParagraph => self.close_paragraph(),
+            Event::Text { content, .. } => {
+                if !self.in_paragraph {
+                    return Ok(());
+                }
+                self.json.object(|j| {
+                    j.key("type").value("Text")?;
+                    j.key("value").value(content.as_str())
+                })
+            }
+            Event::EndBlockQuote
+            | Event::EndCaption
+            | Event::EndDefinitionDetail
+            | Event::EndDefinitionList
+            | Event::EndDefinitionTerm
+            | Event::EndFootnote
+            | Event::EndHeading
+            | Event::EndLink
+            | Event::EndOrderedListItem
+            | Event::EndPreformatted
+            | Event::EndTable
+            | Event::EndTableCell
+            | Event::EndTableHeader
+            | Event::EndTableRow
+            | Event::EndUnorderedListItem
+            | Event::FootnoteRef { .. }
+            | Event::Image { .. }
+            | Event::LineBreak
+            | Event::SoftBreak
+            | Event::StartBlockQuote { .. }
+            | Event::StartCaption { .. }
+            | Event::StartDefinitionDetail { .. }
+            | Event::StartDefinitionList { .. }
+            | Event::StartDefinitionTerm { .. }
+            | Event::StartFootnote { .. }
+            | Event::StartHeading { .. }
+            | Event::StartLink { .. }
+            | Event::StartOrderedListItem { .. }
+            | Event::StartPreformatted { .. }
+            | Event::StartTable { .. }
+            | Event::StartTableCell { .. }
+            | Event::StartTableHeader { .. }
+            | Event::StartTableRow { .. }
+            | Event::StartUnorderedListItem { .. }
+            | Event::ThematicBreak { .. }
+            | _ => Ok(()),
+        }
+    }
+}

--- a/crates/docspec-oxa-writer/tests/writer.rs
+++ b/crates/docspec-oxa-writer/tests/writer.rs
@@ -1,0 +1,353 @@
+//! Unit tests for `OxaWriter` event emission.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+#[cfg(test)]
+mod tests {
+    use docspec_core::{Error, Event, EventSink as _, ImageSource, TextStyle};
+    use docspec_oxa_writer::OxaWriter;
+    use serde_json::{json, Value};
+
+    fn run(events: Vec<Event>) -> Value {
+        let s = run_raw(events);
+        serde_json::from_str(&s).expect("valid JSON")
+    }
+
+    fn run_raw(events: Vec<Event>) -> String {
+        let mut buf = Vec::new();
+        let mut w = OxaWriter::new(&mut buf);
+        for e in events {
+            w.handle_event(e).expect("handle_event");
+        }
+        w.finish().expect("finish");
+        String::from_utf8(buf).expect("utf-8")
+    }
+
+    fn try_run(events: Vec<Event>) -> docspec_core::Result<String> {
+        let mut buf = Vec::new();
+        let mut w = OxaWriter::new(&mut buf);
+        for e in events {
+            w.handle_event(e)?;
+        }
+        w.finish()?;
+        String::from_utf8(buf).map_err(|err| Error::Other {
+            message: err.to_string(),
+        })
+    }
+
+    fn start_doc() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    fn end_doc() -> Event {
+        Event::EndDocument
+    }
+
+    fn start_para() -> Event {
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        }
+    }
+
+    fn end_para() -> Event {
+        Event::EndParagraph
+    }
+
+    fn text(s: &str) -> Event {
+        Event::Text {
+            content: s.to_string(),
+            style: TextStyle::default(),
+        }
+    }
+
+    #[test]
+    fn document_only() {
+        let v = run(vec![start_doc(), end_doc()]);
+        assert_eq!(v, json!({"type": "Document", "children": []}));
+    }
+
+    #[test]
+    fn single_paragraph_single_text() {
+        let v = run(vec![
+            start_doc(),
+            start_para(),
+            text("Hello"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [{
+                    "type": "Paragraph",
+                    "children": [{"type": "Text", "value": "Hello"}]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn multi_paragraph_multi_text() {
+        let v = run(vec![
+            start_doc(),
+            start_para(),
+            text("One"),
+            end_para(),
+            start_para(),
+            text("Two"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [
+                    {
+                        "type": "Paragraph",
+                        "children": [{"type": "Text", "value": "One"}]
+                    },
+                    {
+                        "type": "Paragraph",
+                        "children": [{"type": "Text", "value": "Two"}]
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn empty_paragraph() {
+        let v = run(vec![start_doc(), start_para(), end_para(), end_doc()]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [{"type": "Paragraph", "children": []}]
+            })
+        );
+    }
+
+    #[test]
+    fn multiple_text_in_paragraph() {
+        let v = run(vec![
+            start_doc(),
+            start_para(),
+            text("a"),
+            text("b"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [{
+                    "type": "Paragraph",
+                    "children": [
+                        {"type": "Text", "value": "a"},
+                        {"type": "Text", "value": "b"}
+                    ]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn unsupported_block_events_at_document_level_dropped() {
+        let v = run(vec![
+            start_doc(),
+            Event::StartHeading { level: 1, id: None },
+            text("Title"),
+            Event::EndHeading,
+            Event::Image {
+                alt: None,
+                decorative: false,
+                id: None,
+                source: ImageSource::Uri {
+                    uri: "x".to_string(),
+                },
+                title: None,
+            },
+            Event::ThematicBreak { id: None },
+            end_doc(),
+        ]);
+        assert_eq!(v, json!({"type": "Document", "children": []}));
+    }
+
+    #[test]
+    fn softbreak_and_linebreak_dropped() {
+        let v = run(vec![
+            start_doc(),
+            start_para(),
+            text("a"),
+            Event::SoftBreak,
+            text("b"),
+            Event::LineBreak,
+            text("c"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [{
+                    "type": "Paragraph",
+                    "children": [
+                        {"type": "Text", "value": "a"},
+                        {"type": "Text", "value": "b"},
+                        {"type": "Text", "value": "c"}
+                    ]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn text_with_json_special_chars() {
+        let json = run_raw(vec![
+            start_doc(),
+            start_para(),
+            text("a\nb\t\"c\\d"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            json,
+            "{\"type\":\"Document\",\"children\":[{\"type\":\"Paragraph\",\"children\":[{\"type\":\"Text\",\"value\":\"a\\nb\\t\\\"c\\\\d\"}]}]}"
+        );
+    }
+
+    // # Reason: unicode/emoji literals are intentional content of this test.
+    #[allow(clippy::non_ascii_literal)]
+    #[test]
+    fn text_with_unicode() {
+        let json = run_raw(vec![
+            start_doc(),
+            start_para(),
+            text("héllo 🎉 日本語"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            json,
+            r#"{"type":"Document","children":[{"type":"Paragraph","children":[{"type":"Text","value":"héllo 🎉 日本語"}]}]}"#
+        );
+    }
+
+    #[test]
+    fn empty_string_text() {
+        let v = run(vec![
+            start_doc(),
+            start_para(),
+            text(""),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [{
+                    "type": "Paragraph",
+                    "children": [{"type": "Text", "value": ""}]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn orphan_text_dropped() {
+        let v = run(vec![
+            text("before"),
+            start_doc(),
+            start_para(),
+            end_para(),
+            text("between"),
+            start_para(),
+            text("inside"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [
+                    {"type": "Paragraph", "children": []},
+                    {
+                        "type": "Paragraph",
+                        "children": [{"type": "Text", "value": "inside"}]
+                    }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn orphan_end_paragraph_no_op() {
+        let v = run(vec![start_doc(), end_para(), end_doc()]);
+        assert_eq!(v, json!({"type": "Document", "children": []}));
+    }
+
+    #[test]
+    fn double_start_document_no_op() {
+        let v = run(vec![
+            start_doc(),
+            start_doc(),
+            start_para(),
+            text("x"),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [{
+                    "type": "Paragraph",
+                    "children": [{"type": "Text", "value": "x"}]
+                }]
+            })
+        );
+    }
+
+    #[test]
+    fn end_document_without_start_no_op() {
+        let err = try_run(vec![end_doc()]).expect_err("expected Err");
+        assert_eq!(
+            err.to_string(),
+            "JSON error: cannot finish: open containers remain or no root value written"
+        );
+    }
+
+    #[test]
+    fn nested_paragraph_no_op() {
+        let v = run(vec![
+            start_doc(),
+            start_para(),
+            start_para(),
+            text("a"),
+            end_para(),
+            end_para(),
+            end_doc(),
+        ]);
+        assert_eq!(
+            v,
+            json!({
+                "type": "Document",
+                "children": [{
+                    "type": "Paragraph",
+                    "children": [{"type": "Text", "value": "a"}]
+                }]
+            })
+        );
+    }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -34,6 +34,9 @@
     "crates/docspec-html-writer": {
       "component": "docspec-html-writer"
     },
+    "crates/docspec-oxa-writer": {
+      "component": "docspec-oxa-writer"
+    },
     "crates/docspec-html-reader": {
       "component": "docspec-html-reader"
     }


### PR DESCRIPTION
## Summary

Adds a new `docspec-oxa-writer` crate that streams DocSpec events into [oxa.dev](https://oxa.dev/) JSON. KISS scope: only `Document`, `Paragraph`, and `Text` are emitted. All other events are silently dropped.

Closes #180

## Scope

This PR adds **only** the standalone `docspec-oxa-writer` crate. The `docspec` facade integration (`OutputFormat::Oxa`, `AnyWriter::Oxa`, `oxa` feature flag, `.oxa` extension detection) is **deferred** until `docspec-oxa-writer` has a published version on crates.io.

## Changes

### New crate: `crates/docspec-oxa-writer/`
- `OxaWriter<W: Write>` implementing `EventSink`
- Streaming JSON emission via `docspec-json` (`JsonEmitter` + `StrusonBackend`) — zero buffering
- 15 unit tests covering all edge cases (empty document, orphan text, double StartDocument, JSON special chars, Unicode, etc.)

### Workspace
- Registered as workspace member in root `Cargo.toml`

## OXA JSON shape

```json
{"type":"Document","children":[
  {"type":"Paragraph","children":[
    {"type":"Text","value":"Hello, world"}
  ]}
]}
```

## Usage

```toml
[dependencies]
docspec-oxa-writer = { path = "..." }
```

```rust
use docspec_oxa_writer::OxaWriter;
use docspec_core::{Event, EventSink};

let mut buf = Vec::new();
let mut writer = OxaWriter::new(&mut buf);
// feed events...
writer.finish()?;
```

## Checklist
- [x] `cargo build -p docspec-oxa-writer` exits 0
- [x] `cargo test -p docspec-oxa-writer` — 15 passed, 0 failed
- [x] `cargo clippy -p docspec-oxa-writer --all-targets -- -D warnings` exits 0
- [x] `cargo build --workspace` exits 0
- [x] All public items have doc comments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a streaming converter for document events to oxa.dev JSON format with minimal memory overhead.

* **Chores**
  * Added new crate to workspace and updated release tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->