### PR TITLE
feat(docspec): hookup docx reader behind docx feature flag

### DIFF
--- a/.github/workflows/publish-crate-manual.yml
+++ b/.github/workflows/publish-crate-manual.yml
@@ -15,6 +15,8 @@ on:
           - docspec-html-reader
           - docspec-docx-reader
           - docspec-blocknote-writer
+          - docspec-html-writer
+          - docspec-oxa-writer
           - docspec-cli
           - docspec-http
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ version = "1.3.0"
 dependencies = [
  "docspec-blocknote-writer",
  "docspec-core",
+ "docspec-docx-reader",
  "docspec-html-reader",
  "docspec-html-writer",
  "docspec-json",

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -16,6 +16,7 @@ default = ["markdown", "blocknote"]
 # Format readers (event sources).
 markdown = ["dep:docspec-markdown-reader"]
 html = ["dep:docspec-html-reader"]
+docx = ["dep:docspec-docx-reader"]
 
 # Format writers (event sinks).
 blocknote-writer = ["dep:docspec-blocknote-writer"]
@@ -30,7 +31,7 @@ json = ["dep:docspec-json"]
 # the meta will expand to enable both directions.
 blocknote = ["blocknote-writer"]
 oxa = ["oxa-writer"]
-all-readers = ["markdown", "html"]
+all-readers = ["markdown", "html", "docx"]
 all-writers = ["blocknote-writer", "oxa-writer", "html-writer"]
 all-libs = ["json"]
 full = ["all-readers", "all-writers", "all-libs"]
@@ -41,6 +42,7 @@ docspec-json = { path = "../docspec-json", version = "1.0.2", optional = true }
 docspec-markdown-reader = { path = "../docspec-markdown-reader", version = "1.0.2", optional = true }
 docspec-blocknote-writer = { path = "../docspec-blocknote-writer", version = "1.0.2", optional = true }
 docspec-html-reader = { path = "../docspec-html-reader", version = "1.0.1", optional = true }
+docspec-docx-reader = { path = "../docspec-docx-reader", version = "1.0.0", optional = true }
 docspec-oxa-writer = { path = "../docspec-oxa-writer", version = "1.0.0", optional = true }
 docspec-html-writer = { path = "../docspec-html-writer", version = "1.0.1", optional = true }
 

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -38,6 +38,11 @@ writer.finish()?;
 | ---------- | ------------------------------------------------ | ------------------------- |
 | `markdown` | Markdown (CommonMark + GFM tables/strikethrough) | `docspec-markdown-reader` |
 | `html`     | HTML (paragraphs only)                           | `docspec-html-reader`     |
+| `docx`     | DOCX (paragraphs and text only)                  | `docspec-docx-reader`     |
+
+`DocxReader` takes a file path or `Read + Seek` source (not `&str`), so it cannot be
+dispatched through the text-based `AnyReader` factory. Construct it directly with
+`DocxReader::from_path` or `DocxReader::from_reader`.
 
 ### Writers
 

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -16,6 +16,11 @@
 //! |----------------|-----------------------------------------------------|-----------------------------|
 //! | `markdown`     | Markdown (`CommonMark` + GFM tables/strikethrough)  | [`readers::MarkdownReader`] |
 //! | `html`         | HTML (paragraphs only)                              | `readers::HtmlReader`       |
+//! | `docx`         | DOCX (paragraphs and text only)                     | `readers::DocxReader`       |
+//!
+//! Note: [`readers::DocxReader`] takes a binary file or any `Read + Seek` source rather
+//! than a `&str`, so it is not dispatched through the text-based [`AnyReader`] factory.
+//! Construct it directly with `DocxReader::from_path` or `DocxReader::from_reader`.
 //!
 //! ## Writers
 //!
@@ -107,6 +112,15 @@ pub mod readers {
     #[cfg(feature = "html")]
     #[cfg_attr(docsrs, doc(cfg(feature = "html")))]
     pub use docspec_html_reader::HtmlReader;
+
+    /// Streaming DOCX reader. Available when the `docx` feature is enabled.
+    /// Takes a file path or `Read + Seek` source (not `&str`), so it is not
+    /// dispatched through the text-based [`crate::AnyReader`] factory. Emits
+    /// only paragraphs and text; styles, tables, lists, images, headers/footers,
+    /// metadata, and tracked changes are silently dropped.
+    #[cfg(feature = "docx")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "docx")))]
+    pub use docspec_docx_reader::DocxReader;
 }
 
 /// Document writers (event sinks).

--- a/crates/docspec/tests/readers_docx.rs
+++ b/crates/docspec/tests/readers_docx.rs
@@ -1,0 +1,36 @@
+//! Integration tests for the DOCX reader re-exported through the docspec facade.
+
+#![cfg(feature = "docx")]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Cursor, ErrorKind};
+
+    use docspec::readers::DocxReader;
+    use docspec::{Error, EventSource};
+
+    #[test]
+    fn docx_reader_implements_event_source() {
+        fn assert_event_source<S: EventSource>() {}
+        assert_event_source::<DocxReader>();
+    }
+
+    #[test]
+    fn docx_reader_from_path_propagates_not_found_io_error() {
+        let result = DocxReader::from_path("/nonexistent/path/does/not/exist.docx");
+        let err = result.expect_err("missing file must produce an error");
+        assert!(
+            matches!(&err, Error::Io { source } if source.kind() == ErrorKind::NotFound),
+            "expected Error::Io with ErrorKind::NotFound, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn docx_reader_from_reader_rejects_non_zip_bytes() {
+        let bogus = Cursor::new(b"not a zip archive at all".to_vec());
+        let result = DocxReader::from_reader(bogus);
+        let err = result.expect_err("non-zip input must produce an error");
+        assert_eq!(err.to_string(), "parse error: not a valid ZIP archive");
+    }
+}


### PR DESCRIPTION
Re-exports `docspec-docx-reader` through the `docspec` facade as an optional dependency gated by the new `docx` feature.

`DocxReader` takes a file path or `Read + Seek` source (not `&str`), so it is exposed as a direct re-export only; it is not wired into the text-based `AnyReader` factory.

Manual release prep: `docspec` 1.2.0 \u2192 1.3.0, `docspec-docx-reader` first release at 1.0.0. Adds the missing `docspec-docx-reader` entry to `.release-please-manifest.json` for parity with the existing config.

Refs #21, #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DOCX reader support to the docspec library for reading and processing DOCX documents.

* **Documentation**
  * Updated library documentation and README with comprehensive DOCX reader feature guidelines and usage requirements.

* **Tests**
  * Introduced integration tests for DOCX reader error handling and functionality.

* **Chores**
  * Extended CI/CD workflow capabilities for manual crate publishing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->