### PR TITLE
feat(docspec): hookup html-writer behind html-writer feature flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -471,6 +471,7 @@ dependencies = [
  "docspec-blocknote-writer",
  "docspec-core",
  "docspec-html-reader",
+ "docspec-html-writer",
  "docspec-json",
  "docspec-markdown-reader",
  "docspec-oxa-writer",
@@ -489,7 +490,7 @@ dependencies = [
 
 [[package]]
 name = "docspec-cli"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -539,7 +540,7 @@ dependencies = [
 
 [[package]]
 name = "docspec-http"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "axum",
  "clap",

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -18,16 +18,22 @@ markdown = ["dep:docspec-markdown-reader"]
 html = ["dep:docspec-html-reader"]
 
 # Format writers (event sinks).
-blocknote = ["dep:docspec-blocknote-writer"]
-oxa = ["dep:docspec-oxa-writer"]
+blocknote-writer = ["dep:docspec-blocknote-writer"]
+oxa-writer = ["dep:docspec-oxa-writer"]
+html-writer = ["dep:docspec-html-writer"]
 
 # Lower-level primitives for implementing custom writers.
 json = ["dep:docspec-json"]
 
 # Convenience meta-features.
+# `blocknote`/`oxa` currently enable only the writer; once their readers exist
+# the meta will expand to enable both directions.
+blocknote = ["blocknote-writer"]
+oxa = ["oxa-writer"]
 all-readers = ["markdown", "html"]
-all-writers = ["blocknote", "oxa"]
-full = ["all-readers", "all-writers", "json"]
+all-writers = ["blocknote-writer", "oxa-writer", "html-writer"]
+all-libs = ["json"]
+full = ["all-readers", "all-writers", "all-libs"]
 
 [dependencies]
 docspec-core = { path = "../docspec-core", version = "1.0.0" }
@@ -36,6 +42,7 @@ docspec-markdown-reader = { path = "../docspec-markdown-reader", version = "1.0.
 docspec-blocknote-writer = { path = "../docspec-blocknote-writer", version = "1.0.2", optional = true }
 docspec-html-reader = { path = "../docspec-html-reader", version = "1.0.1", optional = true }
 docspec-oxa-writer = { path = "../docspec-oxa-writer", version = "1.0.0", optional = true }
+docspec-html-writer = { path = "../docspec-html-writer", version = "1.0.1", optional = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -37,13 +37,15 @@ writer.finish()?;
 | Feature    | Format                                           | Crate                     |
 | ---------- | ------------------------------------------------ | ------------------------- |
 | `markdown` | Markdown (CommonMark + GFM tables/strikethrough) | `docspec-markdown-reader` |
+| `html`     | HTML (paragraphs only)                           | `docspec-html-reader`     |
 
 ### Writers
 
-| Feature     | Format         | Crate                      |
-| ----------- | -------------- | -------------------------- |
-| `blocknote` | BlockNote JSON | `docspec-blocknote-writer` |
-| `oxa`       | oxa.dev JSON   | `docspec-oxa-writer`       |
+| Feature            | Format                 | Crate                      |
+| ------------------ | ---------------------- | -------------------------- |
+| `blocknote-writer` | BlockNote JSON         | `docspec-blocknote-writer` |
+| `oxa-writer`       | oxa.dev JSON           | `docspec-oxa-writer`       |
+| `html-writer`      | HTML (paragraphs only) | `docspec-html-writer`      |
 
 ### Primitives
 
@@ -53,11 +55,14 @@ writer.finish()?;
 
 ### Convenience
 
-| Feature       | Enables                                             |
-| ------------- | --------------------------------------------------- |
-| `all-readers` | All reader features                                 |
-| `all-writers` | All writer features                                 |
-| `full`        | Everything (`all-readers` + `all-writers` + `json`) |
+| Feature       | Enables                                                       |
+| ------------- | ------------------------------------------------------------- |
+| `blocknote`   | BlockNote in both directions (writer only until reader lands) |
+| `oxa`         | oxa.dev in both directions (writer only until reader lands)   |
+| `all-readers` | All reader features                                           |
+| `all-writers` | All writer features                                           |
+| `all-libs`    | All primitive/library features (currently `json`)             |
+| `full`        | Everything (`all-readers` + `all-writers` + `all-libs`)       |
 
 No features are enabled by default — opt into what you need.
 

--- a/crates/docspec/src/factory/writer.rs
+++ b/crates/docspec/src/factory/writer.rs
@@ -4,9 +4,11 @@ use std::io::Write;
 
 use docspec_core::{AssetProvider, Event, EventSink, Result, StackTrackingSink};
 
-#[cfg(feature = "blocknote")]
+#[cfg(feature = "blocknote-writer")]
 use docspec_blocknote_writer::BlockNoteWriter;
-#[cfg(feature = "oxa")]
+#[cfg(feature = "html-writer")]
+use docspec_html_writer::HtmlWriter;
+#[cfg(feature = "oxa-writer")]
 use docspec_oxa_writer::OxaWriter;
 
 use crate::format::OutputFormat;
@@ -21,11 +23,13 @@ pub struct AnyWriter<'a, W: Write> {
 }
 
 enum AnyWriterInner<'a, W: Write> {
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     BlockNote(BlockNoteWriter<'a, W>),
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "html-writer")]
+    Html(HtmlWriter<W>),
+    #[cfg(feature = "oxa-writer")]
     Oxa(OxaWriter<W>),
-    #[cfg(not(feature = "blocknote"))]
+    #[cfg(not(feature = "blocknote-writer"))]
     _Phantom(std::marker::PhantomData<&'a W>),
 }
 
@@ -34,17 +38,27 @@ impl<'a, W: Write> AnyWriter<'a, W> {
     #[inline]
     #[must_use]
     pub fn new(format: OutputFormat, writer: W) -> Self {
-        #[cfg(not(any(feature = "blocknote", feature = "oxa")))]
+        #[cfg(not(any(
+            feature = "blocknote-writer",
+            feature = "oxa-writer",
+            feature = "html-writer"
+        )))]
         {
-            let _ = writer;
+            drop(writer);
             match format {}
         }
-        #[cfg(any(feature = "blocknote", feature = "oxa"))]
+        #[cfg(any(
+            feature = "blocknote-writer",
+            feature = "oxa-writer",
+            feature = "html-writer"
+        ))]
         {
             let inner = match format {
-                #[cfg(feature = "blocknote")]
+                #[cfg(feature = "blocknote-writer")]
                 OutputFormat::Blocknote => AnyWriterInner::BlockNote(BlockNoteWriter::new(writer)),
-                #[cfg(feature = "oxa")]
+                #[cfg(feature = "html-writer")]
+                OutputFormat::Html => AnyWriterInner::Html(HtmlWriter::new(writer)),
+                #[cfg(feature = "oxa-writer")]
                 OutputFormat::Oxa => AnyWriterInner::Oxa(OxaWriter::new(writer)),
             };
             Self {
@@ -55,24 +69,39 @@ impl<'a, W: Write> AnyWriter<'a, W> {
 
     /// Construct a writer with an asset provider, where supported.
     ///
-    /// Writers that do not consume an [`AssetProvider`] (currently
-    /// `OxaWriter`) silently ignore the `assets` argument.
+    /// Writers that do not consume an [`AssetProvider`] (currently `OxaWriter`
+    /// and `HtmlWriter`) silently ignore the `assets` argument; the resulting
+    /// writer behaves identically to [`AnyWriter::new`].
     #[inline]
     #[must_use]
     pub fn with_assets(format: OutputFormat, writer: W, assets: &'a dyn AssetProvider) -> Self {
-        #[cfg(not(any(feature = "blocknote", feature = "oxa")))]
+        #[cfg(not(any(
+            feature = "blocknote-writer",
+            feature = "oxa-writer",
+            feature = "html-writer"
+        )))]
         {
-            let _ = (writer, assets);
+            drop(writer);
+            let _ = assets;
             match format {}
         }
-        #[cfg(any(feature = "blocknote", feature = "oxa"))]
+        #[cfg(any(
+            feature = "blocknote-writer",
+            feature = "oxa-writer",
+            feature = "html-writer"
+        ))]
         {
             let inner = match format {
-                #[cfg(feature = "blocknote")]
+                #[cfg(feature = "blocknote-writer")]
                 OutputFormat::Blocknote => {
                     AnyWriterInner::BlockNote(BlockNoteWriter::with_assets(writer, assets))
                 }
-                #[cfg(feature = "oxa")]
+                #[cfg(feature = "html-writer")]
+                OutputFormat::Html => {
+                    let _ = assets;
+                    AnyWriterInner::Html(HtmlWriter::new(writer))
+                }
+                #[cfg(feature = "oxa-writer")]
                 OutputFormat::Oxa => {
                     let _ = assets;
                     AnyWriterInner::Oxa(OxaWriter::new(writer))
@@ -88,22 +117,26 @@ impl<'a, W: Write> AnyWriter<'a, W> {
 impl<W: Write> EventSink for AnyWriterInner<'_, W> {
     fn finish(self) -> Result<()> {
         match self {
-            #[cfg(feature = "blocknote")]
+            #[cfg(feature = "blocknote-writer")]
             Self::BlockNote(w) => w.finish(),
-            #[cfg(feature = "oxa")]
+            #[cfg(feature = "html-writer")]
+            Self::Html(w) => w.finish(),
+            #[cfg(feature = "oxa-writer")]
             Self::Oxa(w) => w.finish(),
-            #[cfg(not(feature = "blocknote"))]
+            #[cfg(not(feature = "blocknote-writer"))]
             Self::_Phantom(_) => Ok(()),
         }
     }
 
     fn handle_event(&mut self, event: Event) -> Result<()> {
         match self {
-            #[cfg(feature = "blocknote")]
+            #[cfg(feature = "blocknote-writer")]
             Self::BlockNote(w) => w.handle_event(event),
-            #[cfg(feature = "oxa")]
+            #[cfg(feature = "html-writer")]
+            Self::Html(w) => w.handle_event(event),
+            #[cfg(feature = "oxa-writer")]
             Self::Oxa(w) => w.handle_event(event),
-            #[cfg(not(feature = "blocknote"))]
+            #[cfg(not(feature = "blocknote-writer"))]
             Self::_Phantom(_) => {
                 let _ = event;
                 Ok(())
@@ -129,8 +162,19 @@ mod tests {
     use std::borrow::Cow;
     use std::io::Write;
 
-    use docspec_core::{AssetProvider, Event, EventSink as _};
+    use docspec_core::AssetProvider;
+    #[cfg(any(
+        feature = "blocknote-writer",
+        feature = "html-writer",
+        feature = "oxa-writer"
+    ))]
+    use docspec_core::{Event, EventSink as _};
 
+    #[cfg(any(
+        feature = "blocknote-writer",
+        feature = "html-writer",
+        feature = "oxa-writer"
+    ))]
     use super::{AnyWriter, OutputFormat};
 
     struct NullAssets;
@@ -149,7 +193,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     #[test]
     fn with_assets_constructs_writer_for_blocknote() {
         let assets = NullAssets;
@@ -169,7 +213,7 @@ mod tests {
         assert!(!buf.is_empty());
     }
 
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "oxa-writer")]
     #[test]
     fn with_assets_constructs_writer_for_oxa() {
         let assets = NullAssets;
@@ -185,5 +229,23 @@ mod tests {
         assert!(writer.handle_event(Event::EndDocument).is_ok());
         assert!(writer.finish().is_ok());
         assert_eq!(buf, br#"{"type":"Document","children":[]}"#);
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn with_assets_ignores_provider_for_html_writer() {
+        let assets = NullAssets;
+        let mut buf = Vec::new();
+        let mut writer = AnyWriter::with_assets(OutputFormat::Html, &mut buf, &assets);
+        assert!(writer
+            .handle_event(Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            })
+            .is_ok());
+        assert!(writer.handle_event(Event::EndDocument).is_ok());
+        assert!(writer.finish().is_ok());
+        assert_eq!(buf, b"<html><body></body></html>");
     }
 }

--- a/crates/docspec/src/format.rs
+++ b/crates/docspec/src/format.rs
@@ -16,10 +16,14 @@ pub enum InputFormat {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum OutputFormat {
     /// `BlockNote` JSON. Available when the `blocknote` feature is enabled.
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     Blocknote,
+    /// HTML5 (paragraph-only; `<p>` elements and text within them only).
+    /// Available when the `html-writer` feature is enabled.
+    #[cfg(feature = "html-writer")]
+    Html,
     /// `oxa.dev` JSON. Available when the `oxa` feature is enabled.
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "oxa-writer")]
     Oxa,
 }
 
@@ -53,8 +57,10 @@ pub fn detect_input_format(path: &Path) -> Option<InputFormat> {
 pub fn detect_output_format(path: &Path) -> Option<OutputFormat> {
     let ext = path.extension()?.to_str()?.to_ascii_lowercase();
     match ext.as_str() {
-        #[cfg(feature = "blocknote")]
+        #[cfg(feature = "blocknote-writer")]
         "json" => Some(OutputFormat::Blocknote),
+        #[cfg(feature = "html-writer")]
+        "html" | "htm" => Some(OutputFormat::Html),
         _ => None,
     }
 }

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -12,17 +12,18 @@
 //!
 //! ## Readers
 //!
-//! | Feature    | Format                                              | Re-exports                  |
-//! |------------|-----------------------------------------------------|-----------------------------|
-//! | `markdown` | Markdown (`CommonMark` + GFM tables/strikethrough)  | [`readers::MarkdownReader`] |
-//! | `html`     | HTML (paragraphs only)                              | `readers::HtmlReader`       |
+//! | Feature        | Format                                              | Re-exports                  |
+//! |----------------|-----------------------------------------------------|-----------------------------|
+//! | `markdown`     | Markdown (`CommonMark` + GFM tables/strikethrough)  | [`readers::MarkdownReader`] |
+//! | `html`         | HTML (paragraphs only)                              | `readers::HtmlReader`       |
 //!
 //! ## Writers
 //!
-//! | Feature     | Format           | Re-exports                    |
-//! |-------------|------------------|-------------------------------|
-//! | `blocknote` | `BlockNote` JSON | [`writers::BlockNoteWriter`]  |
-//! | `oxa`       | `oxa.dev` JSON   | `writers::OxaWriter`          |
+//! | Feature             | Format                  | Re-exports                    |
+//! |---------------------|-------------------------|-------------------------------|
+//! | `blocknote-writer`  | `BlockNote` JSON        | [`writers::BlockNoteWriter`]  |
+//! | `oxa-writer`        | `oxa.dev` JSON          | `writers::OxaWriter`          |
+//! | `html-writer`       | HTML (paragraphs only)  | `writers::HtmlWriter`         |
 //!
 //! ## Primitives
 //!
@@ -32,11 +33,14 @@
 //!
 //! ## Convenience
 //!
-//! | Feature       | Enables                                                |
-//! |---------------|--------------------------------------------------------|
-//! | `all-readers` | All reader features                                    |
-//! | `all-writers` | All writer features                                    |
-//! | `full`        | Everything (`all-readers` + `all-writers` + `json`)    |
+//! | Feature       | Enables                                                          |
+//! |---------------|------------------------------------------------------------------|
+//! | `blocknote`   | `BlockNote` in both directions (writer only until reader lands)  |
+//! | `oxa`         | `oxa.dev` in both directions (writer only until reader lands)    |
+//! | `all-readers` | All reader features                                              |
+//! | `all-writers` | All writer features                                              |
+//! | `all-libs`    | All primitive/library features (currently `json`)                |
+//! | `full`        | Everything (`all-readers` + `all-writers` + `all-libs`)          |
 //!
 //! # Choosing the Right Dependency
 //!
@@ -57,7 +61,7 @@
 //! Convert Markdown to `BlockNote` JSON:
 //!
 //! ```no_run
-//! # #[cfg(all(feature = "markdown", feature = "blocknote"))]
+//! # #[cfg(all(feature = "markdown", feature = "blocknote-writer"))]
 //! # fn run() -> Result<(), Box<dyn std::error::Error>> {
 //! use docspec::readers::MarkdownReader;
 //! use docspec::writers::BlockNoteWriter;
@@ -110,15 +114,24 @@ pub mod readers {
 /// Each writer is gated by a feature flag. See the crate-level documentation for the
 /// full list of supported formats and corresponding feature flags.
 pub mod writers {
-    /// Streaming `BlockNote` JSON writer. Available when the `blocknote` feature is enabled.
-    #[cfg(feature = "blocknote")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "blocknote")))]
+    /// Streaming `BlockNote` JSON writer. Available when the `blocknote-writer` feature
+    /// is enabled (either directly, or via the `blocknote` meta feature).
+    #[cfg(feature = "blocknote-writer")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "blocknote-writer")))]
     pub use docspec_blocknote_writer::BlockNoteWriter;
 
-    /// Streaming `oxa.dev` JSON writer. Available when the `oxa` feature is enabled.
-    #[cfg(feature = "oxa")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "oxa")))]
+    /// Streaming `oxa.dev` JSON writer. Available when the `oxa-writer` feature is
+    /// enabled (either directly, or via the `oxa` meta feature).
+    #[cfg(feature = "oxa-writer")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "oxa-writer")))]
     pub use docspec_oxa_writer::OxaWriter;
+
+    /// Streaming HTML5 writer. Available when the `html-writer` feature is enabled.
+    /// Note: currently emits only `<html>/<body>/<p>` and text within paragraphs;
+    /// other events are silently ignored.
+    #[cfg(feature = "html-writer")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "html-writer")))]
+    pub use docspec_html_writer::HtmlWriter;
 }
 
 /// Format detection and conversion helpers.

--- a/crates/docspec/tests/factory_reader.rs
+++ b/crates/docspec/tests/factory_reader.rs
@@ -4,7 +4,9 @@
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(feature = "markdown", feature = "html"))]
     use docspec::{AnyReader, InputFormat};
+    #[cfg(any(feature = "markdown", feature = "html"))]
     use docspec_core::EventSource;
 
     #[cfg(feature = "markdown")]
@@ -74,5 +76,12 @@ mod tests {
     fn assert_is_event_source() {
         fn check<S: EventSource>(_: S) {}
         check(AnyReader::new(InputFormat::Markdown, ""));
+    }
+
+    #[cfg(feature = "html")]
+    #[test]
+    fn html_assert_is_event_source() {
+        fn check<S: EventSource>(_: S) {}
+        check(AnyReader::new(InputFormat::Html, ""));
     }
 }

--- a/crates/docspec/tests/factory_writer.rs
+++ b/crates/docspec/tests/factory_writer.rs
@@ -4,12 +4,24 @@
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "blocknote", feature = "oxa"))]
+    #[cfg(any(
+        feature = "blocknote-writer",
+        feature = "oxa-writer",
+        feature = "html-writer"
+    ))]
     use docspec::{AnyWriter, OutputFormat, TextStyle};
-    #[cfg(any(feature = "blocknote", feature = "oxa"))]
+    #[cfg(any(
+        feature = "blocknote-writer",
+        feature = "oxa-writer",
+        feature = "html-writer"
+    ))]
     use docspec_core::{Event, EventSink};
 
-    #[cfg(any(feature = "blocknote", feature = "oxa"))]
+    #[cfg(any(
+        feature = "blocknote-writer",
+        feature = "oxa-writer",
+        feature = "html-writer"
+    ))]
     fn start_document() -> Event {
         Event::StartDocument {
             id: None,
@@ -18,7 +30,11 @@ mod tests {
         }
     }
 
-    #[cfg(any(feature = "blocknote", feature = "oxa"))]
+    #[cfg(any(
+        feature = "blocknote-writer",
+        feature = "oxa-writer",
+        feature = "html-writer"
+    ))]
     fn start_paragraph() -> Event {
         Event::StartParagraph {
             alignment: None,
@@ -26,7 +42,11 @@ mod tests {
         }
     }
 
-    #[cfg(any(feature = "blocknote", feature = "oxa"))]
+    #[cfg(any(
+        feature = "blocknote-writer",
+        feature = "oxa-writer",
+        feature = "html-writer"
+    ))]
     fn text(content: &str) -> Event {
         Event::Text {
             content: content.to_string(),
@@ -34,7 +54,7 @@ mod tests {
         }
     }
 
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     #[test]
     fn blocknote_dispatch_writes_expected_bytes_simple() {
         let mut output = Vec::new();
@@ -62,7 +82,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     #[test]
     fn stack_tracking_is_active() {
         let mut output = Vec::new();
@@ -84,7 +104,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     #[test]
     fn assert_is_event_sink() {
         fn check<K: EventSink>(_: K) {}
@@ -92,7 +112,7 @@ mod tests {
         check(AnyWriter::new(OutputFormat::Blocknote, output));
     }
 
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "oxa-writer")]
     #[test]
     fn oxa_dispatch_writes_expected_bytes_simple() {
         let mut output = Vec::new();
@@ -120,7 +140,7 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "oxa-writer")]
     #[test]
     fn oxa_stack_tracking_is_active() {
         let mut output = Vec::new();
@@ -142,11 +162,91 @@ mod tests {
         );
     }
 
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "oxa-writer")]
     #[test]
     fn oxa_assert_is_event_sink() {
         fn check<K: EventSink>(_: K) {}
         let output = Vec::new();
         check(AnyWriter::new(OutputFormat::Oxa, output));
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn html_dispatch_writes_expected_bytes_simple() {
+        let mut output = Vec::new();
+        let mut writer = AnyWriter::new(OutputFormat::Html, &mut output);
+        writer
+            .handle_event(start_document())
+            .expect("handle_event failed");
+        writer
+            .handle_event(start_paragraph())
+            .expect("handle_event failed");
+        writer
+            .handle_event(text("hello"))
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndParagraph)
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndDocument)
+            .expect("handle_event failed");
+        writer.finish().expect("finish failed");
+        let html = String::from_utf8(output).expect("not utf8");
+        assert_eq!(html, "<html><body><p>hello</p></body></html>");
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn html_stack_tracking_normalizes_bare_text() {
+        let mut output = Vec::new();
+        let mut writer = AnyWriter::new(OutputFormat::Html, &mut output);
+        writer
+            .handle_event(start_document())
+            .expect("handle_event failed");
+        writer
+            .handle_event(text("bare text"))
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndDocument)
+            .expect("handle_event failed");
+        writer.finish().expect("finish failed");
+        let html = String::from_utf8(output).expect("not utf8");
+        assert_eq!(html, "<html><body><p>bare text</p></body></html>");
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn html_escapes_special_characters() {
+        let mut output = Vec::new();
+        let mut writer = AnyWriter::new(OutputFormat::Html, &mut output);
+        writer
+            .handle_event(start_document())
+            .expect("handle_event failed");
+        writer
+            .handle_event(start_paragraph())
+            .expect("handle_event failed");
+        writer
+            .handle_event(text("a & b < c > d"))
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndParagraph)
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndDocument)
+            .expect("handle_event failed");
+        writer.finish().expect("finish failed");
+        let html = String::from_utf8(output).expect("not utf8");
+        assert_eq!(
+            html,
+            "<html><body><p>a &amp; b &lt; c &gt; d</p></body></html>"
+        );
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn html_dispatch_is_event_sink() {
+        fn check<K: EventSink>(_: K) {}
+        let output = Vec::new();
+        check(AnyWriter::new(OutputFormat::Html, output));
     }
 }

--- a/crates/docspec/tests/format.rs
+++ b/crates/docspec/tests/format.rs
@@ -48,25 +48,46 @@ mod tests {
         assert_eq!(result, Some(docspec::InputFormat::Markdown));
     }
 
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     #[test]
     fn detect_blocknote_from_json() {
         let result = docspec::detect_output_format(Path::new("file.json"));
         assert_eq!(result, Some(docspec::OutputFormat::Blocknote));
     }
 
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     #[test]
     fn case_insensitive_json() {
         let result = docspec::detect_output_format(Path::new("file.JSON"));
         assert_eq!(result, Some(docspec::OutputFormat::Blocknote));
     }
 
-    #[cfg(all(feature = "oxa", not(feature = "blocknote")))]
+    #[cfg(all(feature = "oxa-writer", not(feature = "blocknote-writer")))]
     #[test]
     fn oxa_is_not_auto_detected_from_json() {
         let result = docspec::detect_output_format(Path::new("file.json"));
         assert_eq!(result, None);
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn detect_html_output_from_html() {
+        let result = docspec::detect_output_format(Path::new("file.html"));
+        assert_eq!(result, Some(docspec::OutputFormat::Html));
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn detect_html_output_from_htm() {
+        let result = docspec::detect_output_format(Path::new("file.htm"));
+        assert_eq!(result, Some(docspec::OutputFormat::Html));
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn case_insensitive_html_output() {
+        let result = docspec::detect_output_format(Path::new("file.HTML"));
+        assert_eq!(result, Some(docspec::OutputFormat::Html));
     }
 
     #[test]
@@ -94,30 +115,58 @@ mod tests {
         assert_eq!(debug_str, "Markdown");
     }
 
-    #[cfg(feature = "blocknote")]
+    #[cfg(feature = "blocknote-writer")]
     #[test]
     fn output_format_debug() {
         let debug_str = format!("{:?}", docspec::OutputFormat::Blocknote);
         assert_eq!(debug_str, "Blocknote");
     }
 
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "oxa-writer")]
     #[test]
     fn output_format_debug_oxa() {
         let debug_str = format!("{:?}", docspec::OutputFormat::Oxa);
         assert_eq!(debug_str, "Oxa");
     }
 
-    #[cfg(feature = "oxa")]
+    #[cfg(feature = "oxa-writer")]
     #[test]
     fn output_format_eq_oxa() {
         assert_eq!(docspec::OutputFormat::Oxa, docspec::OutputFormat::Oxa);
     }
 
-    #[cfg(all(feature = "blocknote", feature = "oxa"))]
+    #[cfg(all(feature = "blocknote-writer", feature = "oxa-writer"))]
     #[test]
     fn output_format_ne_oxa_blocknote() {
         assert_ne!(docspec::OutputFormat::Oxa, docspec::OutputFormat::Blocknote);
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn output_format_debug_html() {
+        let debug_str = format!("{:?}", docspec::OutputFormat::Html);
+        assert_eq!(debug_str, "Html");
+    }
+
+    #[cfg(feature = "html-writer")]
+    #[test]
+    fn output_format_eq_html() {
+        assert_eq!(docspec::OutputFormat::Html, docspec::OutputFormat::Html);
+    }
+
+    #[cfg(all(feature = "blocknote-writer", feature = "html-writer"))]
+    #[test]
+    fn output_format_ne_html_blocknote() {
+        assert_ne!(
+            docspec::OutputFormat::Html,
+            docspec::OutputFormat::Blocknote
+        );
+    }
+
+    #[cfg(all(feature = "oxa-writer", feature = "html-writer"))]
+    #[test]
+    fn output_format_ne_html_oxa() {
+        assert_ne!(docspec::OutputFormat::Html, docspec::OutputFormat::Oxa);
     }
 
     #[cfg(feature = "markdown")]


### PR DESCRIPTION
Splits the previous `html` reader feature into explicit `html-reader` and `html-writer`; `html` is retained as a meta enabling both.