### PR TITLE
Hookup oxa writer in http and cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,7 +448,7 @@ dependencies = [
 
 [[package]]
 name = "docspec"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "docspec-blocknote-writer",
  "docspec-core",

--- a/crates/docspec-cli/Cargo.toml
+++ b/crates/docspec-cli/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4", features = ["derive", "color"] }
-docspec = { path = "../docspec", version = "1.1.0", features = ["markdown", "html", "blocknote"] }
+docspec = { path = "../docspec", version = "1.2.0", features = ["markdown", "html", "blocknote", "oxa"] }
 docspec-core = { path = "../docspec-core", version = "1.0.0" }
 thiserror = "2"
 

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -18,7 +18,7 @@ docspec [OPTIONS] [INPUT]
 
 - `-o, --output <FILE>` — Output file (stdout if omitted)
 - `-f, --from <FORMAT>` — Input format (auto-detected from extension if omitted). Valid values: `markdown`, `html`
-- `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted). Valid values: `blocknote`
+- `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted). Valid values: `blocknote`, `oxa`
 - `--color <WHEN>` — When to use colors: `auto`, `always`, `never` (default: `auto`)
 - `-h, --help` — Print help
 - `-V, --version` — Print version
@@ -51,3 +51,6 @@ Convert Markdown from stdin to BlockNote JSON on stdout:
 ```bash
 echo "# Hello" | docspec --from markdown --to blocknote
 ```
+
+`--to oxa` selects the [oxa.dev](https://oxa.dev/) JSON writer in place of BlockNote. The `.json`
+extension is ambiguous, so `--to oxa` must be explicit.

--- a/crates/docspec-cli/src/args.rs
+++ b/crates/docspec-cli/src/args.rs
@@ -65,6 +65,9 @@ pub enum CliOutputFormat {
     /// `BlockNote` JSON format.
     #[value(name = "blocknote")]
     Blocknote,
+    /// `oxa.dev` JSON format.
+    #[value(name = "oxa")]
+    Oxa,
 }
 
 #[cfg(test)]
@@ -86,6 +89,22 @@ mod tests {
         assert!(
             result.is_err(),
             "markdown should not be a valid output format"
+        );
+    }
+
+    #[test]
+    fn clap_accepts_oxa_as_output_format() {
+        let result = Cli::try_parse_from(["docspec", "--to", "oxa", "x.md"]);
+        assert!(
+            result.is_ok(),
+            "oxa should be a valid output format, got error: {:?}",
+            result.as_ref().err()
+        );
+        let cli = result.unwrap_or_else(|_| std::process::abort());
+        assert!(
+            matches!(cli.to, Some(CliOutputFormat::Oxa)),
+            "expected CliOutputFormat::Oxa, got {:?}",
+            cli.to
         );
     }
 }

--- a/crates/docspec-cli/src/conversions.rs
+++ b/crates/docspec-cli/src/conversions.rs
@@ -19,6 +19,7 @@ impl From<CliOutputFormat> for OutputFormat {
     fn from(f: CliOutputFormat) -> Self {
         match f {
             CliOutputFormat::Blocknote => Self::Blocknote,
+            CliOutputFormat::Oxa => Self::Oxa,
         }
     }
 }
@@ -46,5 +47,10 @@ mod tests {
             OutputFormat::from(CliOutputFormat::Blocknote),
             OutputFormat::Blocknote
         );
+    }
+
+    #[test]
+    fn from_oxa_converts_to_facade_oxa() {
+        assert_eq!(OutputFormat::from(CliOutputFormat::Oxa), OutputFormat::Oxa);
     }
 }

--- a/crates/docspec-cli/src/format.rs
+++ b/crates/docspec-cli/src/format.rs
@@ -29,8 +29,8 @@ pub fn resolve_input_format(
 /// Resolves output format from explicit flag or path detection.
 ///
 /// Uses explicit format if provided, otherwise detects from path extension via the facade.
-/// Defaults to `BlockNote` when no output format can be detected, because it is the only
-/// currently supported output format.
+/// Defaults to `BlockNote` when no output format can be detected: the `.json` extension is
+/// ambiguous between writers, so `oxa.dev` must be selected explicitly via `--to oxa`.
 pub fn resolve_output_format(
     explicit: Option<crate::args::CliOutputFormat>,
     path: Option<&Path>,
@@ -136,6 +136,13 @@ mod tests {
     #[test]
     fn none_path_defaults_to_blocknote_output() {
         let result = resolve_output_format(None, None, "no path err");
+        assert!(matches!(result, Ok(docspec::OutputFormat::Blocknote)));
+    }
+
+    #[test]
+    fn json_path_without_explicit_flag_defaults_to_blocknote_not_oxa() {
+        // Regression guard: .json is ambiguous; auto-detection must NOT pick oxa.
+        let result = resolve_output_format(None, Some(Path::new("doc.json")), "err");
         assert!(matches!(result, Ok(docspec::OutputFormat::Blocknote)));
     }
 }

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -398,4 +398,35 @@ mod tests {
             .success()
             .stdout(contains("0.1.0"));
     }
+
+    #[test]
+    fn convert_markdown_stdin_to_oxa_stdout() {
+        docspec_cmd()
+            .args(["--from", "markdown", "--to", "oxa"])
+            .write_stdin("Hello world")
+            .assert()
+            .success()
+            .stdout(
+                r#"{"type":"Document","children":[{"type":"Paragraph","children":[{"type":"Text","value":"Hello world"}]}]}"#,
+            );
+    }
+
+    #[test]
+    fn json_extension_without_to_flag_still_picks_blocknote() {
+        // Regression guard: .json is ambiguous; auto-detection must NOT pick oxa.
+        let input = markdown_tempfile(b"Hello\n", ".md");
+        let output = empty_tempfile(".json");
+        let output_path = output.path().to_path_buf();
+
+        docspec_cmd()
+            .arg(input.path())
+            .args(["-o", output_path.to_str().unwrap_or("")])
+            .assert()
+            .success();
+
+        assert_eq!(
+            read_output(&output_path),
+            r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Hello","styles":{}}],"children":[]}]"#
+        );
+    }
 }

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -47,7 +47,7 @@ sentry = { version = "0.48", default-features = false, features = [
 ] }
 docspec-core = { path = "../docspec-core", version = "1.0.0" }
 docspec-json = { path = "../docspec-json", version = "1.0.0" }
-docspec = { path = "../docspec", version = "1.0.1", features = ["markdown", "blocknote"] }
+docspec = { path = "../docspec", version = "1.2.0", features = ["markdown", "blocknote", "oxa"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -1,8 +1,8 @@
 # `docspec-http`
 
-HTTP API server for DocSpec markdown to BlockNote JSON conversion.
+HTTP API server for DocSpec markdown to BlockNote JSON conversion (oxa.dev JSON opt-in via `Accept`).
 
-Send markdown, receive BlockNote JSON. The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
+Send markdown, receive BlockNote JSON (default) or oxa.dev JSON (`Accept: application/vnd.oxa+json`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
 
 ## Quick Start
 
@@ -19,21 +19,28 @@ Default host is `127.0.0.1`. Default port is `3000`.
 
 ## Endpoints
 
-| Method  | Path        | Description                        |
-| ------- | ----------- | ---------------------------------- |
-| POST    | /conversion | Convert markdown to BlockNote JSON |
-| OPTIONS | /conversion | Preflight / allowed methods        |
-| GET     | /health     | Liveness check                     |
-| HEAD    | /health     | Liveness check (no body)           |
-| OPTIONS | /health     | Allowed methods                    |
+| Method  | Path        | Description                                              |
+| ------- | ----------- | -------------------------------------------------------- |
+| POST    | /conversion | Convert markdown to BlockNote (default) or oxa.dev JSON  |
+| OPTIONS | /conversion | Preflight / allowed methods                              |
+| GET     | /health     | Liveness check                                           |
+| HEAD    | /health     | Liveness check (no body)                                 |
+| OPTIONS | /health     | Allowed methods                                          |
 
 ## curl Examples
 
 ```bash
-# Convert markdown to BlockNote JSON
+# Convert markdown to BlockNote JSON (default)
 curl -X POST \
      -H 'Content-Type: text/markdown' \
      --data '# Hello World' \
+     http://localhost:3000/conversion
+
+# Convert markdown to oxa.dev JSON (opt-in via Accept)
+curl -X POST \
+     -H 'Content-Type: text/markdown' \
+     -H 'Accept: application/vnd.oxa+json' \
+     --data 'Hello World' \
      http://localhost:3000/conversion
 
 # Check server health
@@ -68,7 +75,7 @@ All errors use RFC 7807 Problem Details JSON (`application/problem+json; charset
 | 422  | Markdown parse error                                |
 | 500  | Internal conversion error                           |
 
-Accepted `Accept` values for `/conversion`: `*/*`, `application/*`, `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json`. Anything else returns 406.
+Accepted `Accept` values for `/conversion`: `application/vnd.oxa+json` (oxa.dev), `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json` (BlockNote alias), `application/*`, or `*/*`. Wildcards and missing `Accept` default to BlockNote for back-compat. Anything else returns 406.
 
 ## Deployment Notes
 
@@ -237,7 +244,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 **`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
 
-**`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `none` (no output produced — any error path).
+**`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `application/vnd.oxa+json` (conversion succeeded; output produced by the oxa.dev writer), `none` (no output produced — any error path).
 
 **`path`**: matched route template (`/conversion`, `/health`) or `unknown` for fallback handlers
 
@@ -247,7 +254,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 ### Cardinality Guarantees
 
-`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 3 values. `output_mime_type` is bounded to 2 values. Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
+`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 3 values. `output_mime_type` is bounded to 3 values. Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
 
 ### Scrape Model
 

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -176,7 +176,8 @@ impl IntoResponse for HttpError {
                 "Not Acceptable",
                 Cow::Borrowed(
                     "Accept header must include application/vnd.docspec.blocknote+json, \
-                     application/vnd.blocknote+json, application/*, or */*",
+                     application/vnd.blocknote+json, application/vnd.oxa+json, \
+                     application/*, or */*",
                 ),
                 None,
             ),

--- a/crates/docspec-http/src/format.rs
+++ b/crates/docspec-http/src/format.rs
@@ -14,3 +14,6 @@ pub const OUTPUT_MIME_ALIAS: &str = "application/vnd.blocknote+json";
 
 /// The primary output MIME type returned on success.
 pub const OUTPUT_MIME_PRIMARY: &str = "application/vnd.docspec.blocknote+json";
+
+/// The primary `oxa.dev` output MIME type returned when the `oxa.dev` writer is selected.
+pub const OUTPUT_MIME_OXA_PRIMARY: &str = "application/vnd.oxa+json";

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -5,6 +5,7 @@ use axum::{
     http::{header, HeaderMap, HeaderValue, Response, StatusCode},
     response::IntoResponse,
 };
+use docspec::OutputFormat;
 use docspec_core::{EventSink as _, EventSource as _};
 
 use crate::{error::HttpError, mime_parser};
@@ -20,7 +21,10 @@ pub async fn options_conversion() -> impl IntoResponse {
     )
 }
 
-/// Handle `POST /conversion` — convert markdown to `BlockNote` JSON.
+/// Handle `POST /conversion` — convert markdown to `BlockNote` or `oxa.dev` JSON.
+///
+/// The output writer is selected by the request's `Accept` header (see
+/// [`crate::mime_parser::negotiate_accept`]).
 ///
 /// The request body is buffered, then converted to completion inside
 /// `spawn_blocking`, then returned in a single response. Conversion errors
@@ -71,12 +75,12 @@ pub async fn post_conversion(
         u64::try_from(conversion_duration.as_millis().min(u128::from(u64::MAX)))
             .unwrap_or(u64::MAX);
 
-    let (response_or_error, output_bytes) = match outcome {
-        Ok((response, bytes)) => (Ok(response), bytes),
-        Err(http_error) => (Err(http_error), 0),
+    let (response_or_error, output_bytes, chosen_format) = match outcome {
+        Ok((response, bytes, format)) => (Ok(response), bytes, Some(format)),
+        Err(http_error) => (Err(http_error), 0, None),
     };
     let conversion_ok = response_or_error.is_ok();
-    let output_mime_label = crate::mime_parser::bucket_output_mime(conversion_ok);
+    let output_mime_label = crate::mime_parser::bucket_output_mime(chosen_format);
 
     let (result_label, error_class_label) = match &response_or_error {
         Ok(_) => (
@@ -142,9 +146,9 @@ async fn do_conversion(
     input_mime_label: &'static str,
     headers: HeaderMap,
     body: Bytes,
-) -> Result<(Response<Body>, u64), HttpError> {
+) -> Result<(Response<Body>, u64, OutputFormat), HttpError> {
     mime_parser::validate_content_type(headers.get(header::CONTENT_TYPE))?;
-    mime_parser::negotiate_accept(headers.get(header::ACCEPT))?;
+    let output_format = mime_parser::negotiate_accept(headers.get(header::ACCEPT))?;
 
     if body.is_empty() {
         return Err(HttpError::EmptyBody);
@@ -171,8 +175,7 @@ async fn do_conversion(
     let join_result = tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64), HttpError> {
         let mut output_buffer = Vec::new();
         let mut reader = docspec::AnyReader::new(docspec::InputFormat::Markdown, &markdown);
-        let mut sink =
-            docspec::AnyWriter::new(docspec::OutputFormat::Blocknote, &mut output_buffer);
+        let mut sink = docspec::AnyWriter::new(output_format, &mut output_buffer);
 
         loop {
             match reader.next_event() {
@@ -205,15 +208,19 @@ async fn do_conversion(
     })
     .await;
 
+    let content_type = match output_format {
+        OutputFormat::Blocknote => {
+            HeaderValue::from_static("application/vnd.docspec.blocknote+json; charset=utf-8")
+        }
+        OutputFormat::Oxa => HeaderValue::from_static("application/vnd.oxa+json; charset=utf-8"),
+    };
+
     match join_result {
         Ok(Ok((output, output_bytes))) => Response::builder()
             .status(StatusCode::OK)
-            .header(
-                header::CONTENT_TYPE,
-                HeaderValue::from_static("application/vnd.docspec.blocknote+json; charset=utf-8"),
-            )
+            .header(header::CONTENT_TYPE, content_type)
             .body(Body::from(output))
-            .map(|response| (response, output_bytes))
+            .map(|response| (response, output_bytes, output_format))
             .map_err(|error| {
                 tracing::error!(error = %error, "failed to build conversion response");
                 HttpError::Internal

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -87,8 +87,11 @@ pub const INPUT_MIME_UNSUPPORTED: &str = "unsupported";
 /// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was absent.
 pub const INPUT_MIME_NONE: &str = "none";
 
-/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `BlockNote` JSON (current sole supported writer).
+/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `BlockNote` JSON.
 pub const OUTPUT_MIME_BLOCKNOTE: &str = "application/vnd.docspec.blocknote+json";
+
+/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `oxa.dev` JSON.
+pub const OUTPUT_MIME_OXA: &str = "application/vnd.oxa+json";
 
 /// Value for [`LABEL_OUTPUT_MIME_TYPE`] when no output was produced (any error path).
 pub const OUTPUT_MIME_NONE: &str = "none";

--- a/crates/docspec-http/src/mime_parser.rs
+++ b/crates/docspec-http/src/mime_parser.rs
@@ -1,31 +1,27 @@
 //! HTTP `Accept` negotiation and `Content-Type` validation for the conversion API.
 
 use axum::http::HeaderValue;
+use docspec::OutputFormat;
 
 use crate::error::HttpError;
-use crate::format::{OUTPUT_MIME_ALIAS, OUTPUT_MIME_PRIMARY};
+use crate::format::{OUTPUT_MIME_ALIAS, OUTPUT_MIME_OXA_PRIMARY, OUTPUT_MIME_PRIMARY};
 
 /// Negotiates the `Accept` header for the `/conversion` endpoint.
 ///
-/// Returns the primary output MIME type string for:
-/// - Missing `Accept` header (HTTP default is `*/*`)
-/// - `Accept: */*`
-/// - `Accept: application/*`
-/// - `Accept: application/vnd.docspec.blocknote+json`
-/// - `Accept: application/vnd.blocknote+json` (alias)
-///
-/// Returns `Err(HttpError::NotAcceptable)` for any other value.
-///
-/// Quality parameters (`q=...`) are stripped and ignored.
+/// Returns [`OutputFormat::Oxa`] for `Accept: application/vnd.oxa+json`, and
+/// [`OutputFormat::Blocknote`] for the `BlockNote` MIMEs, `application/*`, `*/*`, and
+/// missing `Accept`. Wildcards default to `BlockNote` for back-compat with pre-oxa
+/// clients. When `Accept` lists multiple types, the first whose bare MIME matches a
+/// supported value wins (case-insensitive); `q=...` is stripped.
 ///
 /// # Errors
 ///
 /// Returns [`HttpError::NotAcceptable`] if no acceptable MIME type found.
 #[inline]
-pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<&'static str, HttpError> {
+pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<OutputFormat, HttpError> {
     // Missing Accept == */* per RFC 7231 §5.3.2
     let Some(header_val) = header_value else {
-        return Ok(OUTPUT_MIME_PRIMARY);
+        return Ok(OutputFormat::Blocknote);
     };
     let header_str = header_val
         .to_str()
@@ -33,12 +29,15 @@ pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<&'static s
 
     for part in header_str.split(',') {
         let type_part = part.trim().split(';').next().map_or("", str::trim);
+        if type_part.eq_ignore_ascii_case(OUTPUT_MIME_OXA_PRIMARY) {
+            return Ok(OutputFormat::Oxa);
+        }
         if type_part.eq_ignore_ascii_case("*/*")
             || type_part.eq_ignore_ascii_case("application/*")
             || type_part.eq_ignore_ascii_case(OUTPUT_MIME_PRIMARY)
             || type_part.eq_ignore_ascii_case(OUTPUT_MIME_ALIAS)
         {
-            return Ok(OUTPUT_MIME_PRIMARY);
+            return Ok(OutputFormat::Blocknote);
         }
     }
     Err(HttpError::NotAcceptable)
@@ -131,23 +130,14 @@ pub fn bucket_input_mime(header_value: Option<&HeaderValue>) -> &'static str {
 
 /// Returns the bounded `output_mime_type` label value for a conversion outcome.
 ///
-/// When `conversion_ok` is `false`, no output was produced, so the label is
-/// always [`crate::metrics::OUTPUT_MIME_NONE`].
-///
-/// When `conversion_ok` is `true`, the output is always `BlockNote` JSON because
-/// the writer is fixed today.
-///
-/// # Label values
-///
-/// - [`crate::metrics::OUTPUT_MIME_NONE`] — conversion failed (no output)
-/// - [`crate::metrics::OUTPUT_MIME_BLOCKNOTE`] — conversion succeeded
+/// `chosen_format` is `None` for any error path, and `Some(format)` on success.
 #[inline]
 #[must_use]
-pub fn bucket_output_mime(conversion_ok: bool) -> &'static str {
-    if conversion_ok {
-        crate::metrics::OUTPUT_MIME_BLOCKNOTE
-    } else {
-        crate::metrics::OUTPUT_MIME_NONE
+pub fn bucket_output_mime(chosen_format: Option<OutputFormat>) -> &'static str {
+    match chosen_format {
+        None => crate::metrics::OUTPUT_MIME_NONE,
+        Some(OutputFormat::Blocknote) => crate::metrics::OUTPUT_MIME_BLOCKNOTE,
+        Some(OutputFormat::Oxa) => crate::metrics::OUTPUT_MIME_OXA,
     }
 }
 
@@ -226,15 +216,23 @@ mod bucket_tests {
     // ─── bucket_output_mime tests ──────────────────────────────────────────
 
     #[test]
-    fn bucket_output_mime_blocknote_when_success() {
+    fn bucket_output_mime_blocknote_when_blocknote_succeeded() {
         assert_eq!(
-            bucket_output_mime(true),
+            bucket_output_mime(Some(OutputFormat::Blocknote)),
             crate::metrics::OUTPUT_MIME_BLOCKNOTE
         );
     }
 
     #[test]
-    fn bucket_output_mime_none_when_failure() {
-        assert_eq!(bucket_output_mime(false), crate::metrics::OUTPUT_MIME_NONE);
+    fn bucket_output_mime_oxa_when_oxa_succeeded() {
+        assert_eq!(
+            bucket_output_mime(Some(OutputFormat::Oxa)),
+            crate::metrics::OUTPUT_MIME_OXA
+        );
+    }
+
+    #[test]
+    fn bucket_output_mime_none_when_no_format_chosen() {
+        assert_eq!(bucket_output_mime(None), crate::metrics::OUTPUT_MIME_NONE);
     }
 }

--- a/crates/docspec-http/tests/http_integration.rs
+++ b/crates/docspec-http/tests/http_integration.rs
@@ -19,6 +19,7 @@ use tower::ServiceExt as _;
 
 const CACHE_CONTROL: &str = "max-age=0, private, must-revalidate";
 const OUTPUT_MIME: &str = "application/vnd.docspec.blocknote+json; charset=utf-8";
+const OUTPUT_MIME_OXA: &str = "application/vnd.oxa+json; charset=utf-8";
 const PROBLEM_JSON_CT: &str = "application/problem+json; charset=utf-8";
 const HEALTH_CT: &str = "text/plain; charset=utf-8";
 
@@ -274,7 +275,7 @@ async fn post_conversion_wrong_accept() {
             "type": "about:blank",
             "title": "Not Acceptable",
             "status": 406,
-            "detail": "Accept header must include application/vnd.docspec.blocknote+json, application/vnd.blocknote+json, application/*, or */*",
+            "detail": "Accept header must include application/vnd.docspec.blocknote+json, application/vnd.blocknote+json, application/vnd.oxa+json, application/*, or */*",
         })
     );
 }
@@ -574,6 +575,61 @@ async fn unknown_path_returns_404() {
             "detail": "No route matches GET /unknown",
         })
     );
+}
+
+#[tokio::test]
+async fn post_conversion_oxa_happy_path() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[
+            ("content-type", "text/markdown"),
+            ("accept", "application/vnd.oxa+json"),
+        ],
+        Body::from("Hello world"),
+    );
+
+    let response = app().oneshot(request).await.expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME_OXA
+    );
+
+    let body_text = response_body_text(response.into_body()).await;
+    assert_eq!(
+        body_text,
+        r#"{"type":"Document","children":[{"type":"Paragraph","children":[{"type":"Text","value":"Hello world"}]}]}"#
+    );
+}
+
+#[tokio::test]
+async fn post_conversion_wildcard_accept_defaults_to_blocknote_not_oxa() {
+    // Regression guard: `*/*` MUST select BlockNote so pre-oxa clients keep their responses.
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", "text/markdown"), ("accept", "*/*")],
+        Body::from("# Hello"),
+    );
+
+    let response = app().oneshot(request).await.expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME
+    );
+
+    let body = response_body_json(response.into_body()).await;
+    assert_eq!(body, hello_blocknote_json());
 }
 
 #[tokio::test]

--- a/crates/docspec-http/tests/metrics_conversion.rs
+++ b/crates/docspec-http/tests/metrics_conversion.rs
@@ -388,3 +388,31 @@ fn output_bytes_not_recorded_on_unsupported_media() {
         "Expected no docspec_conversion_output_bytes lines on error, but found some.\n  rendered:\n{rendered}",
     );
 }
+
+// ─── Test 14: oxa success records oxa output_mime_type ───────────────────────
+
+/// A successful conversion to oxa records `output_mime_type="application/vnd.oxa+json"`
+/// on `docspec_conversions_total`.
+#[test]
+fn oxa_success_records_oxa_output_mime() {
+    let rt = common::runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "text/markdown")
+        .header("accept", "application/vnd.oxa+json")
+        .body(Body::from("Hello"))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="success",error_class="none",input_mime_type="text/markdown",output_mime_type="application/vnd.oxa+json"} 1"#,
+    );
+}

--- a/crates/docspec-http/tests/mime_parser.rs
+++ b/crates/docspec-http/tests/mime_parser.rs
@@ -3,8 +3,8 @@
 #![allow(clippy::tests_outside_test_module, clippy::unwrap_used)]
 
 use axum::http::HeaderValue;
+use docspec::OutputFormat;
 use docspec_http::error::HttpError;
-use docspec_http::format::OUTPUT_MIME_PRIMARY;
 use docspec_http::mime_parser::{negotiate_accept, validate_content_type};
 
 #[test]
@@ -89,35 +89,49 @@ fn content_type_missing_rejects_with_none() {
 }
 
 #[test]
-fn accept_missing_returns_primary() {
-    assert_eq!(negotiate_accept(None).unwrap(), OUTPUT_MIME_PRIMARY);
+fn accept_missing_returns_blocknote() {
+    assert_eq!(negotiate_accept(None).unwrap(), OutputFormat::Blocknote);
 }
 
 #[test]
-fn accept_wildcard_returns_primary() {
+fn accept_wildcard_returns_blocknote() {
     let header = HeaderValue::from_static("*/*");
     assert_eq!(
         negotiate_accept(Some(&header)).unwrap(),
-        OUTPUT_MIME_PRIMARY
+        OutputFormat::Blocknote
     );
 }
 
 #[test]
-fn accept_primary_mime_returns_primary() {
+fn accept_primary_mime_returns_blocknote() {
     let header = HeaderValue::from_static("application/vnd.docspec.blocknote+json");
     assert_eq!(
         negotiate_accept(Some(&header)).unwrap(),
-        OUTPUT_MIME_PRIMARY
+        OutputFormat::Blocknote
     );
 }
 
 #[test]
-fn accept_alias_mime_returns_primary() {
+fn accept_alias_mime_returns_blocknote() {
     let header = HeaderValue::from_static("application/vnd.blocknote+json");
     assert_eq!(
         negotiate_accept(Some(&header)).unwrap(),
-        OUTPUT_MIME_PRIMARY
+        OutputFormat::Blocknote
     );
+}
+
+#[test]
+fn accept_oxa_primary_mime_returns_oxa() {
+    let header = HeaderValue::from_static("application/vnd.oxa+json");
+    assert_eq!(negotiate_accept(Some(&header)).unwrap(), OutputFormat::Oxa);
+}
+
+#[test]
+fn accept_list_oxa_first_returns_oxa() {
+    let header = HeaderValue::from_static(
+        "application/vnd.oxa+json, application/vnd.docspec.blocknote+json",
+    );
+    assert_eq!(negotiate_accept(Some(&header)).unwrap(), OutputFormat::Oxa);
 }
 
 #[test]
@@ -134,7 +148,7 @@ fn accept_list_with_alias_and_quality_accepts() {
     let header = HeaderValue::from_static("text/html, application/vnd.blocknote+json;q=0.8");
     assert_eq!(
         negotiate_accept(Some(&header)).unwrap(),
-        OUTPUT_MIME_PRIMARY
+        OutputFormat::Blocknote
     );
 }
 
@@ -148,10 +162,10 @@ fn accept_incompatible_list_rejects() {
 }
 
 #[test]
-fn accept_application_wildcard_returns_primary() {
+fn accept_application_wildcard_returns_blocknote() {
     let header = HeaderValue::from_static("application/*");
     assert_eq!(
         negotiate_accept(Some(&header)).unwrap(),
-        OUTPUT_MIME_PRIMARY
+        OutputFormat::Blocknote
     );
 }


### PR DESCRIPTION
Refs: #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: add explicit OXA output support via --to oxa; `.json` extension is ambiguous—use `--to oxa`.
  * HTTP API: opt into OXA JSON via Accept header; BlockNote remains default for wildcards/missing Accept.

* **Documentation**
  * Updated CLI and HTTP docs with OXA examples, Accept header behavior, endpoints, and metrics notes.

* **Tests**
  * Added unit and integration tests for OXA conversions, content negotiation, and metrics labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->