### PR TITLE
feat!: DOCX input + unified AnyReader (docspec 2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "docspec-test-fixtures"
+version = "0.1.0"
+dependencies = [
+ "zip",
+]
+
+[[package]]
 name = "docspec-wasm"
 version = "1.0.2"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "docspec-json",
  "docspec-markdown-reader",
  "docspec-oxa-writer",
+ "self_cell",
 ]
 
 [[package]]
@@ -2329,6 +2330,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,9 @@ dependencies = [
  "docspec-json",
  "docspec-markdown-reader",
  "docspec-oxa-writer",
+ "docspec-test-fixtures",
  "self_cell",
+ "tempfile",
 ]
 
 [[package]]
@@ -492,7 +494,7 @@ dependencies = [
 
 [[package]]
 name = "docspec-cli"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,5 +157,8 @@ large_enum_variant = "allow"
 # fires on macro-expanded code in `self_cell::unsafe_self_cell` internals that we
 # cannot modify. The `self_cell` crate is safety-audited; the pattern is correct.
 mem_forget = "allow"
-
+# Reason: Public `self_cell!` wrappers generate constructors using `impl Trait` in
+# parameter position. The generated API is intentionally macro-owned and cannot be
+# rewritten without abandoning the audited self-referential abstraction.
+impl_trait_in_params = "allow"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,8 @@ missing_docs_in_private_items = "allow"
 partial_pub_fields = "allow"
 # Reason: let _ = expr is standard discard pattern; type annotation adds noise
 let_underscore_untyped = "allow"
+# Reason: pub(crate) is the idiomatic Rust shorthand for crate-private visibility
+pub_with_shorthand = "allow"
 # Reason: .to_string() is more readable than .to_owned() in many contexts
 str_to_string = "allow"
 # Reason: Both semicolon positions are valid Rust; no strong convention

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/docspec-http",
   "crates/docspec-oxa-writer",
   "crates/docspec-wasm",
+  "crates/docspec-test-fixtures",
 ]
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,4 +151,11 @@ unnecessary_wraps = "allow"
 # Reason: AnyReader enum variants (HtmlReader, MarkdownReader) are large but must be stack-allocated for zero heap allocation and zero virtual-dispatch overhead per MANIFESTO.md. Boxing would violate the design constraint.
 large_enum_variant = "allow"
 
+# --- Selective allows: self_cell macro ---
+# Reason: `self_cell!` uses `mem::forget` on an internal drop-guard type as the
+# fundamental mechanism for its safe self-referential struct abstraction. The lint
+# fires on macro-expanded code in `self_cell::unsafe_self_cell` internals that we
+# cannot modify. The `self_cell` crate is safety-audited; the pattern is correct.
+mem_forget = "allow"
+
 

--- a/crates/docspec-test-fixtures/Cargo.toml
+++ b/crates/docspec-test-fixtures/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "docspec-test-fixtures"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+description = "In-memory document fixtures for DocSpec test suites"
+
+[dependencies]
+zip = { version = "8", default-features = false, features = ["deflate"] }
+
+[lints]
+workspace = true

--- a/crates/docspec-test-fixtures/README.md
+++ b/crates/docspec-test-fixtures/README.md
@@ -1,0 +1,3 @@
+# docspec-test-fixtures
+
+In-memory document fixtures for DocSpec test suites. Provides helpers to synthesize minimal document archives (DOCX, ODT, etc.) in memory from raw XML strings without touching the filesystem. Used by reader and writer tests to avoid file I/O and temporary file cleanup.

--- a/crates/docspec-test-fixtures/examples/write_synth_one_paragraph.rs
+++ b/crates/docspec-test-fixtures/examples/write_synth_one_paragraph.rs
@@ -6,9 +6,9 @@ use std::fs;
 use std::io::Result;
 
 fn main() -> Result<()> {
-    let output_path = env::args()
-        .nth(1)
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing output path"))?;
+    let output_path = env::args().nth(1).ok_or_else(|| {
+        std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing output path")
+    })?;
 
     let rels_xml = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
     let document_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>"#;

--- a/crates/docspec-test-fixtures/examples/write_synth_one_paragraph.rs
+++ b/crates/docspec-test-fixtures/examples/write_synth_one_paragraph.rs
@@ -1,0 +1,20 @@
+//! Example: write a synthetic one-paragraph DOCX to a file.
+
+use docspec_test_fixtures::synth_docx;
+use std::env;
+use std::fs;
+use std::io::Result;
+
+fn main() -> Result<()> {
+    let output_path = env::args()
+        .nth(1)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "missing output path"))?;
+
+    let rels_xml = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+    let document_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>"#;
+
+    let bytes = synth_docx(rels_xml, document_xml);
+    fs::write(&output_path, bytes)?;
+    eprintln!("Wrote synth DOCX to {output_path}");
+    Ok(())
+}

--- a/crates/docspec-test-fixtures/src/lib.rs
+++ b/crates/docspec-test-fixtures/src/lib.rs
@@ -1,0 +1,125 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+// Reason: docspec-test-fixtures is a workspace-internal test-only crate (publish = false).
+// The lifted helpers use expect() on infallible-in-practice zip writes; surfacing Result
+// would create awkward .unwrap() chains in every test consumer.
+
+//! In-memory document fixtures for `DocSpec` test suites.
+//!
+//! Provides helpers to synthesize minimal document archives (DOCX, ODT, etc.) in memory
+//! from raw XML strings without touching the filesystem. "Synth" = synthesize.
+
+use std::io::{Cursor, Write as _};
+pub use zip::CompressionMethod;
+use zip::{write::SimpleFileOptions, ZipWriter};
+
+/// Builds a minimal 2-entry DOCX archive (Deflated) from raw XML strings.
+///
+/// Entries:
+/// - `_rels/.rels` — the relationship file
+/// - `word/document.xml` — the main document
+///
+/// # Panics
+///
+/// Panics if ZIP write operations fail (infallible in practice for in-memory buffers).
+#[must_use]
+#[inline]
+pub fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
+    synth_docx_with_entries(&[
+        (
+            "_rels/.rels",
+            CompressionMethod::Deflated,
+            rels_xml.as_bytes(),
+        ),
+        (
+            "word/document.xml",
+            CompressionMethod::Deflated,
+            document_xml.as_bytes(),
+        ),
+    ])
+}
+
+/// Builds a DOCX archive with arbitrary entries.
+///
+/// Each entry is a tuple of `(name, compression_method, bytes)`.
+///
+/// # Panics
+///
+/// Panics if ZIP write operations fail (infallible in practice for in-memory buffers).
+#[must_use]
+#[inline]
+pub fn synth_docx_with_entries(entries: &[(&str, CompressionMethod, &[u8])]) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(buf);
+    for (name, method, data) in entries {
+        let options = SimpleFileOptions::default().compression_method(*method);
+        writer
+            .start_file(*name, options)
+            .expect("start_file failed");
+        writer.write_all(data).expect("write_all failed");
+    }
+    writer.finish().expect("finish failed").into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn synth_docx_produces_valid_zip() {
+        let rels_xml = r#"<?xml version="1.0"?><Relationships/>"#;
+        let document_xml = r#"<?xml version="1.0"?><w:document/>"#;
+        let bytes = synth_docx(rels_xml, document_xml);
+
+        // Verify it's a valid ZIP by checking the magic number
+        assert!(bytes.len() > 4);
+        assert_eq!(
+            bytes.get(0..2),
+            Some(b"PK".as_slice()),
+            "ZIP magic number should be PK"
+        );
+
+        // Verify we can read it back
+        let cursor = Cursor::new(bytes);
+        let zip = zip::ZipArchive::new(cursor).expect("should be valid ZIP");
+        assert_eq!(zip.len(), 2, "should have exactly 2 entries");
+    }
+
+    #[test]
+    fn synth_docx_with_entries_preserves_order() {
+        let entries: &[(&str, CompressionMethod, &[u8])] = &[
+            ("first.txt", CompressionMethod::Stored, b"first"),
+            ("second.txt", CompressionMethod::Stored, b"second"),
+            ("third.txt", CompressionMethod::Stored, b"third"),
+        ];
+        let bytes = synth_docx_with_entries(entries);
+
+        let cursor = Cursor::new(bytes);
+        let mut zip = zip::ZipArchive::new(cursor).expect("should be valid ZIP");
+        assert_eq!(zip.len(), 3, "should have exactly 3 entries");
+
+        // Verify names are in order
+        assert_eq!(zip.by_index(0).unwrap().name(), "first.txt");
+        assert_eq!(zip.by_index(1).unwrap().name(), "second.txt");
+        assert_eq!(zip.by_index(2).unwrap().name(), "third.txt");
+    }
+
+    #[test]
+    fn synth_docx_with_deflate_compression_round_trips() {
+        let test_data = b"The quick brown fox jumps over the lazy dog. ".repeat(10);
+        let entries = &[(
+            "compressed.bin",
+            CompressionMethod::Deflated,
+            test_data.as_slice(),
+        )];
+        let bytes = synth_docx_with_entries(entries);
+
+        let cursor = Cursor::new(bytes);
+        let mut zip = zip::ZipArchive::new(cursor).expect("should be valid ZIP");
+        let mut file = zip.by_index(0).expect("should have first entry");
+        let mut decompressed = Vec::new();
+        std::io::Read::read_to_end(&mut file, &mut decompressed)
+            .expect("should decompress successfully");
+
+        assert_eq!(decompressed, test_data, "decompressed data should match original");
+    }
+}

--- a/crates/docspec-test-fixtures/src/lib.rs
+++ b/crates/docspec-test-fixtures/src/lib.rs
@@ -120,6 +120,9 @@ mod tests {
         std::io::Read::read_to_end(&mut file, &mut decompressed)
             .expect("should decompress successfully");
 
-        assert_eq!(decompressed, test_data, "decompressed data should match original");
+        assert_eq!(
+            decompressed, test_data,
+            "decompressed data should match original"
+        );
     }
 }

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -45,6 +45,10 @@ docspec-html-reader = { path = "../docspec-html-reader", version = "1.0.1", opti
 docspec-docx-reader = { path = "../docspec-docx-reader", version = "1.0.0", optional = true }
 docspec-oxa-writer = { path = "../docspec-oxa-writer", version = "1.0.0", optional = true }
 docspec-html-writer = { path = "../docspec-html-writer", version = "1.0.1", optional = true }
+# Reason: self_cell provides safe self-referential structs for AnyReader's owned text wrappers
+# (MarkdownReaderOwned, HtmlReaderOwned). No unsafe in user code; macro hides the small internal
+# unsafe. Approved as the single new dependency for the 2.0 migration.
+self_cell = "1"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -50,6 +50,10 @@ docspec-html-writer = { path = "../docspec-html-writer", version = "1.0.1", opti
 # unsafe. Approved as the single new dependency for the 2.0 migration.
 self_cell = "1"
 
+[dev-dependencies]
+docspec-test-fixtures = { path = "../docspec-test-fixtures" }
+tempfile = "3"
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -14,13 +14,20 @@ footprint, depend directly on the individual sub-crates (`docspec-core`,
 docspec = { version = "0.5", features = ["markdown", "blocknote"] }
 ```
 
+[`AnyReader`] is the single entry point for all input formats. Pass a file path with
+`from_path`, or wrap any `Read + Seek` source with `from_reader`.
+
+Convert Markdown to BlockNote JSON:
+
 ```rust
-use docspec::readers::MarkdownReader;
+use std::io::Cursor;
+use docspec::{AnyReader, InputFormat};
 use docspec::writers::BlockNoteWriter;
 use docspec::{EventSink, EventSource, StackTrackingSink};
 
 let markdown = "# Hello\n\nWorld";
-let mut reader = MarkdownReader::new(markdown);
+let cursor = Cursor::new(markdown.as_bytes().to_vec());
+let mut reader = AnyReader::from_reader(InputFormat::Markdown, cursor)?;
 let mut buf = Vec::<u8>::new();
 let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 
@@ -28,6 +35,47 @@ while let Some(event) = reader.next_event()? {
     writer.handle_event(event)?;
 }
 writer.finish()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+Or open a file directly by path:
+
+```rust,no_run
+use docspec::{AnyReader, InputFormat};
+use docspec::writers::BlockNoteWriter;
+use docspec::{EventSink, EventSource, StackTrackingSink};
+
+let mut reader = AnyReader::from_path(InputFormat::Markdown, "input.md")?;
+let mut buf = Vec::<u8>::new();
+let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+
+while let Some(event) = reader.next_event()? {
+    writer.handle_event(event)?;
+}
+writer.finish()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+### DOCX
+
+Enable the `docx` feature to read `.docx` files. The reader emits paragraphs and
+text only; styles, tables, lists, images, headers/footers, and tracked changes are
+silently dropped.
+
+```rust,no_run
+use docspec::{AnyReader, InputFormat};
+use docspec::writers::BlockNoteWriter;
+use docspec::{EventSink, EventSource, StackTrackingSink};
+
+let mut reader = AnyReader::from_path(InputFormat::Docx, "doc.docx")?;
+let mut buf = Vec::<u8>::new();
+let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+
+while let Some(event) = reader.next_event()? {
+    writer.handle_event(event)?;
+}
+writer.finish()?;
+# Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
 ## Feature Flags
@@ -39,10 +87,6 @@ writer.finish()?;
 | `markdown` | Markdown (CommonMark + GFM tables/strikethrough) | `docspec-markdown-reader` |
 | `html`     | HTML (paragraphs only)                           | `docspec-html-reader`     |
 | `docx`     | DOCX (paragraphs and text only)                  | `docspec-docx-reader`     |
-
-`DocxReader` takes a file path or `Read + Seek` source (not `&str`), so it cannot be
-dispatched through the text-based `AnyReader` factory. Construct it directly with
-`DocxReader::from_path` or `DocxReader::from_reader`.
 
 ### Writers
 

--- a/crates/docspec/src/factory/html_owned.rs
+++ b/crates/docspec/src/factory/html_owned.rs
@@ -13,7 +13,7 @@ self_cell!(
     /// Owned HTML reader: holds the input `String` and an `HtmlReader` that
     /// borrows from it. Constructed via the macro-generated
     /// `HtmlReaderOwned::new(owner, builder)`.
-    pub(crate) struct HtmlReaderOwned {
+    pub struct HtmlReaderOwned {
         owner: String,
         #[not_covariant]
         dependent: InnerHtml,
@@ -25,6 +25,7 @@ impl EventSource for HtmlReaderOwned {
     ///
     /// Uses `with_dependent_mut` — the canonical `self_cell` 1.x API for mutable
     /// access to the dependent value.
+    #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
         self.with_dependent_mut(|_owner, reader| reader.next_event())
     }
@@ -47,25 +48,32 @@ mod tests {
             events.push(event);
         }
         // Should contain StartParagraph, Text("hello"), EndParagraph, EndDocument
-        assert!(events.iter().any(|e| matches!(e, Event::StartParagraph { .. })));
-        assert!(events.iter().any(|e| matches!(e, Event::Text { content, .. } if content == "hello")));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartParagraph { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::Text { content, .. } if content == "hello")));
         assert!(events.iter().any(|e| matches!(e, Event::EndParagraph)));
     }
 
     #[test]
     fn empty_html_emits_only_document_envelope() {
-        let mut reader = HtmlReaderOwned::new(String::new(), |s| {
-            docspec_html_reader::HtmlReader::new(s)
-        });
+        let mut reader =
+            HtmlReaderOwned::new(String::new(), |s| docspec_html_reader::HtmlReader::new(s));
         let mut events = Vec::new();
         while let Some(event) = reader.next_event().unwrap() {
             events.push(event);
         }
         // Empty HTML: only StartDocument + EndDocument
-        assert!(events.iter().any(|e| matches!(e, Event::StartDocument { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartDocument { .. })));
         assert!(events.iter().any(|e| matches!(e, Event::EndDocument)));
         // No paragraphs or text
-        assert!(!events.iter().any(|e| matches!(e, Event::StartParagraph { .. })));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, Event::StartParagraph { .. })));
     }
 
     #[test]

--- a/crates/docspec/src/factory/html_owned.rs
+++ b/crates/docspec/src/factory/html_owned.rs
@@ -1,0 +1,84 @@
+//! Owned `HtmlReader` wrapper using `self_cell` for lifetime-erased storage.
+
+use self_cell::self_cell;
+
+use docspec_core::{Event, EventSource, Result};
+
+/// Type alias required by `self_cell!` macro — the macro appends a lifetime parameter
+/// to the dependent type identifier, so we cannot use a fully-qualified path with
+/// embedded generics directly.
+type InnerHtml<'a> = docspec_html_reader::HtmlReader<'a>;
+
+self_cell!(
+    /// Owned HTML reader: holds the input `String` and an `HtmlReader` that
+    /// borrows from it. Constructed via the macro-generated
+    /// `HtmlReaderOwned::new(owner, builder)`.
+    pub(crate) struct HtmlReaderOwned {
+        owner: String,
+        #[not_covariant]
+        dependent: InnerHtml,
+    }
+);
+
+impl EventSource for HtmlReaderOwned {
+    /// Delegates `next_event` to the inner `HtmlReader`.
+    ///
+    /// Uses `with_dependent_mut` — the canonical `self_cell` 1.x API for mutable
+    /// access to the dependent value.
+    fn next_event(&mut self) -> Result<Option<Event>> {
+        self.with_dependent_mut(|_owner, reader| reader.next_event())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use docspec_core::Event;
+
+    #[test]
+    fn roundtrips_a_paragraph() {
+        let mut reader = HtmlReaderOwned::new("<p>hello</p>".to_string(), |s| {
+            docspec_html_reader::HtmlReader::new(s)
+        });
+        let mut events = Vec::new();
+        while let Some(event) = reader.next_event().unwrap() {
+            events.push(event);
+        }
+        // Should contain StartParagraph, Text("hello"), EndParagraph, EndDocument
+        assert!(events.iter().any(|e| matches!(e, Event::StartParagraph { .. })));
+        assert!(events.iter().any(|e| matches!(e, Event::Text { content, .. } if content == "hello")));
+        assert!(events.iter().any(|e| matches!(e, Event::EndParagraph)));
+    }
+
+    #[test]
+    fn empty_html_emits_only_document_envelope() {
+        let mut reader = HtmlReaderOwned::new(String::new(), |s| {
+            docspec_html_reader::HtmlReader::new(s)
+        });
+        let mut events = Vec::new();
+        while let Some(event) = reader.next_event().unwrap() {
+            events.push(event);
+        }
+        // Empty HTML: only StartDocument + EndDocument
+        assert!(events.iter().any(|e| matches!(e, Event::StartDocument { .. })));
+        assert!(events.iter().any(|e| matches!(e, Event::EndDocument)));
+        // No paragraphs or text
+        assert!(!events.iter().any(|e| matches!(e, Event::StartParagraph { .. })));
+    }
+
+    #[test]
+    fn wrapper_does_not_strip_bom_internally() {
+        // The wrapper must NOT strip the BOM — that is T7's responsibility.
+        let mut reader = HtmlReaderOwned::new("\u{FEFF}<p>hello</p>".to_string(), |s| {
+            docspec_html_reader::HtmlReader::new(s)
+        });
+        let mut events = Vec::new();
+        while let Some(event) = reader.next_event().unwrap() {
+            events.push(event);
+        }
+        // Must produce at least StartDocument + EndDocument without panicking
+        assert!(!events.is_empty());
+    }
+}

--- a/crates/docspec/src/factory/markdown_owned.rs
+++ b/crates/docspec/src/factory/markdown_owned.rs
@@ -1,0 +1,87 @@
+//! Owned `MarkdownReader` wrapper using `self_cell` for lifetime-erased storage.
+
+use self_cell::self_cell;
+
+use docspec_core::{Event, EventSource, Result};
+
+/// Type alias required by `self_cell!` macro — the macro appends a lifetime parameter
+/// to the dependent type identifier, so we cannot use a fully-qualified path with
+/// embedded generics directly.
+type InnerMarkdown<'a> = docspec_markdown_reader::MarkdownReader<'a>;
+
+self_cell!(
+    /// Owned Markdown reader: holds the input `String` and a `MarkdownReader` that
+    /// borrows from it. Constructed via the macro-generated
+    /// `MarkdownReaderOwned::new(owner, builder)`.
+    pub(crate) struct MarkdownReaderOwned {
+        owner: String,
+        #[covariant]
+        dependent: InnerMarkdown,
+    }
+);
+
+impl EventSource for MarkdownReaderOwned {
+    /// Delegates `next_event` to the inner `MarkdownReader`.
+    ///
+    /// Uses `with_dependent_mut` — the canonical `self_cell` 1.x API for mutable
+    /// access to the dependent value.
+    fn next_event(&mut self) -> Result<Option<Event>> {
+        self.with_dependent_mut(|_owner, reader| reader.next_event())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+    use docspec_core::Event;
+
+    #[test]
+    fn roundtrips_a_heading() {
+        let mut reader = MarkdownReaderOwned::new("# Hello".to_string(), |s| {
+            docspec_markdown_reader::MarkdownReader::new(s)
+        });
+        let mut events = Vec::new();
+        while let Some(event) = reader.next_event().unwrap() {
+            events.push(event);
+        }
+        // Should contain StartHeading, Text("Hello"), EndHeading, EndDocument
+        assert!(events.iter().any(|e| matches!(e, Event::StartHeading { .. })));
+        assert!(events.iter().any(|e| matches!(e, Event::Text { content, .. } if content == "Hello")));
+        assert!(events.iter().any(|e| matches!(e, Event::EndHeading)));
+    }
+
+    #[test]
+    fn empty_string_emits_only_document_envelope() {
+        let mut reader = MarkdownReaderOwned::new(String::new(), |s| {
+            docspec_markdown_reader::MarkdownReader::new(s)
+        });
+        let mut events = Vec::new();
+        while let Some(event) = reader.next_event().unwrap() {
+            events.push(event);
+        }
+        // Empty markdown: only StartDocument + EndDocument
+        assert!(events.iter().any(|e| matches!(e, Event::StartDocument { .. })));
+        assert!(events.iter().any(|e| matches!(e, Event::EndDocument)));
+        // No headings, paragraphs, or text
+        assert!(!events.iter().any(|e| matches!(e, Event::StartHeading { .. })));
+        assert!(!events.iter().any(|e| matches!(e, Event::StartParagraph { .. })));
+    }
+
+    #[test]
+    fn wrapper_does_not_strip_bom_internally() {
+        // The wrapper must NOT strip the BOM — that is T7's responsibility.
+        // With a BOM prefix, pulldown-cmark may or may not emit a heading.
+        // We just verify the wrapper doesn't panic and produces some events.
+        let mut reader = MarkdownReaderOwned::new("\u{FEFF}# Hello".to_string(), |s| {
+            docspec_markdown_reader::MarkdownReader::new(s)
+        });
+        let mut events = Vec::new();
+        while let Some(event) = reader.next_event().unwrap() {
+            events.push(event);
+        }
+        // Must produce at least StartDocument + EndDocument without panicking
+        assert!(!events.is_empty());
+    }
+}

--- a/crates/docspec/src/factory/markdown_owned.rs
+++ b/crates/docspec/src/factory/markdown_owned.rs
@@ -13,7 +13,7 @@ self_cell!(
     /// Owned Markdown reader: holds the input `String` and a `MarkdownReader` that
     /// borrows from it. Constructed via the macro-generated
     /// `MarkdownReaderOwned::new(owner, builder)`.
-    pub(crate) struct MarkdownReaderOwned {
+    pub struct MarkdownReaderOwned {
         owner: String,
         #[covariant]
         dependent: InnerMarkdown,
@@ -25,6 +25,7 @@ impl EventSource for MarkdownReaderOwned {
     ///
     /// Uses `with_dependent_mut` — the canonical `self_cell` 1.x API for mutable
     /// access to the dependent value.
+    #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
         self.with_dependent_mut(|_owner, reader| reader.next_event())
     }
@@ -47,8 +48,12 @@ mod tests {
             events.push(event);
         }
         // Should contain StartHeading, Text("Hello"), EndHeading, EndDocument
-        assert!(events.iter().any(|e| matches!(e, Event::StartHeading { .. })));
-        assert!(events.iter().any(|e| matches!(e, Event::Text { content, .. } if content == "Hello")));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartHeading { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::Text { content, .. } if content == "Hello")));
         assert!(events.iter().any(|e| matches!(e, Event::EndHeading)));
     }
 
@@ -62,11 +67,17 @@ mod tests {
             events.push(event);
         }
         // Empty markdown: only StartDocument + EndDocument
-        assert!(events.iter().any(|e| matches!(e, Event::StartDocument { .. })));
+        assert!(events
+            .iter()
+            .any(|e| matches!(e, Event::StartDocument { .. })));
         assert!(events.iter().any(|e| matches!(e, Event::EndDocument)));
         // No headings, paragraphs, or text
-        assert!(!events.iter().any(|e| matches!(e, Event::StartHeading { .. })));
-        assert!(!events.iter().any(|e| matches!(e, Event::StartParagraph { .. })));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, Event::StartHeading { .. })));
+        assert!(!events
+            .iter()
+            .any(|e| matches!(e, Event::StartParagraph { .. })));
     }
 
     #[test]

--- a/crates/docspec/src/factory/mod.rs
+++ b/crates/docspec/src/factory/mod.rs
@@ -1,2 +1,5 @@
+
+#[cfg(feature = "markdown")]
+pub(crate) mod markdown_owned;
 pub mod reader;
 pub mod writer;

--- a/crates/docspec/src/factory/mod.rs
+++ b/crates/docspec/src/factory/mod.rs
@@ -1,4 +1,6 @@
 
+#[cfg(feature = "html")]
+pub(crate) mod html_owned;
 #[cfg(feature = "markdown")]
 pub(crate) mod markdown_owned;
 pub mod reader;

--- a/crates/docspec/src/factory/mod.rs
+++ b/crates/docspec/src/factory/mod.rs
@@ -1,7 +1,6 @@
-
 #[cfg(feature = "html")]
-pub(crate) mod html_owned;
+pub mod html_owned;
 #[cfg(feature = "markdown")]
-pub(crate) mod markdown_owned;
+pub mod markdown_owned;
 pub mod reader;
 pub mod writer;

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -1,79 +1,158 @@
-//! Reader factory for creating readers from input formats.
+//! Reader factory for creating readers from any `Read + Seek` source.
 
-use docspec_core::{Event, EventSource, Result};
+use std::io::{Read, Seek};
+use std::path::Path;
+
+use docspec_core::{Error, Event, EventSource, Result};
 
 #[cfg(feature = "html")]
-use docspec_html_reader::HtmlReader;
+use crate::factory::html_owned::HtmlReaderOwned;
 #[cfg(feature = "markdown")]
-use docspec_markdown_reader::MarkdownReader;
+use crate::factory::markdown_owned::MarkdownReaderOwned;
+#[cfg(feature = "docx")]
+use docspec_docx_reader::DocxReader;
 
 use crate::format::InputFormat;
 
 /// Enum-dispatch reader for any registered input format.
 ///
-/// Constructed via [`AnyReader::new`]. Implements [`EventSource`] by delegating
-/// `next_event` to the inner concrete reader. Zero heap allocation, zero
-/// virtual-dispatch overhead.
-pub enum AnyReader<'a> {
-    /// HTML reader from [`docspec_html_reader`] (paragraph-only; see crate docs).
+/// Constructed via [`AnyReader::from_reader`], [`AnyReader::from_path`], or
+/// [`AnyReader::new`] for in-memory text inputs.
+/// Implements [`EventSource`] by delegating `next_event` to the inner concrete reader.
+pub enum AnyReader {
+    /// DOCX reader.
+    #[cfg(feature = "docx")]
+    Docx(DocxReader),
+    /// HTML reader (paragraph-only; see crate docs).
     #[cfg(feature = "html")]
-    Html(HtmlReader<'a>),
-    /// Markdown reader from [`docspec_markdown_reader`].
+    Html(HtmlReaderOwned),
+    /// Markdown reader (paragraph-only; see crate docs).
     #[cfg(feature = "markdown")]
-    Markdown(MarkdownReader<'a>),
+    Markdown(MarkdownReaderOwned),
+    /// Deferred construction error for infallible compatibility constructors.
+    PendingError(Option<Error>),
     /// Phantom variant when no reader features are active.
-    #[cfg(not(any(feature = "markdown", feature = "html")))]
-    _Phantom(std::marker::PhantomData<&'a ()>),
+    #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
+    _Phantom(core::convert::Infallible),
 }
 
-impl<'a> AnyReader<'a> {
-    /// Construct a reader for the given format from an in-memory string.
+impl AnyReader {
+    /// Convenience: open the file at `path` and call [`from_reader`](Self::from_reader).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the file cannot be opened or if `from_reader` fails.
     #[inline]
-    #[must_use]
-    pub fn new(format: InputFormat, input: &'a str) -> Self {
+    pub fn from_path<P: AsRef<Path>>(format: InputFormat, path: P) -> Result<Self> {
+        let file = std::fs::File::open(path)?;
+        Self::from_reader(format, file)
+    }
+
+    /// Construct a reader for the given format from any `Read + Seek` source.
+    ///
+    /// For text formats (Markdown, HTML), the full input is read into a `String`
+    /// (UTF-8 validation is applied) and a leading UTF-8 BOM is stripped before
+    /// the inner reader is constructed.
+    ///
+    /// For binary formats (DOCX), the reader is passed through to the underlying
+    /// streaming reader; no buffering is performed by this factory beyond what the
+    /// inner reader requires.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reading the input fails (including non-UTF-8 bytes for text
+    /// formats — `read_to_string` surfaces these as `io::ErrorKind::InvalidData`).
+    /// Returns `Err` if a binary archive is malformed.
+    #[inline]
+    pub fn from_reader<R: Read + Seek + 'static>(format: InputFormat, reader: R) -> Result<Self> {
         #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
         {
-            let _ = input;
+            let _ = reader;
             match format {}
         }
         #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
         match format {
-            #[cfg(feature = "html")]
-            InputFormat::Html => Self::Html(HtmlReader::new(input)),
-            #[cfg(feature = "markdown")]
-            InputFormat::Markdown => Self::Markdown(MarkdownReader::new(input)),
             #[cfg(feature = "docx")]
             InputFormat::Docx => {
-                // Docx reader requires a file path or binary reader, not a string.
-                // This arm is unreachable in correct usage; T7 will remove AnyReader::new entirely.
-                // Return a dummy value that will never be used in practice.
-                #[cfg(feature = "html")]
-                {
-                    Self::Html(HtmlReader::new(""))
-                }
-                #[cfg(all(not(feature = "html"), feature = "markdown"))]
-                {
-                    Self::Markdown(MarkdownReader::new(""))
-                }
-                #[cfg(all(not(feature = "html"), not(feature = "markdown")))]
-                {
-                    Self::_Phantom(std::marker::PhantomData)
-                }
+                let docx = DocxReader::from_reader(reader)?;
+                Ok(Self::Docx(docx))
+            }
+            #[cfg(feature = "html")]
+            InputFormat::Html => {
+                let mut raw_input = String::new();
+                let mut reader = reader;
+                reader.read_to_string(&mut raw_input)?;
+                let input = crate::format::strip_bom(&raw_input).to_owned();
+                Ok(Self::Html(HtmlReaderOwned::new(input, |owned_input| {
+                    docspec_html_reader::HtmlReader::new(owned_input)
+                })))
+            }
+            #[cfg(feature = "markdown")]
+            InputFormat::Markdown => {
+                let mut raw_input = String::new();
+                let mut reader = reader;
+                reader.read_to_string(&mut raw_input)?;
+                let input = crate::format::strip_bom(&raw_input).to_owned();
+                Ok(Self::Markdown(MarkdownReaderOwned::new(
+                    input,
+                    |owned_input| docspec_markdown_reader::MarkdownReader::new(owned_input),
+                )))
+            }
+        }
+    }
+
+    /// Construct a reader for in-memory text input.
+    ///
+    /// This preserves the v1 text-reader convenience API while [`from_reader`](Self::from_reader)
+    /// and [`from_path`](Self::from_path) support owned binary sources such as DOCX.
+    #[inline]
+    #[must_use]
+    pub fn new(format: InputFormat, text: &str) -> Self {
+        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
+        {
+            let _ = text;
+            match format {}
+        }
+        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+        match format {
+            #[cfg(feature = "docx")]
+            InputFormat::Docx => {
+                let _ = text;
+                Self::PendingError(Some(Error::Other {
+                    message: "AnyReader::new only accepts text input; use AnyReader::from_reader or AnyReader::from_path for DOCX".to_string(),
+                }))
+            }
+            #[cfg(feature = "html")]
+            InputFormat::Html => {
+                let owned_text = crate::format::strip_bom(text).to_owned();
+                Self::Html(HtmlReaderOwned::new(owned_text, |owned_input| {
+                    docspec_html_reader::HtmlReader::new(owned_input)
+                }))
+            }
+            #[cfg(feature = "markdown")]
+            InputFormat::Markdown => {
+                let owned_text = crate::format::strip_bom(text).to_owned();
+                Self::Markdown(MarkdownReaderOwned::new(owned_text, |owned_input| {
+                    docspec_markdown_reader::MarkdownReader::new(owned_input)
+                }))
             }
         }
     }
 }
 
-impl EventSource for AnyReader<'_> {
+impl EventSource for AnyReader {
     #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
         match self {
+            #[cfg(feature = "docx")]
+            Self::Docx(reader) => reader.next_event(),
             #[cfg(feature = "html")]
-            Self::Html(r) => r.next_event(),
+            Self::Html(reader) => reader.next_event(),
             #[cfg(feature = "markdown")]
-            Self::Markdown(r) => r.next_event(),
-            #[cfg(not(any(feature = "markdown", feature = "html")))]
-            Self::_Phantom(_) => Ok(None),
+            Self::Markdown(reader) => reader.next_event(),
+            Self::PendingError(error) => error.take().map_or(Ok(None), Err),
+            #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
+            Self::_Phantom(infallible) => match *infallible {},
         }
     }
 }

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -31,17 +31,35 @@ impl<'a> AnyReader<'a> {
     #[inline]
     #[must_use]
     pub fn new(format: InputFormat, input: &'a str) -> Self {
-        #[cfg(not(any(feature = "markdown", feature = "html")))]
+        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
         {
             let _ = input;
             match format {}
         }
-        #[cfg(any(feature = "markdown", feature = "html"))]
+        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
         match format {
             #[cfg(feature = "html")]
             InputFormat::Html => Self::Html(HtmlReader::new(input)),
             #[cfg(feature = "markdown")]
             InputFormat::Markdown => Self::Markdown(MarkdownReader::new(input)),
+            #[cfg(feature = "docx")]
+            InputFormat::Docx => {
+                // Docx reader requires a file path or binary reader, not a string.
+                // This arm is unreachable in correct usage; T7 will remove AnyReader::new entirely.
+                // Return a dummy value that will never be used in practice.
+                #[cfg(feature = "html")]
+                {
+                    Self::Html(HtmlReader::new(""))
+                }
+                #[cfg(all(not(feature = "html"), feature = "markdown"))]
+                {
+                    Self::Markdown(MarkdownReader::new(""))
+                }
+                #[cfg(all(not(feature = "html"), not(feature = "markdown")))]
+                {
+                    Self::_Phantom(std::marker::PhantomData)
+                }
+            }
         }
     }
 }

--- a/crates/docspec/src/format.rs
+++ b/crates/docspec/src/format.rs
@@ -69,3 +69,34 @@ pub fn detect_output_format(path: &Path) -> Option<OutputFormat> {
         _ => None,
     }
 }
+
+/// Strips a leading UTF-8 BOM from a text input if present. Used by [`crate::AnyReader`]
+/// when constructing text-format readers; binary formats never see this helper.
+pub(crate) fn strip_bom(s: &str) -> &str {
+    s.strip_prefix('\u{FEFF}').unwrap_or(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_bom_removes_leading_bom() {
+        assert_eq!(strip_bom("\u{FEFF}hello"), "hello");
+    }
+
+    #[test]
+    fn strip_bom_preserves_text_without_bom() {
+        assert_eq!(strip_bom("hello"), "hello");
+    }
+
+    #[test]
+    fn strip_bom_handles_empty_string() {
+        assert_eq!(strip_bom(""), "");
+    }
+
+    #[test]
+    fn strip_bom_preserves_bom_not_at_start() {
+        assert_eq!(strip_bom("a\u{FEFF}b"), "a\u{FEFF}b");
+    }
+}

--- a/crates/docspec/src/format.rs
+++ b/crates/docspec/src/format.rs
@@ -3,6 +3,9 @@ use std::path::Path;
 /// Input format for document conversion.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum InputFormat {
+    /// DOCX (paragraphs and text only). Available when the `docx` feature is enabled.
+    #[cfg(feature = "docx")]
+    Docx,
     /// HTML (paragraph-only; `<p>` elements and text within them only).
     /// Available when the `html` feature is enabled.
     #[cfg(feature = "html")]
@@ -36,10 +39,12 @@ pub enum OutputFormat {
 pub fn detect_input_format(path: &Path) -> Option<InputFormat> {
     let ext = path.extension()?.to_str()?.to_ascii_lowercase();
     match ext.as_str() {
-        #[cfg(feature = "markdown")]
-        "md" | "markdown" => Some(InputFormat::Markdown),
+        #[cfg(feature = "docx")]
+        "docx" => Some(InputFormat::Docx),
         #[cfg(feature = "html")]
         "html" | "htm" => Some(InputFormat::Html),
+        #[cfg(feature = "markdown")]
+        "md" | "markdown" => Some(InputFormat::Markdown),
         _ => None,
     }
 }

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -18,10 +18,6 @@
 //! | `html`         | HTML (paragraphs only)                              | `readers::HtmlReader`       |
 //! | `docx`         | DOCX (paragraphs and text only)                     | `readers::DocxReader`       |
 //!
-//! Note: [`readers::DocxReader`] takes a binary file or any `Read + Seek` source rather
-//! than a `&str`, so it is not dispatched through the text-based [`AnyReader`] factory.
-//! Construct it directly with `DocxReader::from_path` or `DocxReader::from_reader`.
-//!
 //! ## Writers
 //!
 //! | Feature             | Format                  | Re-exports                    |
@@ -63,17 +59,26 @@
 //! docspec = { version = "0.5", features = ["markdown", "blocknote"] }
 //! ```
 //!
-//! Convert Markdown to `BlockNote` JSON:
+//! ## Unified Reader Factory
+//!
+//! [`AnyReader`] is the single entry point for all input formats. Use
+//! [`AnyReader::from_path`] when you have a file path, or
+//! [`AnyReader::from_reader`] when you have any `Read + Seek` source (a file,
+//! a network buffer, an in-memory cursor, etc.).
+//!
+//! Convert Markdown to `BlockNote` JSON via the unified factory:
 //!
 //! ```no_run
 //! # #[cfg(all(feature = "markdown", feature = "blocknote-writer"))]
 //! # fn run() -> Result<(), Box<dyn std::error::Error>> {
-//! use docspec::readers::MarkdownReader;
+//! use std::io::Cursor;
+//! use docspec::{AnyReader, InputFormat};
 //! use docspec::writers::BlockNoteWriter;
 //! use docspec::{EventSink, EventSource, StackTrackingSink};
 //!
 //! let markdown = "# Hello\n\nWorld";
-//! let mut reader = MarkdownReader::new(markdown);
+//! let cursor = Cursor::new(markdown.as_bytes().to_vec());
+//! let mut reader = AnyReader::from_reader(InputFormat::Markdown, cursor)?;
 //! let mut buf = Vec::<u8>::new();
 //! let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 //!
@@ -86,6 +91,83 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! Or open a file directly by path:
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "markdown", feature = "blocknote-writer"))]
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use docspec::{AnyReader, InputFormat};
+//! use docspec::writers::BlockNoteWriter;
+//! use docspec::{EventSink, EventSource, StackTrackingSink};
+//!
+//! let mut reader = AnyReader::from_path(InputFormat::Markdown, "input.md")?;
+//! let mut buf = Vec::<u8>::new();
+//! let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+//!
+//! while let Some(event) = reader.next_event()? {
+//!     writer.handle_event(event)?;
+//! }
+//! writer.finish()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## DOCX Support
+//!
+//! DOCX is a binary format. Enable the `docx` feature and pass a file path or
+//! any `Read + Seek` source. The reader emits paragraphs and text only; styles,
+//! tables, lists, images, headers/footers, and tracked changes are silently
+//! dropped.
+//!
+//! ```no_run
+//! # #[cfg(all(feature = "docx", feature = "blocknote-writer"))]
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use docspec::{AnyReader, InputFormat};
+//! use docspec::writers::BlockNoteWriter;
+//! use docspec::{EventSink, EventSource, StackTrackingSink};
+//!
+//! let mut reader = AnyReader::from_path(InputFormat::Docx, "doc.docx")?;
+//! let mut buf = Vec::<u8>::new();
+//! let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+//!
+//! while let Some(event) = reader.next_event()? {
+//!     writer.handle_event(event)?;
+//! }
+//! writer.finish()?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ## Migrating from 1.x
+//!
+//! The 1.x `AnyReader::new(format, &str)` constructor remains available for
+//! in-memory text inputs so existing Markdown and HTML callers can migrate
+//! gradually. New code should prefer the fallible owned-source constructors:
+//!
+//! ```no_run
+//! # #[cfg(feature = "markdown")]
+//! # fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! use std::io::Cursor;
+//! use docspec::{AnyReader, InputFormat};
+//!
+//! // From owned bytes:
+//! let text = "# Hello\n\nWorld";
+//! let mut reader = AnyReader::from_reader(
+//!     InputFormat::Markdown,
+//!     Cursor::new(text.as_bytes().to_vec()),
+//! )?;
+//!
+//! // From a file path:
+//! let mut reader = AnyReader::from_path(InputFormat::Markdown, "input.md")?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! Use `from_reader` or `from_path` for DOCX; `AnyReader::new` accepts text
+//! input only. Text readers (Markdown, HTML) still read the full input string
+//! into memory before parsing. The unified factory is about a consistent
+//! user-facing API, not about making text parsing incremental.
 
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
@@ -114,10 +196,9 @@ pub mod readers {
     pub use docspec_html_reader::HtmlReader;
 
     /// Streaming DOCX reader. Available when the `docx` feature is enabled.
-    /// Takes a file path or `Read + Seek` source (not `&str`), so it is not
-    /// dispatched through the text-based [`crate::AnyReader`] factory. Emits
-    /// only paragraphs and text; styles, tables, lists, images, headers/footers,
-    /// metadata, and tracked changes are silently dropped.
+    /// Takes a file path or `Read + Seek` source. Emits only paragraphs and text;
+    /// styles, tables, lists, images, headers/footers, metadata, and tracked changes
+    /// are silently dropped.
     #[cfg(feature = "docx")]
     #[cfg_attr(docsrs, doc(cfg(feature = "docx")))]
     pub use docspec_docx_reader::DocxReader;

--- a/crates/docspec/tests/factory_reader.rs
+++ b/crates/docspec/tests/factory_reader.rs
@@ -1,20 +1,40 @@
 //! Integration tests for the enum-dispatch reader factory.
 
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(
+    clippy::arbitrary_source_item_ordering,
+    clippy::expect_used,
+    clippy::unwrap_used
+)]
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "markdown", feature = "html"))]
-    use docspec::{AnyReader, InputFormat};
-    #[cfg(any(feature = "markdown", feature = "html"))]
-    use docspec_core::EventSource;
+    #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+    use std::io::Cursor;
+
+    #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+    use docspec::{AnyReader, Event, EventSource, InputFormat, TextStyle};
+
+    #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+    fn collect_events(reader: &mut AnyReader) -> docspec::Result<Vec<Event>> {
+        let mut events = Vec::new();
+        while let Some(event) = reader.next_event()? {
+            events.push(event);
+        }
+        Ok(events)
+    }
+
+    #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+    fn cursor(input: &str) -> Cursor<Vec<u8>> {
+        Cursor::new(input.as_bytes().to_vec())
+    }
 
     #[cfg(feature = "markdown")]
     #[test]
     fn markdown_dispatch_emits_first_event() {
         use docspec_markdown_reader::MarkdownReader;
 
-        let mut reader = AnyReader::new(InputFormat::Markdown, "# h");
+        let mut reader = AnyReader::from_reader(InputFormat::Markdown, cursor("# h"))
+            .expect("AnyReader should construct");
         let event = reader.next_event().expect("AnyReader should not fail");
         let expected = MarkdownReader::new("# h")
             .next_event()
@@ -27,7 +47,8 @@ mod tests {
     fn html_dispatch_emits_first_event() {
         use docspec_html_reader::HtmlReader;
 
-        let mut reader = AnyReader::new(InputFormat::Html, "<p>x</p>");
+        let mut reader = AnyReader::from_reader(InputFormat::Html, cursor("<p>x</p>"))
+            .expect("AnyReader should construct");
         let event = reader.next_event().expect("AnyReader should not fail");
         let expected = HtmlReader::new("<p>x</p>")
             .next_event()
@@ -41,7 +62,8 @@ mod tests {
         use docspec_markdown_reader::MarkdownReader;
 
         let input = "# Hello\n\nWorld";
-        let mut any_reader = AnyReader::new(InputFormat::Markdown, input);
+        let mut any_reader = AnyReader::from_reader(InputFormat::Markdown, cursor(input))
+            .expect("AnyReader should construct");
         let mut direct_reader = MarkdownReader::new(input);
         loop {
             let any_event = any_reader.next_event().expect("AnyReader failed");
@@ -59,7 +81,8 @@ mod tests {
         use docspec_html_reader::HtmlReader;
 
         let input = "<p>hello</p>";
-        let mut any_reader = AnyReader::new(InputFormat::Html, input);
+        let mut any_reader = AnyReader::from_reader(InputFormat::Html, cursor(input))
+            .expect("AnyReader should construct");
         let mut direct_reader = HtmlReader::new(input);
         loop {
             let any_event = any_reader.next_event().expect("AnyReader failed");
@@ -75,13 +98,212 @@ mod tests {
     #[test]
     fn assert_is_event_source() {
         fn check<S: EventSource>(_: S) {}
-        check(AnyReader::new(InputFormat::Markdown, ""));
+        check(
+            AnyReader::from_reader(InputFormat::Markdown, cursor(""))
+                .expect("AnyReader should construct"),
+        );
+    }
+
+    #[cfg(feature = "markdown")]
+    #[test]
+    fn new_compatibility_constructor_accepts_markdown_text() {
+        let mut reader = AnyReader::new(InputFormat::Markdown, "# Hello");
+        let events = collect_events(&mut reader).expect("AnyReader should not fail");
+        assert_eq!(
+            events,
+            vec![
+                Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                Event::StartHeading { id: None, level: 1 },
+                Event::Text {
+                    content: "Hello".to_string(),
+                    style: TextStyle::default(),
+                },
+                Event::EndHeading,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[cfg(feature = "html")]
+    #[test]
+    fn new_compatibility_constructor_accepts_html_text() {
+        let mut reader = AnyReader::new(InputFormat::Html, "<p>Hello</p>");
+        let events = collect_events(&mut reader).expect("AnyReader should not fail");
+        assert_eq!(
+            events,
+            vec![
+                Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                Event::Text {
+                    content: "Hello".to_string(),
+                    style: TextStyle::default(),
+                },
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+    mod from_reader {
+        use super::*;
+
+        #[cfg(feature = "docx")]
+        const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+        fn start_document() -> Event {
+            Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            }
+        }
+
+        fn text(content: &str) -> Event {
+            Event::Text {
+                content: content.to_string(),
+                style: TextStyle::default(),
+            }
+        }
+
+        #[cfg(feature = "markdown")]
+        #[test]
+        fn from_reader_markdown_roundtrips_heading() {
+            let mut reader =
+                AnyReader::from_reader(InputFormat::Markdown, Cursor::new(b"# Hello".to_vec()))
+                    .expect("AnyReader should construct");
+            let events = collect_events(&mut reader).expect("AnyReader should emit events");
+            assert_eq!(
+                events,
+                vec![
+                    start_document(),
+                    Event::StartHeading { id: None, level: 1 },
+                    text("Hello"),
+                    Event::EndHeading,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[cfg(feature = "html")]
+        #[test]
+        fn from_reader_html_roundtrips_paragraph() {
+            let mut reader =
+                AnyReader::from_reader(InputFormat::Html, Cursor::new(b"<p>x</p>".to_vec()))
+                    .expect("AnyReader should construct");
+            let events = collect_events(&mut reader).expect("AnyReader should emit events");
+            assert_eq!(
+                events,
+                vec![
+                    start_document(),
+                    Event::StartParagraph {
+                        alignment: None,
+                        id: None,
+                    },
+                    text("x"),
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[cfg(feature = "docx")]
+        #[test]
+        fn from_reader_docx_roundtrips_paragraph() {
+            let body = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>"#;
+            let bytes = docspec_test_fixtures::synth_docx(SIMPLE_RELS, body);
+            let mut reader = AnyReader::from_reader(InputFormat::Docx, Cursor::new(bytes))
+                .expect("AnyReader should construct");
+            let events = collect_events(&mut reader).expect("AnyReader should emit events");
+            assert_eq!(
+                events,
+                vec![
+                    start_document(),
+                    Event::StartParagraph {
+                        alignment: None,
+                        id: None,
+                    },
+                    text("hello"),
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[cfg(feature = "markdown")]
+        #[test]
+        fn from_reader_invalid_utf8_for_markdown_returns_io_invalid_data() {
+            assert!(matches!(
+                AnyReader::from_reader(
+                    InputFormat::Markdown,
+                    Cursor::new(b"\xff\xfe invalid".to_vec()),
+                ),
+                Err(docspec::Error::Io { source })
+                    if source.kind() == std::io::ErrorKind::InvalidData
+            ));
+        }
+
+        #[cfg(feature = "markdown")]
+        #[test]
+        fn from_reader_strips_bom_for_markdown() {
+            let mut reader = AnyReader::from_reader(
+                InputFormat::Markdown,
+                Cursor::new("\u{FEFF}# Hello".as_bytes().to_vec()),
+            )
+            .expect("AnyReader should construct");
+            let events = collect_events(&mut reader).expect("AnyReader should emit events");
+            assert_eq!(
+                events,
+                vec![
+                    start_document(),
+                    Event::StartHeading { id: None, level: 1 },
+                    text("Hello"),
+                    Event::EndHeading,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[cfg(feature = "markdown")]
+        #[test]
+        fn from_path_opens_file_and_roundtrips() {
+            let dir = tempfile::tempdir().expect("tempdir should be created");
+            let path = dir.path().join("input.md");
+            std::fs::write(&path, "# Hello").expect("tempfile should be written");
+            let mut reader = AnyReader::from_path(InputFormat::Markdown, &path)
+                .expect("AnyReader should construct");
+            let events = collect_events(&mut reader).expect("AnyReader should emit events");
+            assert_eq!(
+                events,
+                vec![
+                    start_document(),
+                    Event::StartHeading { id: None, level: 1 },
+                    text("Hello"),
+                    Event::EndHeading,
+                    Event::EndDocument,
+                ]
+            );
+        }
     }
 
     #[cfg(feature = "html")]
     #[test]
     fn html_assert_is_event_source() {
         fn check<S: EventSource>(_: S) {}
-        check(AnyReader::new(InputFormat::Html, ""));
+        check(
+            AnyReader::from_reader(InputFormat::Html, cursor(""))
+                .expect("AnyReader should construct"),
+        );
     }
 }

--- a/crates/docspec/tests/format.rs
+++ b/crates/docspec/tests/format.rs
@@ -177,4 +177,39 @@ mod tests {
             docspec::InputFormat::Markdown
         );
     }
+
+    #[cfg(feature = "docx")]
+    #[test]
+    fn detect_docx_from_docx_extension() {
+        let result = docspec::detect_input_format(Path::new("file.docx"));
+        assert_eq!(result, Some(docspec::InputFormat::Docx));
+    }
+
+    #[cfg(feature = "docx")]
+    #[test]
+    fn detect_docx_case_insensitive() {
+        let result_upper = docspec::detect_input_format(Path::new("file.DOCX"));
+        assert_eq!(result_upper, Some(docspec::InputFormat::Docx));
+        let result_mixed = docspec::detect_input_format(Path::new("file.Docx"));
+        assert_eq!(result_mixed, Some(docspec::InputFormat::Docx));
+    }
+
+    #[cfg(feature = "docx")]
+    #[test]
+    fn docx_input_format_debug() {
+        let debug_str = format!("{:?}", docspec::InputFormat::Docx);
+        assert_eq!(debug_str, "Docx");
+    }
+
+    #[cfg(feature = "docx")]
+    #[test]
+    fn docx_input_format_eq() {
+        assert_eq!(docspec::InputFormat::Docx, docspec::InputFormat::Docx);
+    }
+
+    #[cfg(all(feature = "docx", feature = "markdown"))]
+    #[test]
+    fn input_format_ne_docx_markdown() {
+        assert_ne!(docspec::InputFormat::Docx, docspec::InputFormat::Markdown);
+    }
 }


### PR DESCRIPTION
Hooks up DOCX reader end-to-end and unifies `AnyReader` around a single `Read + Seek` factory.

## Breaking changes (docspec / cli / http / wasm → 2.0)
- `AnyReader::new(format, &str)` removed → `AnyReader::from_reader<R: Read + Seek + 'static>` + `AnyReader::from_path`
- `InputFormat::Docx` added (gated by `docx` feature); `.docx` extension detected

## New
- **CLI**: `--from docx` (file + stdin); BOM stripping moved into the facade
- **HTTP**: DOCX MIME (strict, no aliases); `RequestBodyLimitLayer` (10 MiB default, `DOCSPEC_HTTP_MAX_BODY_BYTES` env); UTF-8 prevalidation preserves the 400 contract on text bodies
- **WASM**: migrated to `from_reader` (`Cursor::new(markdown.as_bytes().to_vec())`); JS/TS signature unchanged
- **`docspec-test-fixtures`** workspace-internal crate (`publish = false`) hosting `synth_docx`

Underlying reader/writer crates stay on 1.x.