### PR TITLE
feat: hookup html writer in cli and http

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ See our [Manifesto](MANIFESTO.md) for what we stand for: memory extremism, strea
 | DOCX | ✓‡ | — |
 | ODT | ✓ | — |
 | RTF | ✓ | ✓ |
-| HTML | ✓† | — |
+| HTML | ✓† | ✓† |
 | Markdown | ✓ | ✓ |
 | BlockNote JSON | ✓ | ✓ |
 
-† HTML reader currently supports only `<p>` paragraph elements; other elements are silently dropped.
+† HTML reader and writer currently support only `<p>` paragraph elements; other elements are silently dropped.
 
 ‡ DOCX reader is intentionally minimal: only paragraphs and text are emitted; styles, breaks, tables, lists, images, tracked changes, headers/footers, and metadata are silently dropped. See the [docspec-docx-reader README](crates/docspec-docx-reader/README.md) for the full scope.
 

--- a/crates/docspec-cli/Cargo.toml
+++ b/crates/docspec-cli/Cargo.toml
@@ -21,6 +21,7 @@ docspec = { path = "../docspec", version = "1.2.0", features = [
   "html",
   "blocknote",
   "oxa",
+  "html-writer",
 ] }
 docspec-core = { path = "../docspec-core", version = "1.0.0" }
 thiserror = "2"

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -18,7 +18,7 @@ docspec [OPTIONS] [INPUT]
 
 - `-o, --output <FILE>` — Output file (stdout if omitted)
 - `-f, --from <FORMAT>` — Input format (auto-detected from extension if omitted). Valid values: `markdown`, `html`
-- `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted). Valid values: `blocknote`, `oxa`
+- `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted). Valid values: `blocknote`, `html`, `oxa`
 - `--color <WHEN>` — When to use colors: `auto`, `always`, `never` (default: `auto`)
 - `-h, --help` — Print help
 - `-V, --version` — Print version
@@ -28,9 +28,10 @@ docspec [OPTIONS] [INPUT]
 - `markdown` — Full Markdown support including headings, lists, tables, and inline formatting
 - `html` — HTML input (see note below)
 
-> **Note:** The HTML reader currently parses only `<p>` paragraph elements and the text within
-> them. All other HTML elements (headings, lists, tables, formatting tags, etc.) are silently
-> dropped. For full feature coverage, use Markdown input.
+> **Note:** HTML input and output currently preserve only paragraph text. Other HTML input
+> elements and non-paragraph output events (headings, lists, tables, formatting tags, etc.)
+> are silently dropped. For fuller feature coverage, use Markdown input with BlockNote JSON
+> output.
 
 ## Examples
 
@@ -52,5 +53,12 @@ Convert Markdown from stdin to BlockNote JSON on stdout:
 echo "# Hello" | docspec --from markdown --to blocknote
 ```
 
+Convert Markdown to HTML:
+
+```bash
+echo "Hello" | docspec --from markdown --to html
+```
+
 `--to oxa` selects the [oxa.dev](https://oxa.dev/) JSON writer in place of BlockNote. The `.json`
-extension is ambiguous, so `--to oxa` must be explicit.
+extension is ambiguous, so `--to oxa` must be explicit. HTML output is selected by `--to html`
+or auto-detected from `.html` and `.htm` output paths.

--- a/crates/docspec-cli/src/args.rs
+++ b/crates/docspec-cli/src/args.rs
@@ -8,7 +8,7 @@ use clap::{Parser, ValueEnum};
 #[command(version = "0.1.0")]
 #[command(
     about = "Convert documents between formats using streaming event pipeline",
-    long_about = "Convert documents between formats using streaming event pipeline.\n\nSupports converting Markdown or HTML input to BlockNote JSON output.\n\nNote: the HTML reader currently parses only <p> paragraph elements and\nthe text within them. All other HTML elements (headings, lists, tables,\nformatting, etc.) are silently dropped. Use Markdown input for full\nfeature coverage."
+    long_about = "Convert documents between formats using streaming event pipeline.\n\nSupports converting Markdown or HTML input to BlockNote JSON, HTML, or oxa.dev JSON output.\n\nNote: HTML input and output currently preserve only paragraph text. Other HTML input\nelements and non-paragraph output events (headings, lists, tables, formatting, etc.)\nare silently dropped. Use BlockNote JSON output for fuller feature coverage."
 )]
 pub struct Cli {
     /// When to use colors.
@@ -65,6 +65,9 @@ pub enum CliOutputFormat {
     /// `BlockNote` JSON format.
     #[value(name = "blocknote")]
     Blocknote,
+    /// HTML5 format.
+    #[value(name = "html")]
+    Html,
     /// `oxa.dev` JSON format.
     #[value(name = "oxa")]
     Oxa,
@@ -89,6 +92,22 @@ mod tests {
         assert!(
             result.is_err(),
             "markdown should not be a valid output format"
+        );
+    }
+
+    #[test]
+    fn clap_accepts_html_as_output_format() {
+        let result = Cli::try_parse_from(["docspec", "--to", "html", "x.md"]);
+        assert!(
+            result.is_ok(),
+            "html should be a valid output format, got error: {:?}",
+            result.as_ref().err()
+        );
+        let cli = result.unwrap_or_else(|_| std::process::abort());
+        assert!(
+            matches!(cli.to, Some(CliOutputFormat::Html)),
+            "expected CliOutputFormat::Html, got {:?}",
+            cli.to
         );
     }
 

--- a/crates/docspec-cli/src/conversions.rs
+++ b/crates/docspec-cli/src/conversions.rs
@@ -19,6 +19,7 @@ impl From<CliOutputFormat> for OutputFormat {
     fn from(f: CliOutputFormat) -> Self {
         match f {
             CliOutputFormat::Blocknote => Self::Blocknote,
+            CliOutputFormat::Html => Self::Html,
             CliOutputFormat::Oxa => Self::Oxa,
         }
     }
@@ -46,6 +47,14 @@ mod tests {
         assert_eq!(
             OutputFormat::from(CliOutputFormat::Blocknote),
             OutputFormat::Blocknote
+        );
+    }
+
+    #[test]
+    fn from_html_output_converts_to_facade_html() {
+        assert_eq!(
+            OutputFormat::from(CliOutputFormat::Html),
+            OutputFormat::Html
         );
     }
 

--- a/crates/docspec-cli/src/format.rs
+++ b/crates/docspec-cli/src/format.rs
@@ -111,6 +111,18 @@ mod tests {
     }
 
     #[test]
+    fn detect_html_from_html_output() {
+        let result = resolve_output_format(None, Some(Path::new("doc.html")), "err");
+        assert!(matches!(result, Ok(docspec::OutputFormat::Html)));
+    }
+
+    #[test]
+    fn detect_html_from_htm_output() {
+        let result = resolve_output_format(None, Some(Path::new("doc.htm")), "err");
+        assert!(matches!(result, Ok(docspec::OutputFormat::Html)));
+    }
+
+    #[test]
     fn case_insensitive_extension_output() {
         let result = resolve_output_format(None, Some(Path::new("doc.JSON")), "err");
         assert!(matches!(result, Ok(docspec::OutputFormat::Blocknote)));

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -400,6 +400,44 @@ mod tests {
     }
 
     #[test]
+    fn convert_markdown_stdin_to_html_stdout() {
+        docspec_cmd()
+            .args(["--from", "markdown", "--to", "html"])
+            .write_stdin("Hello world")
+            .assert()
+            .success()
+            .stdout("<html><body><p>Hello world</p></body></html>");
+    }
+
+    #[test]
+    fn markdown_heading_is_dropped_by_paragraph_only_html_writer() {
+        docspec_cmd()
+            .args(["--from", "markdown", "--to", "html"])
+            .write_stdin("# Dropped\n\nKept paragraph")
+            .assert()
+            .success()
+            .stdout("<html><body><p>Kept paragraph</p></body></html>");
+    }
+
+    #[test]
+    fn convert_markdown_to_html_file_via_extension_autodetect() {
+        let input = markdown_tempfile(b"Hello world\n", ".md");
+        let output = empty_tempfile(".html");
+        let output_path = output.path().to_path_buf();
+
+        docspec_cmd()
+            .arg(input.path())
+            .args(["-o", output_path.to_str().unwrap_or("")])
+            .assert()
+            .success();
+
+        assert_eq!(
+            read_output(&output_path),
+            "<html><body><p>Hello world</p></body></html>"
+        );
+    }
+
+    #[test]
     fn convert_markdown_stdin_to_oxa_stdout() {
         docspec_cmd()
             .args(["--from", "markdown", "--to", "oxa"])

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -47,7 +47,13 @@ sentry = { version = "0.48", default-features = false, features = [
 ] }
 docspec-core = { path = "../docspec-core", version = "1.0.0" }
 docspec-json = { path = "../docspec-json", version = "1.0.0" }
-docspec = { path = "../docspec", version = "1.2.0", features = ["markdown", "html", "blocknote", "oxa"] }
+docspec = { path = "../docspec", version = "1.2.0", features = [
+  "markdown",
+  "html",
+  "blocknote",
+  "oxa",
+  "html-writer",
+] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -1,10 +1,10 @@
 # `docspec-http`
 
-HTTP API server for DocSpec markdown or HTML to BlockNote JSON conversion (oxa.dev JSON opt-in via `Accept`).
+HTTP API server for DocSpec markdown or HTML conversion to BlockNote JSON (default), HTML, or oxa.dev JSON via `Accept`.
 
-Send markdown (`Content-Type: text/markdown`) or HTML (`Content-Type: text/html`), receive BlockNote JSON (default) or oxa.dev JSON (`Accept: application/vnd.oxa+json`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
+Send markdown (`Content-Type: text/markdown`) or HTML (`Content-Type: text/html`), receive BlockNote JSON (default), HTML (`Accept: text/html`), or oxa.dev JSON (`Accept: application/vnd.oxa+json`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
 
-> **HTML input is paragraph-only.** The HTML reader currently parses `<p>` elements only; other elements (headings, lists, tables, etc.) are silently dropped. See [docspec-html-reader](../docspec-html-reader/README.md).
+> **HTML is paragraph-only.** The HTML reader currently parses `<p>` elements only, and the HTML writer currently emits only paragraph events. Other HTML input elements and non-paragraph output events (headings, lists, tables, formatting, etc.) are silently dropped. See [docspec-html-reader](../docspec-html-reader/README.md) and [docspec-html-writer](../docspec-html-writer/README.md).
 
 ## Quick Start
 
@@ -23,7 +23,7 @@ Default host is `127.0.0.1`. Default port is `3000`.
 
 | Method  | Path        | Description                                                      |
 | ------- | ----------- | ---------------------------------------------------------------- |
-| POST    | /conversion | Convert markdown or HTML to BlockNote (default) or oxa.dev JSON  |
+| POST    | /conversion | Convert markdown or HTML to BlockNote (default), HTML, or oxa.dev JSON |
 | OPTIONS | /conversion | Preflight / allowed methods                                      |
 | GET     | /health     | Liveness check                                                   |
 | HEAD    | /health     | Liveness check (no body)                                         |
@@ -42,6 +42,13 @@ curl -X POST \
 curl -X POST \
      -H 'Content-Type: text/html' \
      --data '<p>Hello World</p>' \
+     http://localhost:3000/conversion
+
+# Convert markdown to HTML
+curl -X POST \
+     -H 'Content-Type: text/markdown' \
+     -H 'Accept: text/html' \
+     --data 'Hello World' \
      http://localhost:3000/conversion
 
 # Convert markdown to oxa.dev JSON (opt-in via Accept)
@@ -90,7 +97,7 @@ All errors use RFC 7807 Problem Details JSON (`application/problem+json; charset
 | 422  | Input parse error (malformed markdown or HTML)           |
 | 500  | Internal conversion error                                |
 
-Accepted `Accept` values for `/conversion`: `application/vnd.oxa+json` (oxa.dev), `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json` (BlockNote alias), `application/*`, or `*/*`. Wildcards and missing `Accept` default to BlockNote for back-compat. Anything else returns 406.
+Accepted `Accept` values for `/conversion`: `text/html` (HTML), `application/vnd.oxa+json` (oxa.dev), `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json` (BlockNote alias), `application/*`, or `*/*`. Wildcards and missing `Accept` default to BlockNote for back-compat. Anything else returns 406.
 
 ## Deployment Notes
 
@@ -151,7 +158,7 @@ These follow Sentry's standard conventions:
 `docspec-http` does NOT send the following to Sentry:
 
 - Request bodies (markdown or HTML documents)
-- Response bodies (BlockNote or oxa.dev JSON)
+- Response bodies (BlockNote JSON, HTML, or oxa.dev JSON)
 - PII (Sentry default: `send_default_pii = false`)
 - DSN values (never logged or echoed)
 
@@ -259,7 +266,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 **`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `text/html` (the request's Content-Type matched the HTML reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
 
-**`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `application/vnd.oxa+json` (conversion succeeded; output produced by the oxa.dev writer), `none` (no output produced — any error path).
+**`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `text/html` (conversion succeeded; output produced by the HTML writer), `application/vnd.oxa+json` (conversion succeeded; output produced by the oxa.dev writer), `none` (no output produced — any error path).
 
 **`path`**: matched route template (`/conversion`, `/health`) or `unknown` for fallback handlers
 
@@ -269,7 +276,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 ### Cardinality Guarantees
 
-`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 4 values (`text/markdown`, `text/html`, `unsupported`, `none`). `output_mime_type` is bounded to 3 values. Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
+`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 4 values (`text/markdown`, `text/html`, `unsupported`, `none`). `output_mime_type` is bounded to 4 values (`application/vnd.docspec.blocknote+json`, `text/html`, `application/vnd.oxa+json`, `none`). Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
 
 ### Scrape Model
 

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -176,7 +176,7 @@ impl IntoResponse for HttpError {
                 "Not Acceptable",
                 Cow::Borrowed(
                     "Accept header must include application/vnd.docspec.blocknote+json, \
-                     application/vnd.blocknote+json, application/vnd.oxa+json, \
+                     application/vnd.blocknote+json, application/vnd.oxa+json, text/html, \
                      application/*, or */*",
                 ),
                 None,

--- a/crates/docspec-http/src/format.rs
+++ b/crates/docspec-http/src/format.rs
@@ -15,5 +15,8 @@ pub const OUTPUT_MIME_ALIAS: &str = "application/vnd.blocknote+json";
 /// The primary output MIME type returned on success.
 pub const OUTPUT_MIME_PRIMARY: &str = "application/vnd.docspec.blocknote+json";
 
+/// The primary HTML output MIME type returned when the HTML writer is selected.
+pub const OUTPUT_MIME_HTML_PRIMARY: &str = "text/html";
+
 /// The primary `oxa.dev` output MIME type returned when the `oxa.dev` writer is selected.
 pub const OUTPUT_MIME_OXA_PRIMARY: &str = "application/vnd.oxa+json";

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -21,7 +21,7 @@ pub async fn options_conversion() -> impl IntoResponse {
     )
 }
 
-/// Handle `POST /conversion` — convert markdown or HTML to `BlockNote` or `oxa.dev` JSON.
+/// Handle `POST /conversion` — convert markdown or HTML to `BlockNote` JSON, HTML, or `oxa.dev` JSON.
 ///
 /// The input reader is selected by the request's `Content-Type` header (see
 /// [`crate::mime_parser::validate_content_type`]). The output writer is
@@ -214,6 +214,7 @@ async fn do_conversion(
         OutputFormat::Blocknote => {
             HeaderValue::from_static("application/vnd.docspec.blocknote+json; charset=utf-8")
         }
+        OutputFormat::Html => HeaderValue::from_static("text/html; charset=utf-8"),
         OutputFormat::Oxa => HeaderValue::from_static("application/vnd.oxa+json; charset=utf-8"),
     };
 

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -93,6 +93,9 @@ pub const INPUT_MIME_NONE: &str = "none";
 /// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `BlockNote` JSON.
 pub const OUTPUT_MIME_BLOCKNOTE: &str = "application/vnd.docspec.blocknote+json";
 
+/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced HTML.
+pub const OUTPUT_MIME_HTML: &str = "text/html";
+
 /// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `oxa.dev` JSON.
 pub const OUTPUT_MIME_OXA: &str = "application/vnd.oxa+json";
 

--- a/crates/docspec-http/src/mime_parser.rs
+++ b/crates/docspec-http/src/mime_parser.rs
@@ -4,15 +4,18 @@ use axum::http::HeaderValue;
 use docspec::{InputFormat, OutputFormat};
 
 use crate::error::HttpError;
-use crate::format::{OUTPUT_MIME_ALIAS, OUTPUT_MIME_OXA_PRIMARY, OUTPUT_MIME_PRIMARY};
+use crate::format::{
+    OUTPUT_MIME_ALIAS, OUTPUT_MIME_HTML_PRIMARY, OUTPUT_MIME_OXA_PRIMARY, OUTPUT_MIME_PRIMARY,
+};
 
 /// Negotiates the `Accept` header for the `/conversion` endpoint.
 ///
-/// Returns [`OutputFormat::Oxa`] for `Accept: application/vnd.oxa+json`, and
-/// [`OutputFormat::Blocknote`] for the `BlockNote` MIMEs, `application/*`, `*/*`, and
-/// missing `Accept`. Wildcards default to `BlockNote` for back-compat with pre-oxa
-/// clients. When `Accept` lists multiple types, the first whose bare MIME matches a
-/// supported value wins (case-insensitive); `q=...` is stripped.
+/// Returns [`OutputFormat::Oxa`] for `Accept: application/vnd.oxa+json`,
+/// [`OutputFormat::Html`] for `Accept: text/html`, and [`OutputFormat::Blocknote`]
+/// for the `BlockNote` MIMEs, `application/*`, `*/*`, and missing `Accept`.
+/// Wildcards default to `BlockNote` for back-compat with pre-oxa clients. When
+/// `Accept` lists multiple types, the first whose bare MIME matches a supported
+/// value wins (case-insensitive); `q=...` is stripped.
 ///
 /// # Errors
 ///
@@ -31,6 +34,9 @@ pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<OutputForm
         let type_part = part.trim().split(';').next().map_or("", str::trim);
         if type_part.eq_ignore_ascii_case(OUTPUT_MIME_OXA_PRIMARY) {
             return Ok(OutputFormat::Oxa);
+        }
+        if type_part.eq_ignore_ascii_case(OUTPUT_MIME_HTML_PRIMARY) {
+            return Ok(OutputFormat::Html);
         }
         if type_part.eq_ignore_ascii_case("*/*")
             || type_part.eq_ignore_ascii_case("application/*")
@@ -145,6 +151,7 @@ pub fn bucket_output_mime(chosen_format: Option<OutputFormat>) -> &'static str {
     match chosen_format {
         None => crate::metrics::OUTPUT_MIME_NONE,
         Some(OutputFormat::Blocknote) => crate::metrics::OUTPUT_MIME_BLOCKNOTE,
+        Some(OutputFormat::Html) => crate::metrics::OUTPUT_MIME_HTML,
         Some(OutputFormat::Oxa) => crate::metrics::OUTPUT_MIME_OXA,
     }
 }
@@ -264,6 +271,14 @@ mod bucket_tests {
         assert_eq!(
             bucket_output_mime(Some(OutputFormat::Blocknote)),
             crate::metrics::OUTPUT_MIME_BLOCKNOTE
+        );
+    }
+
+    #[test]
+    fn bucket_output_mime_html_when_html_succeeded() {
+        assert_eq!(
+            bucket_output_mime(Some(OutputFormat::Html)),
+            crate::metrics::OUTPUT_MIME_HTML
         );
     }
 

--- a/crates/docspec-http/tests/http_integration.rs
+++ b/crates/docspec-http/tests/http_integration.rs
@@ -19,6 +19,7 @@ use tower::ServiceExt as _;
 
 const CACHE_CONTROL: &str = "max-age=0, private, must-revalidate";
 const OUTPUT_MIME: &str = "application/vnd.docspec.blocknote+json; charset=utf-8";
+const OUTPUT_MIME_HTML: &str = "text/html; charset=utf-8";
 const OUTPUT_MIME_OXA: &str = "application/vnd.oxa+json; charset=utf-8";
 const PROBLEM_JSON_CT: &str = "application/problem+json; charset=utf-8";
 const HEALTH_CT: &str = "text/plain; charset=utf-8";
@@ -284,7 +285,7 @@ async fn post_conversion_wrong_accept() {
             "type": "about:blank",
             "title": "Not Acceptable",
             "status": 406,
-            "detail": "Accept header must include application/vnd.docspec.blocknote+json, application/vnd.blocknote+json, application/vnd.oxa+json, application/*, or */*",
+            "detail": "Accept header must include application/vnd.docspec.blocknote+json, application/vnd.blocknote+json, application/vnd.oxa+json, text/html, application/*, or */*",
         })
     );
 }
@@ -584,6 +585,54 @@ async fn unknown_path_returns_404() {
             "detail": "No route matches GET /unknown",
         })
     );
+}
+
+#[tokio::test]
+async fn post_conversion_html_output_happy_path() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", "text/markdown"), ("accept", "text/html")],
+        Body::from("Hello world"),
+    );
+
+    let response = app().oneshot(request).await.expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME_HTML
+    );
+
+    let body_text = response_body_text(response.into_body()).await;
+    assert_eq!(body_text, "<html><body><p>Hello world</p></body></html>");
+}
+
+#[tokio::test]
+async fn post_conversion_html_input_to_html_output_happy_path() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", "text/html"), ("accept", "text/html")],
+        Body::from("<p>Hello</p>"),
+    );
+
+    let response = app().oneshot(request).await.expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME_HTML
+    );
+
+    let body_text = response_body_text(response.into_body()).await;
+    assert_eq!(body_text, "<html><body><p>Hello</p></body></html>");
 }
 
 #[tokio::test]

--- a/crates/docspec-http/tests/metrics_conversion.rs
+++ b/crates/docspec-http/tests/metrics_conversion.rs
@@ -389,7 +389,35 @@ fn output_bytes_not_recorded_on_unsupported_media() {
     );
 }
 
-// ─── Test 14: oxa success records oxa output_mime_type ───────────────────────
+// ─── Test 14: HTML success records HTML output_mime_type ─────────────────────
+
+/// A successful conversion to HTML records `output_mime_type="text/html"`
+/// on `docspec_conversions_total`.
+#[test]
+fn html_success_records_html_output_mime() {
+    let rt = common::runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "text/markdown")
+        .header("accept", "text/html")
+        .body(Body::from("Hello"))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="success",error_class="none",input_mime_type="text/markdown",output_mime_type="text/html"} 1"#,
+    );
+}
+
+// ─── Test 15: oxa success records oxa output_mime_type ───────────────────────
 
 /// A successful conversion to oxa records `output_mime_type="application/vnd.oxa+json"`
 /// on `docspec_conversions_total`.

--- a/crates/docspec-http/tests/mime_parser.rs
+++ b/crates/docspec-http/tests/mime_parser.rs
@@ -192,6 +192,18 @@ fn accept_alias_mime_returns_blocknote() {
 }
 
 #[test]
+fn accept_html_mime_returns_html() {
+    let header = HeaderValue::from_static("text/html");
+    assert_eq!(negotiate_accept(Some(&header)).unwrap(), OutputFormat::Html);
+}
+
+#[test]
+fn accept_html_mime_with_quality_returns_html() {
+    let header = HeaderValue::from_static("text/html;q=0.8");
+    assert_eq!(negotiate_accept(Some(&header)).unwrap(), OutputFormat::Html);
+}
+
+#[test]
 fn accept_oxa_primary_mime_returns_oxa() {
     let header = HeaderValue::from_static("application/vnd.oxa+json");
     assert_eq!(negotiate_accept(Some(&header)).unwrap(), OutputFormat::Oxa);
@@ -216,7 +228,7 @@ fn accept_application_json_rejects() {
 
 #[test]
 fn accept_list_with_alias_and_quality_accepts() {
-    let header = HeaderValue::from_static("text/html, application/vnd.blocknote+json;q=0.8");
+    let header = HeaderValue::from_static("text/plain, application/vnd.blocknote+json;q=0.8");
     assert_eq!(
         negotiate_accept(Some(&header)).unwrap(),
         OutputFormat::Blocknote
@@ -225,7 +237,7 @@ fn accept_list_with_alias_and_quality_accepts() {
 
 #[test]
 fn accept_incompatible_list_rejects() {
-    let header = HeaderValue::from_static("text/html, application/xml");
+    let header = HeaderValue::from_static("text/plain, application/xml");
     assert!(matches!(
         negotiate_accept(Some(&header)),
         Err(HttpError::NotAcceptable)


### PR DESCRIPTION
## Summary
- Hook up HTML writer in CLI and HTTP
- Document paragraph-only HTML output contract

Refs: #26

## Verification
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo build --workspace --all-features