### PR TITLE
Show help when running docspec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "docspec"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "docspec-blocknote-writer",
  "docspec-core",
@@ -491,7 +491,7 @@ dependencies = [
 
 [[package]]
 name = "docspec-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "assert_cmd",
  "clap",
@@ -541,7 +541,7 @@ dependencies = [
 
 [[package]]
 name = "docspec-http"
-version = "1.1.0"
+version = "1.3.0"
 dependencies = [
  "axum",
  "clap",

--- a/crates/docspec-cli/src/main.rs
+++ b/crates/docspec-cli/src/main.rs
@@ -9,7 +9,7 @@ mod format;
 use std::fs::File;
 use std::io::{BufWriter, IsTerminal as _, Read as _, Write};
 
-use clap::Parser as _;
+use clap::{CommandFactory as _, Parser as _};
 use docspec::{AnyReader, AnyWriter};
 
 use crate::args::{Cli, ColorChoice};
@@ -29,6 +29,17 @@ fn run_pipeline<W: Write>(
 
 /// Main entry point.
 fn main() {
+    if std::env::args_os().len() == 1 {
+        let mut cmd = Cli::command();
+        let mut stdout = std::io::stdout().lock();
+        if let Err(err) = cmd.write_long_help(&mut stdout) {
+            let write_result = writeln!(std::io::stderr(), "error: {err}");
+            drop(write_result);
+            std::process::exit(1);
+        }
+        return;
+    }
+
     let cli = Cli::parse();
 
     let result: Result<()> = (|| {

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -212,6 +212,18 @@ mod tests {
     }
 
     #[test]
+    fn no_arguments_prints_help() {
+        let help_assert = docspec_cmd().arg("--help").assert().success();
+        let help_output = help_assert.get_output();
+
+        let bare_assert = docspec_cmd().assert().success();
+        let bare_output = bare_assert.get_output();
+
+        assert_eq!(bare_output.stdout.as_slice(), help_output.stdout.as_slice());
+        assert_eq!(bare_output.stderr.as_slice(), help_output.stderr.as_slice());
+    }
+
+    #[test]
     fn invalid_arguments_exits_2() {
         docspec_cmd()
             .arg("--invalid-flag-xyz")


### PR DESCRIPTION
Refs: #16


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * The CLI now displays help text when invoked without arguments, providing immediate guidance on command usage.

* **Tests**
  * Added integration test to verify help output behavior when no arguments are provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->