### PR TITLE
Pandoc native writer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "docspec-json",
  "docspec-markdown-reader",
  "docspec-oxa-writer",
+ "docspec-pandoc-native-writer",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,6 +589,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "docspec-pandoc-native-writer"
+version = "1.5.0"
+dependencies = [
+ "docspec-core",
+]
+
+[[package]]
 name = "docspec-wasm"
 version = "1.5.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "docspec-pandoc-native-writer"
-version = "1.5.0"
+version = "1.5.1"
 dependencies = [
  "docspec-core",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ docspec-docx-reader = { path = "crates/docspec-docx-reader", version = "1.5.1" }
 docspec-blocknote-writer = { path = "crates/docspec-blocknote-writer", version = "1.5.1" }
 docspec-html-writer = { path = "crates/docspec-html-writer", version = "1.5.1" }
 docspec-oxa-writer = { path = "crates/docspec-oxa-writer", version = "1.5.1" }
+docspec-pandoc-native-writer = { path = "crates/docspec-pandoc-native-writer", version = "1.5.1" }
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/docspec-cli",
   "crates/docspec-http",
   "crates/docspec-oxa-writer",
+  "crates/docspec-pandoc-native-writer",
   "crates/docspec-wasm",
 ]
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DocSpec
 
-DocSpec is a streaming document conversion library. It converts DOCX, ODT, RTF, HTML, Markdown, and BlockNote JSON — event by event, byte by byte, without buffering the world. Built in Rust for memory-conscious systems, from microcontrollers to servers.
+DocSpec is a streaming document conversion library. It converts DOCX, ODT, RTF, HTML, Markdown, BlockNote JSON, and Pandoc native — event by event, byte by byte, without buffering the world. Built in Rust for memory-conscious systems, from microcontrollers to servers.
 
 ## Philosophy
 
@@ -16,6 +16,7 @@ See our [Manifesto](MANIFESTO.md) for what we stand for: memory extremism, strea
 | HTML | ✓† | ✓† |
 | Markdown | ✓ | ✓ |
 | BlockNote JSON | ✓ | ✓ |
+| Pandoc native | — | ✓ |
 
 † HTML reader and writer currently support only `<p>` paragraph elements; other elements are silently dropped.
 

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -18,7 +18,7 @@ docspec [OPTIONS] [INPUT]
 
 - `-o, --output <FILE>` — Output file (stdout if omitted)
 - `-f, --from <FORMAT>` — Input format (auto-detected from extension if omitted). Valid values: `markdown`, `html`
-- `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted). Valid values: `blocknote`, `html`, `oxa`
+- `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted). Valid values: `blocknote`, `html`, `oxa`, `pandoc-native`
 - `--color <WHEN>` — When to use colors: `auto`, `always`, `never` (default: `auto`)
 - `-h, --help` — Print help
 - `-V, --version` — Print version
@@ -59,6 +59,13 @@ Convert Markdown to HTML:
 echo "Hello" | docspec --from markdown --to html
 ```
 
+Convert Markdown to Pandoc native syntax:
+
+```bash
+echo "Hello" | docspec --from markdown --to pandoc-native
+```
+
 `--to oxa` selects the [oxa.dev](https://oxa.dev/) JSON writer in place of BlockNote. The `.json`
 extension is ambiguous, so `--to oxa` must be explicit. HTML output is selected by `--to html`
-or auto-detected from `.html` and `.htm` output paths.
+or auto-detected from `.html` and `.htm` output paths. Pandoc native output is selected by
+`--to pandoc-native` or auto-detected from `.native` output paths.

--- a/crates/docspec-cli/src/args.rs
+++ b/crates/docspec-cli/src/args.rs
@@ -8,7 +8,7 @@ use clap::{Parser, ValueEnum};
 #[command(version = "0.1.0")]
 #[command(
     about = "Convert documents between formats using streaming event pipeline",
-    long_about = "Convert documents between formats using streaming event pipeline.\n\nSupports converting Markdown or HTML input to BlockNote JSON, HTML, or oxa.dev JSON output.\n\nNote: HTML input and output currently preserve only paragraph text. Other HTML input\nelements and non-paragraph output events (headings, lists, tables, formatting, etc.)\nare silently dropped. Use BlockNote JSON output for fuller feature coverage."
+    long_about = "Convert documents between formats using streaming event pipeline.\n\nSupports converting Markdown or HTML input to BlockNote JSON, HTML, oxa.dev JSON, or Pandoc native output.\n\nNote: HTML input and output currently preserve only paragraph text. Other HTML input\nelements and non-paragraph output events (headings, lists, tables, formatting, etc.)\nare silently dropped. Use BlockNote JSON output for fuller feature coverage."
 )]
 pub struct Cli {
     /// When to use colors.
@@ -71,6 +71,9 @@ pub enum CliOutputFormat {
     /// `oxa.dev` JSON format.
     #[value(name = "oxa")]
     Oxa,
+    /// Pandoc native block-list syntax.
+    #[value(name = "pandoc-native")]
+    PandocNative,
 }
 
 #[cfg(test)]
@@ -123,6 +126,22 @@ mod tests {
         assert!(
             matches!(cli.to, Some(CliOutputFormat::Oxa)),
             "expected CliOutputFormat::Oxa, got {:?}",
+            cli.to
+        );
+    }
+
+    #[test]
+    fn clap_accepts_pandoc_native_as_output_format() {
+        let result = Cli::try_parse_from(["docspec", "--to", "pandoc-native", "x.md"]);
+        assert!(
+            result.is_ok(),
+            "pandoc-native should be a valid output format, got error: {:?}",
+            result.as_ref().err()
+        );
+        let cli = result.unwrap_or_else(|_| std::process::abort());
+        assert!(
+            matches!(cli.to, Some(CliOutputFormat::PandocNative)),
+            "expected CliOutputFormat::PandocNative, got {:?}",
             cli.to
         );
     }

--- a/crates/docspec-cli/src/conversions.rs
+++ b/crates/docspec-cli/src/conversions.rs
@@ -21,6 +21,7 @@ impl From<CliOutputFormat> for OutputFormat {
             CliOutputFormat::Blocknote => Self::Blocknote,
             CliOutputFormat::Html => Self::Html,
             CliOutputFormat::Oxa => Self::Oxa,
+            CliOutputFormat::PandocNative => Self::PandocNative,
         }
     }
 }
@@ -61,5 +62,13 @@ mod tests {
     #[test]
     fn from_oxa_converts_to_facade_oxa() {
         assert_eq!(OutputFormat::from(CliOutputFormat::Oxa), OutputFormat::Oxa);
+    }
+
+    #[test]
+    fn from_pandoc_native_converts_to_facade_pandoc_native() {
+        assert_eq!(
+            OutputFormat::from(CliOutputFormat::PandocNative),
+            OutputFormat::PandocNative
+        );
     }
 }

--- a/crates/docspec-cli/src/format.rs
+++ b/crates/docspec-cli/src/format.rs
@@ -123,6 +123,12 @@ mod tests {
     }
 
     #[test]
+    fn detect_pandoc_native_from_native_output() {
+        let result = resolve_output_format(None, Some(Path::new("doc.native")), "err");
+        assert!(matches!(result, Ok(docspec::OutputFormat::PandocNative)));
+    }
+
+    #[test]
     fn case_insensitive_extension_output() {
         let result = resolve_output_format(None, Some(Path::new("doc.JSON")), "err");
         assert!(matches!(result, Ok(docspec::OutputFormat::Blocknote)));

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -495,6 +495,16 @@ mod tests {
     }
 
     #[test]
+    fn convert_markdown_stdin_to_pandoc_native_stdout() {
+        docspec_cmd()
+            .args(["--from", "markdown", "--to", "pandoc-native"])
+            .write_stdin("Hello world")
+            .assert()
+            .success()
+            .stdout(concat!(r#"[Para [Str "Hello world"]]"#, "\n"));
+    }
+
+    #[test]
     fn json_extension_without_to_flag_still_picks_blocknote() {
         // Regression guard: .json is ambiguous; auto-detection must NOT pick oxa.
         let input = markdown_tempfile(b"Hello\n", ".md");
@@ -513,6 +523,23 @@ mod tests {
                 r#"[{"type":"paragraph","props":{"textAlignment":"left"},"content":[{"type":"text","text":"Hello","styles":{}}],"children":[]}]"#,
                 "\n"
             )
+        );
+    }
+    #[test]
+    fn native_extension_without_to_flag_picks_pandoc_native() {
+        let input = markdown_tempfile(b"Hello\n", ".md");
+        let output = empty_tempfile(".native");
+        let output_path = output.path().to_path_buf();
+
+        docspec_cmd()
+            .arg(input.path())
+            .args(["-o", output_path.to_str().unwrap_or("")])
+            .assert()
+            .success();
+
+        assert_eq!(
+            read_output(&output_path),
+            concat!(r#"[Para [Str "Hello"]]"#, "\n")
         );
     }
 }

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -1,8 +1,8 @@
 # `docspec-http`
 
-HTTP API server for DocSpec markdown or HTML conversion to BlockNote JSON (default), HTML, or oxa.dev JSON via `Accept`.
+HTTP API server for DocSpec markdown or HTML conversion to BlockNote JSON (default), HTML, oxa.dev JSON, or Pandoc native via `Accept`.
 
-Send markdown (`Content-Type: text/markdown`) or HTML (`Content-Type: text/html`), receive BlockNote JSON (default), HTML (`Accept: text/html`), or oxa.dev JSON (`Accept: application/vnd.oxa+json`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
+Send markdown (`Content-Type: text/markdown`) or HTML (`Content-Type: text/html`), receive BlockNote JSON (default), HTML (`Accept: text/html`), oxa.dev JSON (`Accept: application/vnd.oxa+json`), or Pandoc native (`Accept: application/vnd.pandoc.native`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
 
 > **HTML is paragraph-only.** The HTML reader currently parses `<p>` elements only, and the HTML writer currently emits only paragraph events. Other HTML input elements and non-paragraph output events (headings, lists, tables, formatting, etc.) are silently dropped. See [docspec-html-reader](../docspec-html-reader/README.md) and [docspec-html-writer](../docspec-html-writer/README.md).
 
@@ -23,7 +23,7 @@ Default host is `127.0.0.1`. Default port is `3000`.
 
 | Method  | Path        | Description                                                      |
 | ------- | ----------- | ---------------------------------------------------------------- |
-| POST    | /conversion | Convert markdown or HTML to BlockNote (default), HTML, or oxa.dev JSON |
+| POST    | /conversion | Convert markdown or HTML to BlockNote (default), HTML, oxa.dev JSON, or Pandoc native |
 | OPTIONS | /conversion | Preflight / allowed methods                                      |
 | GET     | /health     | Liveness check                                                   |
 | HEAD    | /health     | Liveness check (no body)                                         |
@@ -55,6 +55,13 @@ curl -X POST \
 curl -X POST \
      -H 'Content-Type: text/markdown' \
      -H 'Accept: application/vnd.oxa+json' \
+     --data 'Hello World' \
+     http://localhost:3000/conversion
+
+# Convert markdown to Pandoc native syntax
+curl -X POST \
+     -H 'Content-Type: text/markdown' \
+     -H 'Accept: application/vnd.pandoc.native' \
      --data 'Hello World' \
      http://localhost:3000/conversion
 
@@ -97,7 +104,7 @@ All errors use RFC 7807 Problem Details JSON (`application/problem+json; charset
 | 422  | Input parse error (malformed markdown or HTML)           |
 | 500  | Internal conversion error                                |
 
-Accepted `Accept` values for `/conversion`: `text/html` (HTML), `application/vnd.oxa+json` (oxa.dev), `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json` (BlockNote alias), `application/*`, or `*/*`. Wildcards and missing `Accept` default to BlockNote for back-compat. Anything else returns 406.
+Accepted `Accept` values for `/conversion`: `text/html` (HTML), `application/vnd.oxa+json` (oxa.dev), `application/vnd.pandoc.native` (Pandoc native), `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json` (BlockNote alias), `application/*`, or `*/*`. Wildcards and missing `Accept` default to BlockNote for back-compat. Anything else returns 406.
 
 ## Deployment Notes
 
@@ -158,7 +165,7 @@ These follow Sentry's standard conventions:
 `docspec-http` does NOT send the following to Sentry:
 
 - Request bodies (markdown or HTML documents)
-- Response bodies (BlockNote JSON, HTML, or oxa.dev JSON)
+- Response bodies (BlockNote JSON, HTML, oxa.dev JSON, or Pandoc native)
 - PII (Sentry default: `send_default_pii = false`)
 - DSN values (never logged or echoed)
 
@@ -266,7 +273,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 **`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `text/html` (the request's Content-Type matched the HTML reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
 
-**`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `text/html` (conversion succeeded; output produced by the HTML writer), `application/vnd.oxa+json` (conversion succeeded; output produced by the oxa.dev writer), `none` (no output produced — any error path).
+**`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `text/html` (conversion succeeded; output produced by the HTML writer), `application/vnd.oxa+json` (conversion succeeded; output produced by the oxa.dev writer), `application/vnd.pandoc.native` (conversion succeeded; output produced by the Pandoc native writer), `none` (no output produced — any error path).
 
 **`path`**: matched route template (`/conversion`, `/health`) or `unknown` for fallback handlers
 
@@ -276,7 +283,7 @@ TLS termination, CORS headers, authentication, and rate limiting are intentional
 
 ### Cardinality Guarantees
 
-`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 4 values (`text/markdown`, `text/html`, `unsupported`, `none`). `output_mime_type` is bounded to 4 values (`application/vnd.docspec.blocknote+json`, `text/html`, `application/vnd.oxa+json`, `none`). Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
+`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 4 values (`text/markdown`, `text/html`, `unsupported`, `none`). `output_mime_type` is bounded to 5 values (`application/vnd.docspec.blocknote+json`, `text/html`, `application/vnd.oxa+json`, `application/vnd.pandoc.native`, `none`). Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
 
 ### Scrape Model
 

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -176,8 +176,8 @@ impl IntoResponse for HttpError {
                 "Not Acceptable",
                 Cow::Borrowed(
                     "Accept header must include application/vnd.docspec.blocknote+json, \
-                     application/vnd.blocknote+json, application/vnd.oxa+json, text/html, \
-                     application/*, or */*",
+                     application/vnd.blocknote+json, application/vnd.oxa+json, \
+                     application/vnd.pandoc.native, text/html, application/*, or */*",
                 ),
                 None,
             ),

--- a/crates/docspec-http/src/format.rs
+++ b/crates/docspec-http/src/format.rs
@@ -20,3 +20,6 @@ pub const OUTPUT_MIME_HTML_PRIMARY: &str = "text/html";
 
 /// The primary `oxa.dev` output MIME type returned when the `oxa.dev` writer is selected.
 pub const OUTPUT_MIME_OXA_PRIMARY: &str = "application/vnd.oxa+json";
+
+/// The primary Pandoc native output MIME type returned when the Pandoc native writer is selected.
+pub const OUTPUT_MIME_PANDOC_NATIVE_PRIMARY: &str = "application/vnd.pandoc.native";

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -21,7 +21,7 @@ pub async fn options_conversion() -> impl IntoResponse {
     )
 }
 
-/// Handle `POST /conversion` — convert markdown or HTML to `BlockNote` JSON, HTML, or `oxa.dev` JSON.
+/// Handle `POST /conversion` — convert markdown or HTML to `BlockNote` JSON, HTML, `oxa.dev` JSON, or Pandoc native.
 ///
 /// The input reader is selected by the request's `Content-Type` header (see
 /// [`crate::mime_parser::validate_content_type`]). The output writer is
@@ -216,6 +216,9 @@ async fn do_conversion(
         }
         OutputFormat::Html => HeaderValue::from_static("text/html; charset=utf-8"),
         OutputFormat::Oxa => HeaderValue::from_static("application/vnd.oxa+json; charset=utf-8"),
+        OutputFormat::PandocNative => {
+            HeaderValue::from_static("application/vnd.pandoc.native; charset=utf-8")
+        }
     };
 
     match join_result {

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -99,6 +99,9 @@ pub const OUTPUT_MIME_HTML: &str = "text/html";
 /// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `oxa.dev` JSON.
 pub const OUTPUT_MIME_OXA: &str = "application/vnd.oxa+json";
 
+/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced Pandoc native syntax.
+pub const OUTPUT_MIME_PANDOC_NATIVE: &str = "application/vnd.pandoc.native";
+
 /// Value for [`LABEL_OUTPUT_MIME_TYPE`] when no output was produced (any error path).
 pub const OUTPUT_MIME_NONE: &str = "none";
 

--- a/crates/docspec-http/src/mime_parser.rs
+++ b/crates/docspec-http/src/mime_parser.rs
@@ -5,12 +5,14 @@ use docspec::{InputFormat, OutputFormat};
 
 use crate::error::HttpError;
 use crate::format::{
-    OUTPUT_MIME_ALIAS, OUTPUT_MIME_HTML_PRIMARY, OUTPUT_MIME_OXA_PRIMARY, OUTPUT_MIME_PRIMARY,
+    OUTPUT_MIME_ALIAS, OUTPUT_MIME_HTML_PRIMARY, OUTPUT_MIME_OXA_PRIMARY,
+    OUTPUT_MIME_PANDOC_NATIVE_PRIMARY, OUTPUT_MIME_PRIMARY,
 };
 
 /// Negotiates the `Accept` header for the `/conversion` endpoint.
 ///
 /// Returns [`OutputFormat::Oxa`] for `Accept: application/vnd.oxa+json`,
+/// [`OutputFormat::PandocNative`] for `Accept: application/vnd.pandoc.native`,
 /// [`OutputFormat::Html`] for `Accept: text/html`, and [`OutputFormat::Blocknote`]
 /// for the `BlockNote` MIMEs, `application/*`, `*/*`, and missing `Accept`.
 /// Wildcards default to `BlockNote` for back-compat with pre-oxa clients. When
@@ -34,6 +36,9 @@ pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<OutputForm
         let type_part = part.trim().split(';').next().map_or("", str::trim);
         if type_part.eq_ignore_ascii_case(OUTPUT_MIME_OXA_PRIMARY) {
             return Ok(OutputFormat::Oxa);
+        }
+        if type_part.eq_ignore_ascii_case(OUTPUT_MIME_PANDOC_NATIVE_PRIMARY) {
+            return Ok(OutputFormat::PandocNative);
         }
         if type_part.eq_ignore_ascii_case(OUTPUT_MIME_HTML_PRIMARY) {
             return Ok(OutputFormat::Html);
@@ -153,6 +158,7 @@ pub fn bucket_output_mime(chosen_format: Option<OutputFormat>) -> &'static str {
         Some(OutputFormat::Blocknote) => crate::metrics::OUTPUT_MIME_BLOCKNOTE,
         Some(OutputFormat::Html) => crate::metrics::OUTPUT_MIME_HTML,
         Some(OutputFormat::Oxa) => crate::metrics::OUTPUT_MIME_OXA,
+        Some(OutputFormat::PandocNative) => crate::metrics::OUTPUT_MIME_PANDOC_NATIVE,
     }
 }
 
@@ -287,6 +293,14 @@ mod bucket_tests {
         assert_eq!(
             bucket_output_mime(Some(OutputFormat::Oxa)),
             crate::metrics::OUTPUT_MIME_OXA
+        );
+    }
+
+    #[test]
+    fn bucket_output_mime_pandoc_native_when_pandoc_native_succeeded() {
+        assert_eq!(
+            bucket_output_mime(Some(OutputFormat::PandocNative)),
+            crate::metrics::OUTPUT_MIME_PANDOC_NATIVE
         );
     }
 

--- a/crates/docspec-http/tests/http_integration.rs
+++ b/crates/docspec-http/tests/http_integration.rs
@@ -21,6 +21,7 @@ const CACHE_CONTROL: &str = "max-age=0, private, must-revalidate";
 const OUTPUT_MIME: &str = "application/vnd.docspec.blocknote+json; charset=utf-8";
 const OUTPUT_MIME_HTML: &str = "text/html; charset=utf-8";
 const OUTPUT_MIME_OXA: &str = "application/vnd.oxa+json; charset=utf-8";
+const OUTPUT_MIME_PANDOC_NATIVE: &str = "application/vnd.pandoc.native; charset=utf-8";
 const PROBLEM_JSON_CT: &str = "application/problem+json; charset=utf-8";
 const HEALTH_CT: &str = "text/plain; charset=utf-8";
 
@@ -285,7 +286,7 @@ async fn post_conversion_wrong_accept() {
             "type": "about:blank",
             "title": "Not Acceptable",
             "status": 406,
-            "detail": "Accept header must include application/vnd.docspec.blocknote+json, application/vnd.blocknote+json, application/vnd.oxa+json, text/html, application/*, or */*",
+            "detail": "Accept header must include application/vnd.docspec.blocknote+json, application/vnd.blocknote+json, application/vnd.oxa+json, application/vnd.pandoc.native, text/html, application/*, or */*",
         })
     );
 }
@@ -663,6 +664,33 @@ async fn post_conversion_oxa_happy_path() {
         body_text,
         r#"{"type":"Document","children":[{"type":"Paragraph","children":[{"type":"Text","value":"Hello world"}]}]}"#
     );
+}
+
+#[tokio::test]
+async fn post_conversion_pandoc_native_happy_path() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[
+            ("content-type", "text/markdown"),
+            ("accept", "application/vnd.pandoc.native"),
+        ],
+        Body::from("Hello world"),
+    );
+
+    let response = app().oneshot(request).await.expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME_PANDOC_NATIVE
+    );
+
+    let body_text = response_body_text(response.into_body()).await;
+    assert_eq!(body_text, r#"[Para [Str "Hello world"]]"#);
 }
 
 #[tokio::test]

--- a/crates/docspec-http/tests/metrics_conversion.rs
+++ b/crates/docspec-http/tests/metrics_conversion.rs
@@ -444,3 +444,32 @@ fn oxa_success_records_oxa_output_mime() {
         r#"docspec_conversions_total{result="success",error_class="none",input_mime_type="text/markdown",output_mime_type="application/vnd.oxa+json"} 1"#,
     );
 }
+
+// ─── Test 16: Pandoc native success records pandoc output_mime_type ───────────
+
+/// A successful conversion to Pandoc native records
+/// `output_mime_type="application/vnd.pandoc.native"` on
+/// `docspec_conversions_total`.
+#[test]
+fn pandoc_native_success_records_pandoc_native_output_mime() {
+    let rt = common::runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/conversion")
+        .header("content-type", "text/markdown")
+        .header("accept", "application/vnd.pandoc.native")
+        .body(Body::from("Hello"))
+        .unwrap();
+
+    metrics::with_local_recorder(&recorder, || rt.block_on(router.oneshot(request)))
+        .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="success",error_class="none",input_mime_type="text/markdown",output_mime_type="application/vnd.pandoc.native"} 1"#,
+    );
+}

--- a/crates/docspec-http/tests/mime_parser.rs
+++ b/crates/docspec-http/tests/mime_parser.rs
@@ -210,6 +210,24 @@ fn accept_oxa_primary_mime_returns_oxa() {
 }
 
 #[test]
+fn accept_pandoc_native_primary_mime_returns_pandoc_native() {
+    let header = HeaderValue::from_static("application/vnd.pandoc.native");
+    assert_eq!(
+        negotiate_accept(Some(&header)).unwrap(),
+        OutputFormat::PandocNative
+    );
+}
+
+#[test]
+fn accept_pandoc_native_mime_with_quality_returns_pandoc_native() {
+    let header = HeaderValue::from_static("application/vnd.pandoc.native;q=0.8");
+    assert_eq!(
+        negotiate_accept(Some(&header)).unwrap(),
+        OutputFormat::PandocNative
+    );
+}
+
+#[test]
 fn accept_list_oxa_first_returns_oxa() {
     let header = HeaderValue::from_static(
         "application/vnd.oxa+json, application/vnd.docspec.blocknote+json",

--- a/crates/docspec-pandoc-native-writer/Cargo.toml
+++ b/crates/docspec-pandoc-native-writer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "docspec-pandoc-native-writer"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+readme = "README.md"
+description = "Streaming Pandoc native (block-list) writer for DocSpec events"
+keywords = ["pandoc", "native", "writer", "streaming", "document"]
+categories = ["text-processing"]
+
+[dependencies]
+docspec-core = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/docspec-pandoc-native-writer/README.md
+++ b/crates/docspec-pandoc-native-writer/README.md
@@ -1,0 +1,66 @@
+# `docspec-pandoc-native-writer`
+
+Streaming [Pandoc native](https://pandoc.org/MANUAL.html#native-pandoc) (block-list) writer for DocSpec events.
+
+Converts a DocSpec event stream into compact Pandoc native block-list syntax, suitable for being read by Pandoc's `-f native` reader. Implements the `EventSink` trait and emits output directly to any `Write` target as events arrive — no intermediate document representation, constant memory regardless of file size.
+
+## Supported Events
+
+| DocSpec Event | Pandoc native output |
+| --- | --- |
+| `StartDocument` / `EndDocument` | `[` / `]` (block list framing) |
+| `StartParagraph` / `EndParagraph` | `Para [` / `]` |
+| `Text` (styles dropped) | `Str "..."` |
+
+## Not Supported
+
+The following DocSpec events are silently ignored:
+
+- Headings — `StartHeading` / `EndHeading`
+- Block quotes — `StartBlockQuote` / `EndBlockQuote`
+- Preformatted / code blocks — `StartPreformatted` / `EndPreformatted`
+- Images — `Image`
+- Tables — `StartTable` / `EndTable` and related events
+- Thematic breaks — `ThematicBreak`
+- List items — `StartOrderedListItem` / `StartUnorderedListItem` and related events
+- Inline links — `StartLink` / `EndLink`
+- Footnotes — `StartFootnote` / `EndFootnote` / `FootnoteRef`
+- Definition lists — `StartDefinitionList` / `StartDefinitionTerm` / `StartDefinitionDetail`
+- Captions — `StartCaption` / `EndCaption`
+- Line breaks — `LineBreak` / `SoftBreak`
+- Text formatting styles (bold, italic, etc.) — styles are accepted but silently dropped
+
+## Usage
+
+```rust
+use docspec_pandoc_native_writer::PandocNativeWriter;
+use docspec_core::{Event, EventSink, TextStyle};
+
+let mut buf = Vec::<u8>::new();
+let mut writer = PandocNativeWriter::new(&mut buf);
+
+writer.handle_event(Event::StartDocument { id: None, language: None, metadata: None })?;
+writer.handle_event(Event::StartParagraph { alignment: None, id: None })?;
+writer.handle_event(Event::Text {
+    content: "Hello, world".to_string(),
+    style: TextStyle::default(),
+})?;
+writer.handle_event(Event::EndParagraph)?;
+writer.handle_event(Event::EndDocument)?;
+writer.finish()?;
+
+let output = String::from_utf8(buf)?;
+// output == "[Para [Str \"Hello, world\"]]"
+# Ok::<(), Box<dyn std::error::Error>>(())
+```
+
+## Limitations
+
+- **Compact output only**: no pretty-printing, no indentation.
+- **No metadata wrapper**: emits block-list form `[Para [...]]`, not `Pandoc (Meta ...) [...]`.
+- **No `Space` inlines**: adjacent `Text` events produce adjacent `Str` constructors with no auto-inserted `Space`.
+- **Targets pandoc-types >= 1.23**: uses `Str Text` (not `Str String`).
+
+## License
+
+See the [repository LICENSE](../../LICENSE).

--- a/crates/docspec-pandoc-native-writer/examples/roundtrip.rs
+++ b/crates/docspec-pandoc-native-writer/examples/roundtrip.rs
@@ -1,0 +1,62 @@
+//! Roundtrip example: writes a representative event sequence to stdout in Pandoc native format.
+//!
+//! Run with: `cargo run -p docspec-pandoc-native-writer --example roundtrip`
+//! Then pipe through pandoc: `cargo run ... | pandoc -f native -t native`.
+
+use docspec_core::{Event, EventSink as _, TextStyle};
+use docspec_pandoc_native_writer::PandocNativeWriter;
+use std::io;
+
+fn main() -> io::Result<()> {
+    let stdout = io::stdout();
+    let mut writer = PandocNativeWriter::new(stdout.lock());
+
+    let events = [
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        },
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        },
+        Event::Text {
+            content: "Hello".to_string(),
+            style: TextStyle::default(),
+        },
+        Event::Text {
+            content: "\u{2019}".to_string(),
+            style: TextStyle::default(),
+        },
+        Event::EndParagraph,
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        },
+        Event::Text {
+            content: "\u{0e}Hello".to_string(),
+            style: TextStyle::default(),
+        },
+        Event::Text {
+            content: "\u{1}5".to_string(),
+            style: TextStyle::default(),
+        },
+        Event::Text {
+            content: "\u{0}".to_string(),
+            style: TextStyle::default(),
+        },
+        Event::EndParagraph,
+        Event::EndDocument,
+    ];
+
+    for event in events {
+        writer
+            .handle_event(event)
+            .map_err(|e| io::Error::other(e.to_string()))?;
+    }
+    writer
+        .finish()
+        .map_err(|e| io::Error::other(e.to_string()))?;
+    Ok(())
+}

--- a/crates/docspec-pandoc-native-writer/src/escape.rs
+++ b/crates/docspec-pandoc-native-writer/src/escape.rs
@@ -1,0 +1,232 @@
+//! Haskell string escape utilities for Pandoc native output.
+
+/// Writes a Haskell `Read`-safe string literal to `out`.
+///
+/// Emits the opening `"`, the escaped body, and the closing `"`.
+/// Streams character-by-character; never accumulates the whole output in a
+/// `String` or `Vec<u8>`.
+///
+/// # Escape table
+///
+/// | Input | Output |
+/// |-------|--------|
+/// | `"` (0x22) | `\"` |
+/// | `\` (0x5C) | `\\` |
+/// | 0x00 | `\NUL` |
+/// | 0x07 | `\a` |
+/// | 0x08 | `\b` |
+/// | 0x09 | `\t` |
+/// | 0x0A | `\n` |
+/// | 0x0B | `\v` |
+/// | 0x0C | `\f` |
+/// | 0x0D | `\r` |
+/// | 0x0E | `\SO` |
+/// | 0x0F | `\SI` |
+/// | 0x7F | `\DEL` |
+/// | 0x01–0x06, 0x10–0x1F | `\NNN` decimal |
+/// | ≥ 0x80 | raw UTF-8 bytes |
+///
+/// Gap escapes: `\SO` followed by `H` emits `\SO\&H`; `\NNN` followed by
+/// a digit `0`–`9` emits `\NNN\&<digit>`.
+pub fn write_haskell_string(out: &mut dyn std::io::Write, content: &str) -> std::io::Result<()> {
+    out.write_all(b"\"")?;
+    let mut chars = content.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '"' => out.write_all(b"\\\"")?,
+            '\\' => out.write_all(b"\\\\")?,
+            '\x00' => {
+                out.write_all(b"\\NUL")?;
+                // No gap escape needed after \NUL (not a decimal escape)
+            }
+            '\x07' => out.write_all(b"\\a")?,
+            '\x08' => out.write_all(b"\\b")?,
+            '\x09' => out.write_all(b"\\t")?,
+            '\x0A' => out.write_all(b"\\n")?,
+            '\x0B' => out.write_all(b"\\v")?,
+            '\x0C' => out.write_all(b"\\f")?,
+            '\x0D' => out.write_all(b"\\r")?,
+            '\x0E' => {
+                out.write_all(b"\\SO")?;
+                // Gap escape: \SO followed by H would be read as \SOH (U+0001)
+                if chars.peek() == Some(&'H') {
+                    out.write_all(b"\\&")?;
+                }
+            }
+            '\x0F' => out.write_all(b"\\SI")?,
+            '\x7F' => out.write_all(b"\\DEL")?,
+            c if u32::from(c) < 0x20 => {
+                // Other control chars 0x01-0x06, 0x10-0x1F: decimal escape
+                let n = u32::from(c);
+                write!(out, "\\{n}")?;
+                // Gap escape: decimal escape followed by digit would extend the number
+                if matches!(chars.peek(), Some('0'..='9')) {
+                    out.write_all(b"\\&")?;
+                }
+            }
+            c => {
+                // All other chars including non-ASCII: emit raw UTF-8
+                let mut buf: [u8; 4] = [0; 4];
+                out.write_all(c.encode_utf8(&mut buf).as_bytes())?;
+            }
+        }
+    }
+    out.write_all(b"\"")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::write_haskell_string;
+
+    fn escape(s: &str) -> String {
+        let mut buf = Vec::new();
+        write_haskell_string(&mut buf, s).unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    #[test]
+    fn empty_string() {
+        assert_eq!(escape(""), "\"\"");
+    }
+
+    #[test]
+    fn plain_ascii() {
+        assert_eq!(escape("hi"), "\"hi\"");
+    }
+
+    #[test]
+    fn escape_double_quote() {
+        assert_eq!(escape("a\"b"), "\"a\\\"b\"");
+    }
+
+    #[test]
+    fn escape_backslash() {
+        assert_eq!(escape("a\\b"), "\"a\\\\b\"");
+    }
+
+    #[test]
+    fn escape_nul() {
+        assert_eq!(escape("\x00"), "\"\\NUL\"");
+    }
+
+    #[test]
+    fn escape_bel() {
+        assert_eq!(escape("\x07"), "\"\\a\"");
+    }
+
+    #[test]
+    fn escape_bs() {
+        assert_eq!(escape("\x08"), "\"\\b\"");
+    }
+
+    #[test]
+    fn escape_ht() {
+        assert_eq!(escape("\x09"), "\"\\t\"");
+    }
+
+    #[test]
+    fn escape_lf() {
+        assert_eq!(escape("\x0A"), "\"\\n\"");
+    }
+
+    #[test]
+    fn escape_vt() {
+        assert_eq!(escape("\x0B"), "\"\\v\"");
+    }
+
+    #[test]
+    fn escape_ff() {
+        assert_eq!(escape("\x0C"), "\"\\f\"");
+    }
+
+    #[test]
+    fn escape_cr() {
+        assert_eq!(escape("\x0D"), "\"\\r\"");
+    }
+
+    #[test]
+    fn escape_so() {
+        assert_eq!(escape("\x0E"), "\"\\SO\"");
+    }
+
+    #[test]
+    fn escape_si() {
+        assert_eq!(escape("\x0F"), "\"\\SI\"");
+    }
+
+    #[test]
+    fn escape_del() {
+        assert_eq!(escape("\x7F"), "\"\\DEL\"");
+    }
+
+    #[test]
+    fn escape_ctrl_0x01() {
+        assert_eq!(escape("\x01"), "\"\\1\"");
+    }
+
+    #[test]
+    fn escape_ctrl_0x16() {
+        assert_eq!(escape("\x16"), "\"\\22\"");
+    }
+
+    #[test]
+    fn escape_ctrl_0x1f() {
+        assert_eq!(escape("\x1F"), "\"\\31\"");
+    }
+
+    #[test]
+    fn unicode_right_single_quote_raw_utf8() {
+        // U+2019 = 0xE2 0x80 0x99 in UTF-8
+        let result = escape("\u{2019}");
+        assert_eq!(result.as_bytes(), b"\"\xe2\x80\x99\"");
+    }
+
+    #[test]
+    fn gap_escape_so_followed_by_uppercase_h() {
+        // \x0E followed by 'H' -> "\SO\&H"
+        assert_eq!(escape("\x0EH"), "\"\\SO\\&H\"");
+    }
+
+    #[test]
+    fn gap_escape_so_followed_by_lowercase_h() {
+        // \x0E followed by 'h' -> "\SOh" (no gap escape; 'h' is not 'H')
+        assert_eq!(escape("\x0Eh"), "\"\\SOh\"");
+    }
+
+    #[test]
+    fn gap_escape_decimal_followed_by_digit() {
+        // 0x01 followed by '5' -> "\1\&5"
+        assert_eq!(escape("\x015"), "\"\\1\\&5\"");
+    }
+
+    #[test]
+    fn gap_escape_decimal_followed_by_non_digit() {
+        // 0x01 followed by 'a' -> "\1a" (no gap escape)
+        assert_eq!(escape("\x01a"), "\"\\1a\"");
+    }
+
+    #[test]
+    fn gap_escape_decimal_0x16_followed_by_digit() {
+        // 0x16 followed by '9' -> "\22\&9"
+        assert_eq!(escape("\x169"), "\"\\22\\&9\"");
+    }
+
+    #[test]
+    fn no_gap_escape_for_non_ascii_followed_by_digit() {
+        // U+00A0 followed by '5' -> raw UTF-8 bytes 0xC2 0xA0 then '5'
+        // No gap escape because non-ASCII emits raw bytes, not a numeric escape
+        let result = escape("\u{00A0}5");
+        assert_eq!(result.as_bytes(), b"\"\xc2\xa05\"");
+    }
+
+    #[test]
+    fn mixed_complex_string() {
+        // "hello\n\"world\"\\done\x01\x0EHellow"
+        let input = "hello\n\"world\"\\done\x01\x0EHellow";
+        let result = escape(input);
+        assert_eq!(result, "\"hello\\n\\\"world\\\"\\\\done\\1\\SO\\&Hellow\"");
+    }
+}

--- a/crates/docspec-pandoc-native-writer/src/lib.rs
+++ b/crates/docspec-pandoc-native-writer/src/lib.rs
@@ -1,0 +1,123 @@
+#![forbid(unsafe_code)]
+
+//! Streaming Pandoc native (block-list) writer for `DocSpec` events.
+
+mod escape;
+
+use docspec_core::{Event, EventSink, Result};
+use std::io::Write;
+
+/// A streaming Pandoc native writer for `DocSpec` events.
+///
+/// Writes compact Pandoc native block-list syntax directly to the underlying
+/// `Write` as events arrive. Implements [`EventSink`] for integration with
+/// the `DocSpec` pipeline.
+///
+/// # Output format
+///
+/// Emits block-list form: `[Para [Str "..."],Para [Str "..."]]`.
+/// No `Pandoc (Meta ...)` wrapper. Compact one-line output, no trailing newline.
+///
+/// # Type Parameters
+///
+/// * `W` - Any type implementing [`Write`]
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "PandocNativeWriter uses one boolean per state flag for a direct state machine; a separate state enum would be more complex without benefit"
+)]
+pub struct PandocNativeWriter<W: Write> {
+    finished: bool,
+    first_block: bool,
+    in_paragraph: bool,
+    paragraph_has_inline: bool,
+    started: bool,
+    writer: W,
+}
+
+impl<W: Write> PandocNativeWriter<W> {
+    /// Creates a new `PandocNativeWriter` that writes to the given writer.
+    #[inline]
+    #[must_use]
+    pub fn new(writer: W) -> Self {
+        Self {
+            finished: false,
+            first_block: true,
+            in_paragraph: false,
+            paragraph_has_inline: false,
+            started: false,
+            writer,
+        }
+    }
+}
+
+impl<W: Write> EventSink for PandocNativeWriter<W> {
+    /// Finalizes the output.
+    ///
+    /// If the document was started but not finished (i.e., `EndDocument` was never
+    /// received), performs a best-effort close: closes any open paragraph and emits
+    /// the closing `]` for the block list.
+    #[inline]
+    fn finish(mut self) -> Result<()> {
+        if self.started && !self.finished {
+            if self.in_paragraph {
+                self.writer.write_all(b"]")?;
+            }
+            self.writer.write_all(b"]")?;
+        }
+        self.writer.flush()?;
+        Ok(())
+    }
+
+    /// Handles a single `DocSpec` event.
+    ///
+    /// Only `StartDocument`, `EndDocument`, `StartParagraph`, `EndParagraph`,
+    /// and `Text` events produce output. All other events are silently ignored.
+    #[inline]
+    fn handle_event(&mut self, event: Event) -> Result<()> {
+        match event {
+            Event::StartDocument { .. } => {
+                if !self.started && !self.finished {
+                    self.writer.write_all(b"[")?;
+                    self.started = true;
+                }
+            }
+            Event::EndDocument => {
+                if self.started && !self.finished {
+                    if self.in_paragraph {
+                        self.writer.write_all(b"]")?;
+                        self.in_paragraph = false;
+                    }
+                    self.writer.write_all(b"]")?;
+                    self.finished = true;
+                }
+            }
+            Event::StartParagraph { .. } => {
+                if self.started && !self.finished && !self.in_paragraph {
+                    if !self.first_block {
+                        self.writer.write_all(b",")?;
+                    }
+                    self.writer.write_all(b"Para [")?;
+                    self.in_paragraph = true;
+                    self.paragraph_has_inline = false;
+                    self.first_block = false;
+                }
+            }
+            Event::EndParagraph => {
+                if self.in_paragraph {
+                    self.writer.write_all(b"]")?;
+                    self.in_paragraph = false;
+                }
+            }
+            Event::Text { content, .. } if self.in_paragraph => {
+                if self.paragraph_has_inline {
+                    self.writer.write_all(b",")?;
+                }
+                self.writer.write_all(b"Str ")?;
+                escape::write_haskell_string(&mut self.writer, &content)?;
+                self.paragraph_has_inline = true;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -1,0 +1,338 @@
+//! Integration tests for `PandocNativeWriter`.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use docspec_core::{Event, TextStyle};
+use docspec_pandoc_native_writer::PandocNativeWriter;
+use std::io::{self, Write};
+
+/// A writer that always fails on write.
+struct FailingWriter;
+
+impl Write for FailingWriter {
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+        Err(io::Error::other("write failed"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::panic, clippy::panic_in_result_fn, clippy::unwrap_in_result)]
+
+    use super::*;
+    use docspec_core::EventSink as _;
+
+    fn run(events: impl IntoIterator<Item = Event>) -> String {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer = PandocNativeWriter::new(&mut buf);
+        for event in events {
+            writer.handle_event(event).unwrap();
+        }
+        writer.finish().unwrap();
+        String::from_utf8(buf).unwrap()
+    }
+
+    fn try_run(events: impl IntoIterator<Item = Event>) -> docspec_core::Result<String> {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer = PandocNativeWriter::new(&mut buf);
+        for event in events {
+            writer.handle_event(event)?;
+        }
+        writer.finish()?;
+        Ok(String::from_utf8(buf).unwrap())
+    }
+
+    fn start_doc() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    fn start_para() -> Event {
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        }
+    }
+
+    fn text(s: &str) -> Event {
+        Event::Text {
+            content: s.to_string(),
+            style: TextStyle::default(),
+        }
+    }
+
+    #[test]
+    fn empty_document_emits_empty_list() {
+        assert_eq!(run([start_doc(), Event::EndDocument]), "[]");
+    }
+
+    #[test]
+    fn single_empty_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para []]"
+        );
+    }
+
+    #[test]
+    fn single_text_in_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("hi"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"hi\"]]"
+        );
+    }
+
+    #[test]
+    fn two_texts_in_one_paragraph_emit_two_strs() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\",Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn two_paragraphs_separated_by_comma() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::EndParagraph,
+                start_para(),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\"],Para [Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn text_styles_ignored() {
+        let bold_text = Event::Text {
+            content: "x".to_string(),
+            style: TextStyle::default().bold().italic(),
+        };
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                bold_text,
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"x\"]]"
+        );
+    }
+
+    #[test]
+    fn text_outside_paragraph_ignored() {
+        assert_eq!(run([start_doc(), text("orphan"), Event::EndDocument]), "[]");
+    }
+
+    #[test]
+    fn text_before_startdocument_ignored() {
+        assert_eq!(run([text("a"), start_doc(), Event::EndDocument]), "[]");
+    }
+
+    #[test]
+    fn events_after_enddocument_ignored() {
+        assert_eq!(
+            run([
+                start_doc(),
+                Event::EndDocument,
+                start_para(),
+                text("x"),
+                Event::EndParagraph
+            ]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn double_start_document_is_noop() {
+        assert_eq!(run([start_doc(), start_doc(), Event::EndDocument]), "[]");
+    }
+
+    #[test]
+    fn orphan_end_paragraph_is_noop() {
+        assert_eq!(
+            run([start_doc(), Event::EndParagraph, Event::EndDocument]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn orphan_end_document_is_noop() {
+        assert_eq!(run([Event::EndDocument]), "");
+    }
+
+    #[test]
+    fn ignored_events_do_not_break_structure() {
+        assert_eq!(
+            run([
+                start_doc(),
+                Event::StartHeading { level: 1, id: None },
+                Event::EndHeading,
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::ThematicBreak { id: None },
+                Event::EndDocument
+            ]),
+            "[Para [Str \"x\"]]"
+        );
+    }
+
+    #[test]
+    fn escaped_text_quotes_and_backslashes() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a\"b\\c"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\\\"b\\\\c\"]]"
+        );
+    }
+
+    #[test]
+    fn escaped_text_newline_and_tab() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a\nb\tc"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\\nb\\tc\"]]"
+        );
+    }
+
+    #[test]
+    fn escaped_text_nul_byte() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("\u{0}"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"\\NUL\"]]"
+        );
+    }
+
+    #[test]
+    fn escaped_text_unicode_raw_utf8() {
+        let result = run([
+            start_doc(),
+            start_para(),
+            text("it\u{2019}s"),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        let expected_bytes: Vec<u8> = b"[Para [Str \"it\xe2\x80\x99s\"]]".to_vec();
+        assert_eq!(result.as_bytes(), expected_bytes.as_slice());
+    }
+
+    #[test]
+    fn gap_escape_so_followed_by_h() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("\u{0e}H"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"\\SO\\&H\"]]"
+        );
+    }
+
+    #[test]
+    fn gap_escape_decimal_followed_by_digit() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("\u{1}5"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"\\1\\&5\"]]"
+        );
+    }
+
+    #[test]
+    fn non_ascii_emits_raw_utf8_no_gap_escape() {
+        let result = run([
+            start_doc(),
+            start_para(),
+            text("\u{a0}5"),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        let expected_bytes: Vec<u8> = b"[Para [Str \"\xc2\xa05\"]]".to_vec();
+        assert_eq!(result.as_bytes(), expected_bytes.as_slice());
+    }
+
+    #[test]
+    fn finish_without_enddocument_best_effort_closes() {
+        let mut buf: Vec<u8> = Vec::new();
+        let mut writer = PandocNativeWriter::new(&mut buf);
+        writer.handle_event(start_doc()).unwrap();
+        writer.handle_event(start_para()).unwrap();
+        writer.handle_event(text("hi")).unwrap();
+        writer.finish().unwrap();
+        let output = String::from_utf8(buf).unwrap();
+        assert_eq!(output, "[Para [Str \"hi\"]]");
+    }
+
+    #[test]
+    fn write_error_propagates() {
+        let mut writer = PandocNativeWriter::new(FailingWriter);
+        let result = writer.handle_event(start_doc());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn try_run_returns_ok_for_valid_events() {
+        let result = try_run([
+            start_doc(),
+            start_para(),
+            text("ok"),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(result.unwrap(), "[Para [Str \"ok\"]]");
+    }
+}

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -10,7 +10,8 @@ keywords = ["document", "conversion", "streaming"]
 categories = ["parsing", "encoding"]
 
 [features]
-default = []
+# Default features: markdown reader, blocknote writer, and pandoc native writer.
+default = ["markdown", "blocknote", "pandoc-native"]
 
 # Format readers (event sources).
 markdown = ["dep:docspec-markdown-reader"]
@@ -21,17 +22,19 @@ docx = ["dep:docspec-docx-reader"]
 blocknote-writer = ["dep:docspec-blocknote-writer"]
 oxa-writer = ["dep:docspec-oxa-writer"]
 html-writer = ["dep:docspec-html-writer"]
+pandoc-native-writer = ["dep:docspec-pandoc-native-writer"]
 
 # Lower-level primitives for implementing custom writers.
 json = ["dep:docspec-json"]
 
 # Convenience meta-features.
-# `blocknote`/`oxa` currently enable only the writer; once their readers exist
+# `blocknote`/`oxa`/`pandoc-native` currently enable only the writer; once their readers exist
 # the meta will expand to enable both directions.
 blocknote = ["blocknote-writer"]
 oxa = ["oxa-writer"]
+pandoc-native = ["pandoc-native-writer"]
 all-readers = ["markdown", "html", "docx"]
-all-writers = ["blocknote-writer", "oxa-writer", "html-writer"]
+all-writers = ["blocknote-writer", "oxa-writer", "html-writer", "pandoc-native-writer"]
 all-libs = ["json"]
 full = ["all-readers", "all-writers", "all-libs"]
 
@@ -44,6 +47,7 @@ docspec-html-reader = { workspace = true, optional = true }
 docspec-docx-reader = { workspace = true, optional = true }
 docspec-oxa-writer = { workspace = true, optional = true }
 docspec-html-writer = { workspace = true, optional = true }
+docspec-pandoc-native-writer = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -51,6 +51,7 @@ dispatched through the text-based `AnyReader` factory. Construct it directly wit
 | `blocknote-writer` | BlockNote JSON         | `docspec-blocknote-writer` |
 | `oxa-writer`       | oxa.dev JSON           | `docspec-oxa-writer`       |
 | `html-writer`      | HTML (paragraphs only) | `docspec-html-writer`      |
+| `pandoc-native-writer` | Pandoc native block list | `docspec-pandoc-native-writer` |
 
 ### Primitives
 
@@ -64,12 +65,13 @@ dispatched through the text-based `AnyReader` factory. Construct it directly wit
 | ------------- | ------------------------------------------------------------- |
 | `blocknote`   | BlockNote in both directions (writer only until reader lands) |
 | `oxa`         | oxa.dev in both directions (writer only until reader lands)   |
+| `pandoc-native` | Pandoc native in both directions (writer only until reader lands) |
 | `all-readers` | All reader features                                           |
 | `all-writers` | All writer features                                           |
 | `all-libs`    | All primitive/library features (currently `json`)             |
 | `full`        | Everything (`all-readers` + `all-writers` + `all-libs`)       |
 
-No features are enabled by default — opt into what you need.
+Default features are `markdown`, `blocknote`, and `pandoc-native`; disable default features when you need the smallest possible dependency footprint.
 
 ## Documentation
 

--- a/crates/docspec/src/factory/writer.rs
+++ b/crates/docspec/src/factory/writer.rs
@@ -10,6 +10,8 @@ use docspec_blocknote_writer::BlockNoteWriter;
 use docspec_html_writer::HtmlWriter;
 #[cfg(feature = "oxa-writer")]
 use docspec_oxa_writer::OxaWriter;
+#[cfg(feature = "pandoc-native-writer")]
+use docspec_pandoc_native_writer::PandocNativeWriter;
 
 use crate::format::OutputFormat;
 
@@ -29,6 +31,8 @@ enum AnyWriterInner<'a, W: Write> {
     Html(HtmlWriter<W>),
     #[cfg(feature = "oxa-writer")]
     Oxa(OxaWriter<W>),
+    #[cfg(feature = "pandoc-native-writer")]
+    PandocNative(PandocNativeWriter<W>),
     #[cfg(not(feature = "blocknote-writer"))]
     _Phantom(std::marker::PhantomData<&'a W>),
 }
@@ -41,7 +45,8 @@ impl<'a, W: Write> AnyWriter<'a, W> {
         #[cfg(not(any(
             feature = "blocknote-writer",
             feature = "oxa-writer",
-            feature = "html-writer"
+            feature = "html-writer",
+            feature = "pandoc-native-writer"
         )))]
         {
             drop(writer);
@@ -50,7 +55,8 @@ impl<'a, W: Write> AnyWriter<'a, W> {
         #[cfg(any(
             feature = "blocknote-writer",
             feature = "oxa-writer",
-            feature = "html-writer"
+            feature = "html-writer",
+            feature = "pandoc-native-writer"
         ))]
         {
             let inner = match format {
@@ -60,6 +66,10 @@ impl<'a, W: Write> AnyWriter<'a, W> {
                 OutputFormat::Html => AnyWriterInner::Html(HtmlWriter::new(writer)),
                 #[cfg(feature = "oxa-writer")]
                 OutputFormat::Oxa => AnyWriterInner::Oxa(OxaWriter::new(writer)),
+                #[cfg(feature = "pandoc-native-writer")]
+                OutputFormat::PandocNative => {
+                    AnyWriterInner::PandocNative(PandocNativeWriter::new(writer))
+                }
             };
             Self {
                 inner: StackTrackingSink::new(inner),
@@ -69,8 +79,9 @@ impl<'a, W: Write> AnyWriter<'a, W> {
 
     /// Construct a writer with an asset provider, where supported.
     ///
-    /// Writers that do not consume an [`AssetProvider`] (currently `OxaWriter`
-    /// and `HtmlWriter`) silently ignore the `assets` argument; the resulting
+    /// Writers that do not consume an [`AssetProvider`] (currently `OxaWriter`,
+    /// `HtmlWriter`, and `PandocNativeWriter`) silently ignore the `assets` argument;
+    /// the resulting
     /// writer behaves identically to [`AnyWriter::new`].
     #[inline]
     #[must_use]
@@ -78,7 +89,8 @@ impl<'a, W: Write> AnyWriter<'a, W> {
         #[cfg(not(any(
             feature = "blocknote-writer",
             feature = "oxa-writer",
-            feature = "html-writer"
+            feature = "html-writer",
+            feature = "pandoc-native-writer"
         )))]
         {
             drop(writer);
@@ -88,7 +100,8 @@ impl<'a, W: Write> AnyWriter<'a, W> {
         #[cfg(any(
             feature = "blocknote-writer",
             feature = "oxa-writer",
-            feature = "html-writer"
+            feature = "html-writer",
+            feature = "pandoc-native-writer"
         ))]
         {
             let inner = match format {
@@ -105,6 +118,11 @@ impl<'a, W: Write> AnyWriter<'a, W> {
                 OutputFormat::Oxa => {
                     let _ = assets;
                     AnyWriterInner::Oxa(OxaWriter::new(writer))
+                }
+                #[cfg(feature = "pandoc-native-writer")]
+                OutputFormat::PandocNative => {
+                    let _ = assets;
+                    AnyWriterInner::PandocNative(PandocNativeWriter::new(writer))
                 }
             };
             Self {
@@ -123,6 +141,8 @@ impl<W: Write> EventSink for AnyWriterInner<'_, W> {
             Self::Html(w) => w.finish(),
             #[cfg(feature = "oxa-writer")]
             Self::Oxa(w) => w.finish(),
+            #[cfg(feature = "pandoc-native-writer")]
+            Self::PandocNative(w) => w.finish(),
             #[cfg(not(feature = "blocknote-writer"))]
             Self::_Phantom(_) => Ok(()),
         }
@@ -136,6 +156,8 @@ impl<W: Write> EventSink for AnyWriterInner<'_, W> {
             Self::Html(w) => w.handle_event(event),
             #[cfg(feature = "oxa-writer")]
             Self::Oxa(w) => w.handle_event(event),
+            #[cfg(feature = "pandoc-native-writer")]
+            Self::PandocNative(w) => w.handle_event(event),
             #[cfg(not(feature = "blocknote-writer"))]
             Self::_Phantom(_) => {
                 let _ = event;
@@ -166,14 +188,16 @@ mod tests {
     #[cfg(any(
         feature = "blocknote-writer",
         feature = "html-writer",
-        feature = "oxa-writer"
+        feature = "oxa-writer",
+        feature = "pandoc-native-writer"
     ))]
     use docspec_core::{Event, EventSink as _};
 
     #[cfg(any(
         feature = "blocknote-writer",
         feature = "html-writer",
-        feature = "oxa-writer"
+        feature = "oxa-writer",
+        feature = "pandoc-native-writer"
     ))]
     use super::{AnyWriter, OutputFormat};
 
@@ -247,5 +271,23 @@ mod tests {
         assert!(writer.handle_event(Event::EndDocument).is_ok());
         assert!(writer.finish().is_ok());
         assert_eq!(buf, b"<html><body></body></html>");
+    }
+
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn with_assets_ignores_provider_for_pandoc_native_writer() {
+        let assets = NullAssets;
+        let mut buf = Vec::new();
+        let mut writer = AnyWriter::with_assets(OutputFormat::PandocNative, &mut buf, &assets);
+        assert!(writer
+            .handle_event(Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            })
+            .is_ok());
+        assert!(writer.handle_event(Event::EndDocument).is_ok());
+        assert!(writer.finish().is_ok());
+        assert_eq!(buf, b"[]");
     }
 }

--- a/crates/docspec/src/format.rs
+++ b/crates/docspec/src/format.rs
@@ -25,6 +25,9 @@ pub enum OutputFormat {
     /// `oxa.dev` JSON. Available when the `oxa` feature is enabled.
     #[cfg(feature = "oxa-writer")]
     Oxa,
+    /// Pandoc native block-list syntax. Available when the `pandoc-native` feature is enabled.
+    #[cfg(feature = "pandoc-native-writer")]
+    PandocNative,
 }
 
 /// Detect the input format from a file path's extension.
@@ -61,6 +64,8 @@ pub fn detect_output_format(path: &Path) -> Option<OutputFormat> {
         "json" => Some(OutputFormat::Blocknote),
         #[cfg(feature = "html-writer")]
         "html" | "htm" => Some(OutputFormat::Html),
+        #[cfg(feature = "pandoc-native-writer")]
+        "native" => Some(OutputFormat::PandocNative),
         _ => None,
     }
 }

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -29,6 +29,7 @@
 //! | `blocknote-writer`  | `BlockNote` JSON        | [`writers::BlockNoteWriter`]  |
 //! | `oxa-writer`        | `oxa.dev` JSON          | `writers::OxaWriter`          |
 //! | `html-writer`       | HTML (paragraphs only)  | `writers::HtmlWriter`         |
+//! | `pandoc-native-writer` | Pandoc native block list | `writers::PandocNativeWriter` |
 //!
 //! ## Primitives
 //!
@@ -42,6 +43,7 @@
 //! |---------------|------------------------------------------------------------------|
 //! | `blocknote`   | `BlockNote` in both directions (writer only until reader lands)  |
 //! | `oxa`         | `oxa.dev` in both directions (writer only until reader lands)    |
+//! | `pandoc-native` | Pandoc native in both directions (writer only until reader lands) |
 //! | `all-readers` | All reader features                                              |
 //! | `all-writers` | All writer features                                              |
 //! | `all-libs`    | All primitive/library features (currently `json`)                |
@@ -146,6 +148,13 @@ pub mod writers {
     #[cfg(feature = "html-writer")]
     #[cfg_attr(docsrs, doc(cfg(feature = "html-writer")))]
     pub use docspec_html_writer::HtmlWriter;
+
+    /// Streaming Pandoc native block-list writer. Available when the
+    /// `pandoc-native-writer` feature is enabled (either directly, or via the
+    /// `pandoc-native` meta feature).
+    #[cfg(feature = "pandoc-native-writer")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "pandoc-native-writer")))]
+    pub use docspec_pandoc_native_writer::PandocNativeWriter;
 }
 
 /// Format detection and conversion helpers.

--- a/crates/docspec/tests/factory_writer.rs
+++ b/crates/docspec/tests/factory_writer.rs
@@ -7,20 +7,23 @@ mod tests {
     #[cfg(any(
         feature = "blocknote-writer",
         feature = "oxa-writer",
-        feature = "html-writer"
+        feature = "html-writer",
+        feature = "pandoc-native-writer"
     ))]
     use docspec::{AnyWriter, OutputFormat, TextStyle};
     #[cfg(any(
         feature = "blocknote-writer",
         feature = "oxa-writer",
-        feature = "html-writer"
+        feature = "html-writer",
+        feature = "pandoc-native-writer"
     ))]
     use docspec_core::{Event, EventSink};
 
     #[cfg(any(
         feature = "blocknote-writer",
         feature = "oxa-writer",
-        feature = "html-writer"
+        feature = "html-writer",
+        feature = "pandoc-native-writer"
     ))]
     fn start_document() -> Event {
         Event::StartDocument {
@@ -33,7 +36,8 @@ mod tests {
     #[cfg(any(
         feature = "blocknote-writer",
         feature = "oxa-writer",
-        feature = "html-writer"
+        feature = "html-writer",
+        feature = "pandoc-native-writer"
     ))]
     fn start_paragraph() -> Event {
         Event::StartParagraph {
@@ -45,7 +49,8 @@ mod tests {
     #[cfg(any(
         feature = "blocknote-writer",
         feature = "oxa-writer",
-        feature = "html-writer"
+        feature = "html-writer",
+        feature = "pandoc-native-writer"
     ))]
     fn text(content: &str) -> Event {
         Event::Text {
@@ -168,6 +173,58 @@ mod tests {
         fn check<K: EventSink>(_: K) {}
         let output = Vec::new();
         check(AnyWriter::new(OutputFormat::Oxa, output));
+    }
+
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn pandoc_native_dispatch_writes_expected_bytes_simple() {
+        let mut output = Vec::new();
+        let mut writer = AnyWriter::new(OutputFormat::PandocNative, &mut output);
+        writer
+            .handle_event(start_document())
+            .expect("handle_event failed");
+        writer
+            .handle_event(start_paragraph())
+            .expect("handle_event failed");
+        writer
+            .handle_event(text("hello"))
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndParagraph)
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndDocument)
+            .expect("handle_event failed");
+        writer.finish().expect("finish failed");
+        let native = String::from_utf8(output).expect("not utf8");
+        assert_eq!(native, r#"[Para [Str "hello"]]"#);
+    }
+
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn pandoc_native_stack_tracking_normalizes_bare_text() {
+        let mut output = Vec::new();
+        let mut writer = AnyWriter::new(OutputFormat::PandocNative, &mut output);
+        writer
+            .handle_event(start_document())
+            .expect("handle_event failed");
+        writer
+            .handle_event(text("bare text"))
+            .expect("handle_event failed");
+        writer
+            .handle_event(Event::EndDocument)
+            .expect("handle_event failed");
+        writer.finish().expect("finish failed");
+        let native = String::from_utf8(output).expect("not utf8");
+        assert_eq!(native, r#"[Para [Str "bare text"]]"#);
+    }
+
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn pandoc_native_assert_is_event_sink() {
+        fn check<K: EventSink>(_: K) {}
+        let output = Vec::new();
+        check(AnyWriter::new(OutputFormat::PandocNative, output));
     }
 
     #[cfg(feature = "html-writer")]

--- a/crates/docspec/tests/format.rs
+++ b/crates/docspec/tests/format.rs
@@ -90,6 +90,20 @@ mod tests {
         assert_eq!(result, Some(docspec::OutputFormat::Html));
     }
 
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn detect_pandoc_native_output_from_native() {
+        let result = docspec::detect_output_format(Path::new("file.native"));
+        assert_eq!(result, Some(docspec::OutputFormat::PandocNative));
+    }
+
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn case_insensitive_native_output() {
+        let result = docspec::detect_output_format(Path::new("file.NATIVE"));
+        assert_eq!(result, Some(docspec::OutputFormat::PandocNative));
+    }
+
     #[test]
     fn unknown_extension_returns_none() {
         let result = docspec::detect_input_format(Path::new("file.txt"));
@@ -154,6 +168,22 @@ mod tests {
         assert_eq!(docspec::OutputFormat::Html, docspec::OutputFormat::Html);
     }
 
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn output_format_debug_pandoc_native() {
+        let debug_str = format!("{:?}", docspec::OutputFormat::PandocNative);
+        assert_eq!(debug_str, "PandocNative");
+    }
+
+    #[cfg(feature = "pandoc-native-writer")]
+    #[test]
+    fn output_format_eq_pandoc_native() {
+        assert_eq!(
+            docspec::OutputFormat::PandocNative,
+            docspec::OutputFormat::PandocNative
+        );
+    }
+
     #[cfg(all(feature = "blocknote-writer", feature = "html-writer"))]
     #[test]
     fn output_format_ne_html_blocknote() {
@@ -167,6 +197,15 @@ mod tests {
     #[test]
     fn output_format_ne_html_oxa() {
         assert_ne!(docspec::OutputFormat::Html, docspec::OutputFormat::Oxa);
+    }
+
+    #[cfg(all(feature = "blocknote-writer", feature = "pandoc-native-writer"))]
+    #[test]
+    fn output_format_ne_pandoc_native_blocknote() {
+        assert_ne!(
+            docspec::OutputFormat::PandocNative,
+            docspec::OutputFormat::Blocknote
+        );
     }
 
     #[cfg(feature = "markdown")]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streaming Pandoc native writer and first-class output format (including CLI option and .native autodetection); enabled as a feature and included in default writer set.

* **Documentation**
  * Updated multiple READMEs and CLI docs to document the Pandoc native output, usage, and limitations.

* **HTTP / API**
  * Added Pandoc-native content-type support, Accept negotiation, response Content-Type, and metrics labeling.

* **Tests**
  * Extensive unit and integration tests covering serialization, escaping, CLI, HTTP, and metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->