### PR TITLE
feat(http): hookup html reader

### DIFF
--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -47,7 +47,7 @@ sentry = { version = "0.48", default-features = false, features = [
 ] }
 docspec-core = { path = "../docspec-core", version = "1.0.0" }
 docspec-json = { path = "../docspec-json", version = "1.0.0" }
-docspec = { path = "../docspec", version = "1.2.0", features = ["markdown", "blocknote", "oxa"] }
+docspec = { path = "../docspec", version = "1.2.0", features = ["markdown", "html", "blocknote", "oxa"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -1,8 +1,10 @@
 # `docspec-http`
 
-HTTP API server for DocSpec markdown to BlockNote JSON conversion (oxa.dev JSON opt-in via `Accept`).
+HTTP API server for DocSpec markdown or HTML to BlockNote JSON conversion (oxa.dev JSON opt-in via `Accept`).
 
-Send markdown, receive BlockNote JSON (default) or oxa.dev JSON (`Accept: application/vnd.oxa+json`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
+Send markdown (`Content-Type: text/markdown`) or HTML (`Content-Type: text/html`), receive BlockNote JSON (default) or oxa.dev JSON (`Accept: application/vnd.oxa+json`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
+
+> **HTML input is paragraph-only.** The HTML reader currently parses `<p>` elements only; other elements (headings, lists, tables, etc.) are silently dropped. See [docspec-html-reader](../docspec-html-reader/README.md).
 
 ## Quick Start
 
@@ -19,13 +21,13 @@ Default host is `127.0.0.1`. Default port is `3000`.
 
 ## Endpoints
 
-| Method  | Path        | Description                                              |
-| ------- | ----------- | -------------------------------------------------------- |
-| POST    | /conversion | Convert markdown to BlockNote (default) or oxa.dev JSON  |
-| OPTIONS | /conversion | Preflight / allowed methods                              |
-| GET     | /health     | Liveness check                                           |
-| HEAD    | /health     | Liveness check (no body)                                 |
-| OPTIONS | /health     | Allowed methods                                          |
+| Method  | Path        | Description                                                      |
+| ------- | ----------- | ---------------------------------------------------------------- |
+| POST    | /conversion | Convert markdown or HTML to BlockNote (default) or oxa.dev JSON  |
+| OPTIONS | /conversion | Preflight / allowed methods                                      |
+| GET     | /health     | Liveness check                                                   |
+| HEAD    | /health     | Liveness check (no body)                                         |
+| OPTIONS | /health     | Allowed methods                                                  |
 
 ## curl Examples
 
@@ -36,11 +38,24 @@ curl -X POST \
      --data '# Hello World' \
      http://localhost:3000/conversion
 
+# Convert HTML to BlockNote JSON
+curl -X POST \
+     -H 'Content-Type: text/html' \
+     --data '<p>Hello World</p>' \
+     http://localhost:3000/conversion
+
 # Convert markdown to oxa.dev JSON (opt-in via Accept)
 curl -X POST \
      -H 'Content-Type: text/markdown' \
      -H 'Accept: application/vnd.oxa+json' \
      --data 'Hello World' \
+     http://localhost:3000/conversion
+
+# Convert HTML to oxa.dev JSON
+curl -X POST \
+     -H 'Content-Type: text/html' \
+     -H 'Accept: application/vnd.oxa+json' \
+     --data '<p>Hello World</p>' \
      http://localhost:3000/conversion
 
 # Check server health
@@ -65,15 +80,15 @@ curl -X OPTIONS -i http://localhost:3000/conversion
 
 All errors use RFC 7807 Problem Details JSON (`application/problem+json; charset=utf-8`).
 
-| Code | Meaning                                             |
-| ---- | --------------------------------------------------- |
-| 400  | Empty body or invalid UTF-8                         |
-| 404  | Unknown path                                        |
-| 405  | Wrong method (response includes `Allow` header)     |
-| 406  | `Accept` header excludes all supported output types |
-| 415  | `Content-Type` must be `text/markdown`              |
-| 422  | Markdown parse error                                |
-| 500  | Internal conversion error                           |
+| Code | Meaning                                                  |
+| ---- | -------------------------------------------------------- |
+| 400  | Empty body or invalid UTF-8                              |
+| 404  | Unknown path                                             |
+| 405  | Wrong method (response includes `Allow` header)          |
+| 406  | `Accept` header excludes all supported output types      |
+| 415  | `Content-Type` must be `text/markdown` or `text/html`    |
+| 422  | Input parse error (malformed markdown or HTML)           |
+| 500  | Internal conversion error                                |
 
 Accepted `Accept` values for `/conversion`: `application/vnd.oxa+json` (oxa.dev), `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json` (BlockNote alias), `application/*`, or `*/*`. Wildcards and missing `Accept` default to BlockNote for back-compat. Anything else returns 406.
 
@@ -135,8 +150,8 @@ These follow Sentry's standard conventions:
 
 `docspec-http` does NOT send the following to Sentry:
 
-- Request bodies (markdown documents)
-- Response bodies (BlockNote JSON)
+- Request bodies (markdown or HTML documents)
+- Response bodies (BlockNote or oxa.dev JSON)
 - PII (Sentry default: `send_default_pii = false`)
 - DSN values (never logged or echoed)
 
@@ -147,7 +162,7 @@ Each captured event is tagged with `request_id` (UUID v4) and `trace_id`
 
 ## Wire Contract
 
-Mirrors `github.com/docspecio/api` v3.0.2 where feasible: same endpoint path, RFC 7807 errors, `X-Request-ID`/`X-Trace-ID` header handling. Diverges in input MIME (`text/markdown` vs DOCX) and adds `Cache-Control` on all responses.
+Mirrors `github.com/docspecio/api` v3.0.2 where feasible: same endpoint path, RFC 7807 errors, `X-Request-ID`/`X-Trace-ID` header handling. Diverges in supported conversions.
 
 ## Graceful Shutdown
 
@@ -242,7 +257,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 **`error_class`**: `body_not_utf8`, `empty_body`, `internal`, `method_not_allowed`, `not_acceptable`, `not_found`, `unprocessable`, `unsupported_media_type`, `none` (only when `result=success`)
 
-**`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
+**`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `text/html` (the request's Content-Type matched the HTML reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
 
 **`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `application/vnd.oxa+json` (conversion succeeded; output produced by the oxa.dev writer), `none` (no output produced — any error path).
 
@@ -254,7 +269,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 ### Cardinality Guarantees
 
-`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 3 values. `output_mime_type` is bounded to 3 values. Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
+`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 4 values (`text/markdown`, `text/html`, `unsupported`, `none`). `output_mime_type` is bounded to 3 values. Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
 
 ### Scrape Model
 

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -124,7 +124,7 @@ pub enum HttpError {
         /// Explanation of what made the input invalid.
         detail: String,
     },
-    /// The `Content-Type` header is not `text/markdown`.
+    /// The `Content-Type` header is neither `text/markdown` nor `text/html`.
     ///
     /// → HTTP 415 Unsupported Media Type.
     UnsupportedMediaType {
@@ -184,7 +184,7 @@ impl IntoResponse for HttpError {
             Self::UnsupportedMediaType { received: None } => (
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
                 "Unsupported Media Type",
-                Cow::Borrowed("Content-Type must be text/markdown"),
+                Cow::Borrowed("Content-Type must be text/markdown or text/html"),
                 None,
             ),
             Self::UnsupportedMediaType {
@@ -193,7 +193,7 @@ impl IntoResponse for HttpError {
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
                 "Unsupported Media Type",
                 Cow::Owned(format!(
-                    "Content-Type must be text/markdown, got {content_type}"
+                    "Content-Type must be text/markdown or text/html, got {content_type}"
                 )),
                 None,
             ),
@@ -478,7 +478,7 @@ mod tests {
                 "type": "about:blank",
                 "title": "Unsupported Media Type",
                 "status": 415,
-                "detail": "Content-Type must be text/markdown, got application/json",
+                "detail": "Content-Type must be text/markdown or text/html, got application/json",
             })
         );
     }

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -21,9 +21,11 @@ pub async fn options_conversion() -> impl IntoResponse {
     )
 }
 
-/// Handle `POST /conversion` — convert markdown to `BlockNote` or `oxa.dev` JSON.
+/// Handle `POST /conversion` — convert markdown or HTML to `BlockNote` or `oxa.dev` JSON.
 ///
-/// The output writer is selected by the request's `Accept` header (see
+/// The input reader is selected by the request's `Content-Type` header (see
+/// [`crate::mime_parser::validate_content_type`]). The output writer is
+/// selected by the request's `Accept` header (see
 /// [`crate::mime_parser::negotiate_accept`]).
 ///
 /// The request body is buffered, then converted to completion inside
@@ -147,7 +149,7 @@ async fn do_conversion(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<(Response<Body>, u64, OutputFormat), HttpError> {
-    mime_parser::validate_content_type(headers.get(header::CONTENT_TYPE))?;
+    let input_format = mime_parser::validate_content_type(headers.get(header::CONTENT_TYPE))?;
     let output_format = mime_parser::negotiate_accept(headers.get(header::ACCEPT))?;
 
     if body.is_empty() {
@@ -167,14 +169,14 @@ async fn do_conversion(
     )
     .record(body_len_bytes);
 
-    let markdown = String::from_utf8(body.into()).map_err(|error| {
+    let input_text = String::from_utf8(body.into()).map_err(|error| {
         tracing::debug!(error = %error, "request body is not valid UTF-8");
         HttpError::BodyNotUtf8
     })?;
 
     let join_result = tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64), HttpError> {
         let mut output_buffer = Vec::new();
-        let mut reader = docspec::AnyReader::new(docspec::InputFormat::Markdown, &markdown);
+        let mut reader = docspec::AnyReader::new(input_format, &input_text);
         let mut sink = docspec::AnyWriter::new(output_format, &mut output_buffer);
 
         loop {
@@ -187,7 +189,7 @@ async fn do_conversion(
                 })?,
                 Ok(None) => break,
                 Err(error) => {
-                    tracing::debug!(error = %error, "markdown reader failed");
+                    tracing::debug!(error = %error, "reader failed");
                     return Err(HttpError::Unprocessable {
                         detail: error.to_string(),
                     });

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -78,8 +78,11 @@ pub const RESULT_SERVER_ERROR: &str = "server_error";
 /// Value for [`LABEL_ERROR_CLASS`] when no error occurred.
 pub const ERROR_CLASS_NONE: &str = "none";
 
-/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was text/markdown (current sole supported reader).
+/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was text/markdown.
 pub const INPUT_MIME_MARKDOWN: &str = "text/markdown";
+
+/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was text/html.
+pub const INPUT_MIME_HTML: &str = "text/html";
 
 /// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was present but not a supported reader format.
 pub const INPUT_MIME_UNSUPPORTED: &str = "unsupported";

--- a/crates/docspec-http/src/mime_parser.rs
+++ b/crates/docspec-http/src/mime_parser.rs
@@ -1,7 +1,7 @@
 //! HTTP `Accept` negotiation and `Content-Type` validation for the conversion API.
 
 use axum::http::HeaderValue;
-use docspec::OutputFormat;
+use docspec::{InputFormat, OutputFormat};
 
 use crate::error::HttpError;
 use crate::format::{OUTPUT_MIME_ALIAS, OUTPUT_MIME_OXA_PRIMARY, OUTPUT_MIME_PRIMARY};
@@ -43,19 +43,22 @@ pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<OutputForm
     Err(HttpError::NotAcceptable)
 }
 
-/// Validates the `Content-Type` header for the `/conversion` endpoint.
+/// Validates the `Content-Type` header for the `/conversion` endpoint and
+/// resolves it to the matching reader format.
 ///
-/// Accepts `text/markdown` with no charset, or `text/markdown; charset=utf-8`
+/// Accepts `text/markdown` ([`InputFormat::Markdown`]) and `text/html`
+/// ([`InputFormat::Html`]), each with no charset, or with `charset=utf-8`
 /// (case-insensitive). Any other charset is rejected — the handler always
 /// decodes the body as UTF-8, so a non-UTF-8 charset is unsupportable.
-/// Returns `Err` if the header is missing, malformed, the MIME type is not
-/// `text/markdown`, or the charset is anything other than `utf-8`.
+/// Returns `Err` if the header is missing, malformed, the MIME type is
+/// neither `text/markdown` nor `text/html`, the charset is anything other
+/// than `utf-8`, or an unknown parameter is present.
 ///
 /// # Errors
 ///
 /// Returns [`HttpError::UnsupportedMediaType`] with the received value (or `None` if missing).
 #[inline]
-pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<(), HttpError> {
+pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<InputFormat, HttpError> {
     let Some(header_val) = header_value else {
         return Err(HttpError::UnsupportedMediaType { received: None });
     };
@@ -72,11 +75,15 @@ pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<(), H
             .ok_or_else(|| HttpError::UnsupportedMediaType {
                 received: Some(header_str.to_owned()),
             })?;
-    if parsed.type_() != mime::TEXT || parsed.subtype().as_str() != "markdown" {
-        return Err(HttpError::UnsupportedMediaType {
-            received: Some(header_str.to_owned()),
-        });
-    }
+    let format = match (parsed.type_(), parsed.subtype().as_str()) {
+        (mime::TEXT, "markdown") => InputFormat::Markdown,
+        (mime::TEXT, "html") => InputFormat::Html,
+        _ => {
+            return Err(HttpError::UnsupportedMediaType {
+                received: Some(header_str.to_owned()),
+            });
+        }
+    };
     if let Some(charset) = parsed.get_param(mime::CHARSET) {
         if !charset.as_str().eq_ignore_ascii_case("utf-8") {
             return Err(HttpError::UnsupportedMediaType {
@@ -94,20 +101,21 @@ pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<(), H
             });
         }
     }
-    Ok(())
+    Ok(format)
 }
 
 /// Returns the bounded `input_mime_type` label value for a `Content-Type` header.
 ///
 /// This function is intentionally MORE permissive than [`validate_content_type`]:
-/// it returns [`crate::metrics::INPUT_MIME_MARKDOWN`] for any `text/markdown`
-/// value regardless of charset or other parameters, because the label answers
+/// it returns the matching label for any `text/markdown` or `text/html` value
+/// regardless of charset or other parameters, because the label answers
 /// "what did the client try to send?" rather than "is it valid?".
 ///
 /// # Label values
 ///
 /// - [`crate::metrics::INPUT_MIME_NONE`] — header absent
 /// - [`crate::metrics::INPUT_MIME_MARKDOWN`] — `text/markdown` (any params)
+/// - [`crate::metrics::INPUT_MIME_HTML`] — `text/html` (any params)
 /// - [`crate::metrics::INPUT_MIME_UNSUPPORTED`] — anything else
 #[must_use]
 #[inline]
@@ -121,10 +129,10 @@ pub fn bucket_input_mime(header_value: Option<&HeaderValue>) -> &'static str {
     let Ok(parsed) = header_str.parse::<mime::Mime>() else {
         return crate::metrics::INPUT_MIME_UNSUPPORTED;
     };
-    if parsed.type_() == mime::TEXT && parsed.subtype().as_str() == "markdown" {
-        crate::metrics::INPUT_MIME_MARKDOWN
-    } else {
-        crate::metrics::INPUT_MIME_UNSUPPORTED
+    match (parsed.type_(), parsed.subtype().as_str()) {
+        (mime::TEXT, "markdown") => crate::metrics::INPUT_MIME_MARKDOWN,
+        (mime::TEXT, "html") => crate::metrics::INPUT_MIME_HTML,
+        _ => crate::metrics::INPUT_MIME_UNSUPPORTED,
     }
 }
 
@@ -183,6 +191,42 @@ mod bucket_tests {
         assert_eq!(
             bucket_input_mime(Some(&val)),
             crate::metrics::INPUT_MIME_MARKDOWN
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_html_when_text_html() {
+        let val = HeaderValue::from_static("text/html");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_HTML
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_html_when_text_html_with_charset() {
+        let val = HeaderValue::from_static("text/html; charset=utf-8");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_HTML
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_html_case_insensitive() {
+        let val = HeaderValue::from_static("TEXT/HTML");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_HTML
+        );
+    }
+
+    #[test]
+    fn bucket_input_mime_html_with_non_utf8_charset_still_buckets_html() {
+        let val = HeaderValue::from_static("text/html; charset=iso-8859-1");
+        assert_eq!(
+            bucket_input_mime(Some(&val)),
+            crate::metrics::INPUT_MIME_HTML
         );
     }
 

--- a/crates/docspec-http/tests/http_integration.rs
+++ b/crates/docspec-http/tests/http_integration.rs
@@ -31,6 +31,15 @@ fn post_markdown(body: impl Into<Body>) -> axum::http::Request<Body> {
     common::markdown_request(body)
 }
 
+fn post_html(body: impl Into<Body>) -> axum::http::Request<Body> {
+    common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", "text/html")],
+        body,
+    )
+}
+
 async fn response_body_text(body: axum::body::Body) -> String {
     let bytes = axum::body::to_bytes(body, usize::MAX)
         .await
@@ -197,7 +206,7 @@ async fn post_conversion_missing_content_type() {
             "type": "about:blank",
             "title": "Unsupported Media Type",
             "status": 415,
-            "detail": "Content-Type must be text/markdown",
+            "detail": "Content-Type must be text/markdown or text/html",
         })
     );
 }
@@ -222,7 +231,7 @@ async fn post_conversion_wrong_content_type() {
             "type": "about:blank",
             "title": "Unsupported Media Type",
             "status": 415,
-            "detail": "Content-Type must be text/markdown, got application/json",
+            "detail": "Content-Type must be text/markdown or text/html, got application/json",
         })
     );
 }
@@ -247,7 +256,7 @@ async fn post_conversion_multipart_content_type() {
             "type": "about:blank",
             "title": "Unsupported Media Type",
             "status": 415,
-            "detail": "Content-Type must be text/markdown, got multipart/form-data; boundary=x",
+            "detail": "Content-Type must be text/markdown or text/html, got multipart/form-data; boundary=x",
         })
     );
 }
@@ -630,6 +639,110 @@ async fn post_conversion_wildcard_accept_defaults_to_blocknote_not_oxa() {
 
     let body = response_body_json(response.into_body()).await;
     assert_eq!(body, hello_blocknote_json());
+}
+
+#[tokio::test]
+async fn post_conversion_html_happy_path() {
+    let response = app()
+        .oneshot(post_html("<p>Hello</p>"))
+        .await
+        .expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME
+    );
+
+    let body = response_body_json(response.into_body()).await;
+    assert_eq!(
+        body,
+        serde_json::json!([{
+            "type": "paragraph",
+            "props": { "textAlignment": "left" },
+            "content": [{ "type": "text", "text": "Hello", "styles": {} }],
+            "children": [],
+        }])
+    );
+}
+
+#[tokio::test]
+async fn post_conversion_html_with_utf8_charset_happy_path() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", "text/html; charset=utf-8")],
+        Body::from("<p>Hello</p>"),
+    );
+
+    let response = app().oneshot(request).await.expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_body_json(response.into_body()).await;
+    assert_eq!(
+        body,
+        serde_json::json!([{
+            "type": "paragraph",
+            "props": { "textAlignment": "left" },
+            "content": [{ "type": "text", "text": "Hello", "styles": {} }],
+            "children": [],
+        }])
+    );
+}
+
+#[tokio::test]
+async fn post_conversion_html_to_oxa_happy_path() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[
+            ("content-type", "text/html"),
+            ("accept", "application/vnd.oxa+json"),
+        ],
+        Body::from("<p>Hello</p>"),
+    );
+
+    let response = app().oneshot(request).await.expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME_OXA
+    );
+
+    let body_text = response_body_text(response.into_body()).await;
+    assert_eq!(
+        body_text,
+        r#"{"type":"Document","children":[{"type":"Paragraph","children":[{"type":"Text","value":"Hello"}]}]}"#
+    );
+}
+
+#[tokio::test]
+async fn post_conversion_html_empty_body() {
+    let response = app()
+        .oneshot(post_html(""))
+        .await
+        .expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response_body_json(response.into_body()).await;
+    assert_eq!(
+        body,
+        serde_json::json!({
+            "type": "about:blank",
+            "title": "Bad Request",
+            "status": 400,
+            "detail": "Request body is empty",
+        })
+    );
 }
 
 #[tokio::test]

--- a/crates/docspec-http/tests/http_smoke.rs
+++ b/crates/docspec-http/tests/http_smoke.rs
@@ -191,6 +191,38 @@ fn smoke_post_conversion() {
 }
 
 #[test]
+fn smoke_post_conversion_html() {
+    let (_guard, port) = start_server();
+    let url = format!("http://127.0.0.1:{port}/conversion");
+    let client = smoke_client();
+    let resp = client
+        .post(&url)
+        .header("Content-Type", "text/html")
+        .body("<p>Hello</p>")
+        .send()
+        .expect("HTTP request");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert_eq!(
+        resp.headers()
+            .get("content-type")
+            .unwrap()
+            .to_str()
+            .unwrap(),
+        "application/vnd.docspec.blocknote+json; charset=utf-8"
+    );
+    let body: serde_json::Value = resp.json().expect("JSON body");
+    assert_eq!(
+        body,
+        serde_json::json!([{
+            "type": "paragraph",
+            "props": { "textAlignment": "left" },
+            "content": [{ "type": "text", "text": "Hello", "styles": {} }],
+            "children": [],
+        }])
+    );
+}
+
+#[test]
 fn smoke_get_health() {
     let (_guard, port) = start_server();
     let url = format!("http://127.0.0.1:{port}/health");

--- a/crates/docspec-http/tests/mime_parser.rs
+++ b/crates/docspec-http/tests/mime_parser.rs
@@ -3,30 +3,41 @@
 #![allow(clippy::tests_outside_test_module, clippy::unwrap_used)]
 
 use axum::http::HeaderValue;
-use docspec::OutputFormat;
+use docspec::{InputFormat, OutputFormat};
 use docspec_http::error::HttpError;
 use docspec_http::mime_parser::{negotiate_accept, validate_content_type};
 
+// ─── validate_content_type: markdown ────────────────────────────────────────
+
 #[test]
-fn content_type_text_markdown_accepts() {
+fn content_type_text_markdown_returns_markdown_format() {
     let header = HeaderValue::from_static("text/markdown");
-    assert!(validate_content_type(Some(&header)).is_ok());
+    assert_eq!(
+        validate_content_type(Some(&header)).unwrap(),
+        InputFormat::Markdown
+    );
 }
 
 #[test]
-fn content_type_with_utf8_charset_accepts() {
+fn content_type_text_markdown_with_utf8_charset_returns_markdown() {
     let header = HeaderValue::from_static("text/markdown; charset=utf-8");
-    assert!(validate_content_type(Some(&header)).is_ok());
+    assert_eq!(
+        validate_content_type(Some(&header)).unwrap(),
+        InputFormat::Markdown
+    );
 }
 
 #[test]
-fn content_type_with_utf8_charset_case_insensitive() {
+fn content_type_text_markdown_charset_is_case_insensitive() {
     let header = HeaderValue::from_static("text/markdown; charset=UTF-8");
-    assert!(validate_content_type(Some(&header)).is_ok());
+    assert_eq!(
+        validate_content_type(Some(&header)).unwrap(),
+        InputFormat::Markdown
+    );
 }
 
 #[test]
-fn content_type_with_non_utf8_charset_rejects() {
+fn content_type_text_markdown_with_non_utf8_charset_rejects() {
     let header = HeaderValue::from_static("text/markdown; charset=iso-8859-1");
     assert!(matches!(
         validate_content_type(Some(&header)),
@@ -35,7 +46,7 @@ fn content_type_with_non_utf8_charset_rejects() {
 }
 
 #[test]
-fn content_type_with_unknown_param_rejects() {
+fn content_type_text_markdown_with_unknown_param_rejects() {
     let header = HeaderValue::from_static("text/markdown; boundary=xyz");
     assert!(matches!(
         validate_content_type(Some(&header)),
@@ -44,13 +55,62 @@ fn content_type_with_unknown_param_rejects() {
 }
 
 #[test]
-fn content_type_with_charset_and_unknown_param_rejects() {
+fn content_type_text_markdown_with_charset_and_unknown_param_rejects() {
     let header = HeaderValue::from_static("text/markdown; charset=utf-8; format=fixed");
     assert!(matches!(
         validate_content_type(Some(&header)),
         Err(HttpError::UnsupportedMediaType { received: Some(text) }) if text == "text/markdown; charset=utf-8; format=fixed"
     ));
 }
+
+// ─── validate_content_type: html ────────────────────────────────────────────
+
+#[test]
+fn content_type_text_html_returns_html_format() {
+    let header = HeaderValue::from_static("text/html");
+    assert_eq!(
+        validate_content_type(Some(&header)).unwrap(),
+        InputFormat::Html
+    );
+}
+
+#[test]
+fn content_type_text_html_with_utf8_charset_returns_html() {
+    let header = HeaderValue::from_static("text/html; charset=utf-8");
+    assert_eq!(
+        validate_content_type(Some(&header)).unwrap(),
+        InputFormat::Html
+    );
+}
+
+#[test]
+fn content_type_text_html_charset_is_case_insensitive() {
+    let header = HeaderValue::from_static("text/html; charset=UTF-8");
+    assert_eq!(
+        validate_content_type(Some(&header)).unwrap(),
+        InputFormat::Html
+    );
+}
+
+#[test]
+fn content_type_text_html_with_non_utf8_charset_rejects() {
+    let header = HeaderValue::from_static("text/html; charset=iso-8859-1");
+    assert!(matches!(
+        validate_content_type(Some(&header)),
+        Err(HttpError::UnsupportedMediaType { received: Some(text) }) if text == "text/html; charset=iso-8859-1"
+    ));
+}
+
+#[test]
+fn content_type_text_html_with_unknown_param_rejects() {
+    let header = HeaderValue::from_static("text/html; boundary=xyz");
+    assert!(matches!(
+        validate_content_type(Some(&header)),
+        Err(HttpError::UnsupportedMediaType { received: Some(text) }) if text == "text/html; boundary=xyz"
+    ));
+}
+
+// ─── validate_content_type: rejections ──────────────────────────────────────
 
 #[test]
 fn content_type_text_plain_rejects_with_received() {
@@ -72,6 +132,15 @@ fn content_type_application_json_rejects() {
 }
 
 #[test]
+fn content_type_application_xhtml_rejects() {
+    let header = HeaderValue::from_static("application/xhtml+xml");
+    assert!(matches!(
+        validate_content_type(Some(&header)),
+        Err(HttpError::UnsupportedMediaType { received: Some(text) }) if text == "application/xhtml+xml"
+    ));
+}
+
+#[test]
 fn content_type_multipart_rejects() {
     let header = HeaderValue::from_static("multipart/form-data; boundary=xxx");
     assert!(matches!(
@@ -87,6 +156,8 @@ fn content_type_missing_rejects_with_none() {
         Err(HttpError::UnsupportedMediaType { received: None })
     ));
 }
+
+// ─── negotiate_accept ───────────────────────────────────────────────────────
 
 #[test]
 fn accept_missing_returns_blocknote() {


### PR DESCRIPTION
## Summary

Wires the existing `docspec-html-reader` into the HTTP API. `POST /conversion` now accepts `text/html` (in addition to `text/markdown`) and dispatches the reader by `Content-Type`. The output negotiation (`Accept` → BlockNote or oxa.dev JSON) is unchanged.

Investigation before this PR confirmed:
- CLI: HTML reader was already wired end-to-end (no change needed).
- HTTP: hardcoded to `InputFormat::Markdown`; HTML was rejected with 415.

## Changes

| Area | File | Change |
|---|---|---|
| Feature flag | \`Cargo.toml\` | Add \`html\` to \`docspec\` features |
| Dispatch | \`src/mime_parser.rs\` | \`validate_content_type\` now returns \`Result<InputFormat, HttpError>\`; \`bucket_input_mime\` recognizes \`text/html\` |
| Handler | \`src/handlers/conversion.rs\` | Use parsed \`InputFormat\` to build \`AnyReader\` (was hardcoded to Markdown) |
| Errors | \`src/error.rs\` | 415 detail now says \"text/markdown or text/html\" |
| Metrics | \`src/metrics/mod.rs\` | New \`INPUT_MIME_HTML\` label value (\`text/html\`); cardinality bound goes 3 → 4 |
| Docs | \`README.md\` | Endpoint table, curl examples, error table, metric label values, wire contract |

## Tests added

- **Unit (mime_parser bucket_tests)**: 4 new tests covering \`text/html\` bucketing (with/without charset, case-insensitive, non-utf8 charset still buckets to html).
- **Integration (tests/mime_parser.rs)**: 5 new tests for HTML \`validate_content_type\` paths + return-type assertions on all markdown cases.
- **Integration (tests/http_integration.rs)**: 4 new end-to-end tests — HTML → BlockNote, HTML+charset → BlockNote, HTML → oxa.dev, HTML empty body → 400. All with exact-value JSON assertions.
- **Smoke (tests/http_smoke.rs)**: 1 new test exercising the real binary with \`Content-Type: text/html\`.

## Verification

- \`cargo test -p docspec-http\` → **167 passed, 0 failed** across 15 test binaries
- \`cargo clippy --workspace --all-targets\` → **zero warnings**
- \`cargo fmt --check -p docspec-http\` → clean
- Pre-commit + pre-push hooks all green

## Behavior caveat

The \`docspec-html-reader\` crate currently parses only \`<p>\` elements; other HTML elements are silently dropped. This is unchanged by this PR and is documented in the updated README. Extending HTML element coverage is out of scope here.

## Wire-contract note

Per repo guidance, the \`Wire Contract\` section in the README was simplified to \"Diverges in supported conversions\" rather than enumerating MIME types and \`Cache-Control\` specifics.