### PR TITLE
feat: unify reader constructors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,6 +578,7 @@ version = "1.5.1"
 dependencies = [
  "docspec-core",
  "pulldown-cmark",
+ "self_cell",
 ]
 
 [[package]]
@@ -2330,6 +2331,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ docspec-blocknote-writer = { path = "crates/docspec-blocknote-writer", version =
 docspec-html-writer = { path = "crates/docspec-html-writer", version = "1.5.1" }
 docspec-oxa-writer = { path = "crates/docspec-oxa-writer", version = "1.5.1" }
 docspec-pandoc-native-writer = { path = "crates/docspec-pandoc-native-writer", version = "1.5.1" }
+self_cell = "1.2"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"
@@ -213,4 +214,3 @@ publish-prereleases = false
 
 # Announcement settings
 announce-in-tag = true
-

--- a/crates/docspec-cli/src/main.rs
+++ b/crates/docspec-cli/src/main.rs
@@ -22,7 +22,7 @@ fn run_pipeline<W: Write>(
     output_format: docspec::OutputFormat,
     output: W,
 ) -> Result<()> {
-    let reader = AnyReader::new(input_format, content);
+    let reader = AnyReader::from_str(input_format, content);
     let sink = AnyWriter::new(output_format, output);
     docspec_core::pipe(reader, sink).map_err(Into::into)
 }

--- a/crates/docspec-html-reader/README.md
+++ b/crates/docspec-html-reader/README.md
@@ -1,5 +1,55 @@
 # docspec-html-reader
 
-HTML to DocSpec event stream reader.
+Streaming HTML to DocSpec event stream reader.
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation.
+See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation,
+architecture, and the event protocol.
+
+## Supported Elements
+
+- Paragraphs (`<p>`)
+- Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `EndParagraph`, `EndDocument`
+
+## Out of Scope (silently dropped)
+
+All other HTML elements are silently ignored. Text content inside inline elements
+(e.g., `<strong>`, `<em>`) is preserved as `Text` events, but the formatting
+structure is dropped.
+
+## Streaming Guarantee
+
+`HtmlReader` streams its source via `html5gum::IoReader`'s 16 KB sliding-window
+buffer. Memory usage is constant regardless of document size — the document need
+not fit in memory. Both `from_str` and `from_reader` use this streaming path
+internally.
+
+## Quick Start
+
+```rust
+use docspec_html_reader::{HtmlReader, EventSource};
+
+let mut reader = HtmlReader::from_str("<p>Hello world</p>");
+while let Some(event) = reader.next_event()? {
+    println!("{event:?}");
+}
+# Ok::<(), docspec_core::Error>(())
+```
+
+From a file or any `Read + Seek` source:
+
+```rust,no_run
+use std::fs::File;
+use docspec_html_reader::{HtmlReader, EventSource};
+
+let file = File::open("document.html")?;
+let mut reader = HtmlReader::from_reader(file)?;
+while let Some(event) = reader.next_event()? {
+    println!("{event:?}");
+}
+# Ok::<(), docspec_core::Error>(())
+```
+
+## See Also
+
+- [MANIFESTO.md](../../MANIFESTO.md) — philosophy and values
+- [EVENTS.md](../../EVENTS.md) — event types and well-formedness rules

--- a/crates/docspec-html-reader/src/lib.rs
+++ b/crates/docspec-html-reader/src/lib.rs
@@ -11,7 +11,7 @@
 //! use docspec_html_reader::{HtmlReader, EventSource};
 //!
 //! let html = "<p>Hello world</p>";
-//! let mut reader = HtmlReader::new(html);
+//! let mut reader = HtmlReader::from_str(html);
 //!
 //! while let Some(event) = reader.next_event()? {
 //!     println!("{event:?}");
@@ -28,14 +28,22 @@
 //! All other HTML elements are silently ignored. Text content inside inline
 //! elements (e.g., `<strong>`, `<em>`) is preserved as `Text` events, but
 //! the formatting structure is dropped.
+//!
+//! # Streaming
+//!
+//! `HtmlReader` streams its source via `html5gum::IoReader`'s 16 KB sliding-window
+//! buffer. Memory usage is constant regardless of document size — the document need
+//! not fit in memory. Both [`HtmlReader::from_str`] and [`HtmlReader::from_reader`]
+//! use this streaming path internally.
 
 extern crate alloc;
 
 use alloc::collections::VecDeque;
+use std::io::{Cursor, Read, Seek};
 
 pub use docspec_core::EventSource;
 use docspec_core::{Event, Result, TextStyle};
-use html5gum::{StringReader, Tokenizer};
+use html5gum::{IoReader, Tokenizer};
 
 /// Document processing phase.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -59,13 +67,13 @@ enum Phase {
 /// ```
 /// use docspec_html_reader::{HtmlReader, EventSource};
 ///
-/// let mut reader = HtmlReader::new("<p>hello</p>");
+/// let mut reader = HtmlReader::from_str("<p>hello</p>");
 /// while let Some(event) = reader.next_event()? {
 ///     // Process events...
 /// }
 /// # Ok::<(), docspec_core::Error>(())
 /// ```
-pub struct HtmlReader<'a> {
+pub struct HtmlReader {
     /// Whether the reader is currently inside a `<p>` element.
     in_paragraph: bool,
     /// Document processing phase.
@@ -73,13 +81,56 @@ pub struct HtmlReader<'a> {
     /// Queue of `DocSpec` events to emit.
     queue: VecDeque<Event>,
     /// The html5gum tokenizer iterator.
-    tokens: Tokenizer<StringReader<'a>>,
+    tokens: Tokenizer<IoReader<Box<dyn Read + Send>>>,
 }
 
-impl<'a> HtmlReader<'a> {
+impl HtmlReader {
     /// Pops the front event from the queue, if any.
     fn drain_queue(&mut self) -> Option<Event> {
         self.queue.pop_front()
+    }
+
+    fn from_boxed_reader(reader: Box<dyn Read + Send>) -> Self {
+        Self {
+            in_paragraph: false,
+            phase: Phase::NotStarted,
+            queue: VecDeque::new(),
+            tokens: Tokenizer::new(IoReader::new(reader)),
+        }
+    }
+
+    /// Creates an `HtmlReader` from any `Read + Seek` source.
+    ///
+    /// The source is streamed via `html5gum::IoReader`'s 16 KB sliding-window
+    /// buffer. Memory usage is constant regardless of document size.
+    ///
+    /// The `Seek` bound is required for API symmetry with other `DocSpec` readers
+    /// (e.g., `DocxReader`), even though `html5gum::IoReader` only needs `Read`.
+    ///
+    /// # Errors
+    ///
+    /// This constructor does not read from the source eagerly and therefore
+    /// currently cannot fail.
+    #[inline]
+    pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
+        let boxed: Box<dyn Read + Send> = Box::new(reader);
+        Ok(Self::from_boxed_reader(boxed))
+    }
+
+    /// Creates an `HtmlReader` from a string slice.
+    ///
+    /// The input bytes are copied into an owned `Vec<u8>` and streamed via
+    /// `html5gum::IoReader`'s 16 KB sliding-window buffer.
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "Public API requires an infallible constructor named from_str."
+    )]
+    #[inline]
+    #[must_use]
+    pub fn from_str(input: &str) -> Self {
+        let bytes: Vec<u8> = input.as_bytes().to_vec();
+        let reader: Box<dyn Read + Send> = Box::new(Cursor::new(bytes));
+        Self::from_boxed_reader(reader)
     }
 
     /// Translates an end tag token into queued events.
@@ -139,32 +190,9 @@ impl<'a> HtmlReader<'a> {
         }
         Ok(())
     }
-
-    /// Creates a new `HtmlReader` from the given HTML string.
-    ///
-    /// The reader will emit `StartDocument` as its first event and `EndDocument`
-    /// as its last event, with the parsed content events in between.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use docspec_html_reader::HtmlReader;
-    ///
-    /// let reader = HtmlReader::new("<p>Hello World</p>");
-    /// ```
-    #[inline]
-    #[must_use]
-    pub fn new(input: &'a str) -> Self {
-        Self {
-            in_paragraph: false,
-            phase: Phase::NotStarted,
-            queue: VecDeque::new(),
-            tokens: Tokenizer::new(input),
-        }
-    }
 }
 
-impl EventSource for HtmlReader<'_> {
+impl EventSource for HtmlReader {
     #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
         loop {
@@ -210,10 +238,20 @@ impl EventSource for HtmlReader<'_> {
                                 });
                             }
                         },
-                        Err(infallible) => match infallible {},
+                        Err(source) => return Err(docspec_core::Error::Io { source }),
                     }
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod send_static_assertions {
+    fn assert_send_static<T: Send + 'static>() {}
+
+    #[test]
+    fn html_reader_is_send_static() {
+        assert_send_static::<crate::HtmlReader>();
     }
 }

--- a/crates/docspec-html-reader/tests/reader.rs
+++ b/crates/docspec-html-reader/tests/reader.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `HtmlReader`.
 
-#![allow(clippy::expect_used, clippy::panic)]
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
 #[cfg(test)]
 mod tests {
@@ -8,7 +8,7 @@ mod tests {
     use docspec_html_reader::{EventSource as _, HtmlReader};
 
     fn collect_events(input: &str) -> Vec<Event> {
-        let mut reader = HtmlReader::new(input);
+        let mut reader = HtmlReader::from_str(input);
         let mut events = Vec::new();
         while let Some(ev) = reader.next_event().expect("unexpected parse error") {
             events.push(ev);
@@ -17,7 +17,7 @@ mod tests {
     }
 
     fn collect_events_result(input: &str) -> Result<Vec<Event>> {
-        let mut reader = HtmlReader::new(input);
+        let mut reader = HtmlReader::from_str(input);
         let mut events = Vec::new();
         loop {
             match reader.next_event()? {
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn idempotent_after_eof() {
-        let mut reader = HtmlReader::new("");
+        let mut reader = HtmlReader::from_str("");
         // Drain to Ok(None)
         while reader.next_event().expect("no error").is_some() {}
         // Call twice more — must return Ok(None) both times
@@ -516,5 +516,37 @@ mod tests {
             }
             other => panic!("expected Parse error, got: {other:?}"),
         }
+    }
+
+    #[test]
+    fn from_reader_matches_from_str() {
+        use std::io::Cursor;
+
+        let input = "<p>hi</p>";
+        let mut r1 = HtmlReader::from_str(input);
+        let mut r2 = HtmlReader::from_reader(Cursor::new(input.as_bytes())).unwrap();
+        let events1: Vec<_> = core::iter::from_fn(|| r1.next_event().unwrap()).collect();
+        let events2: Vec<_> = core::iter::from_fn(|| r2.next_event().unwrap()).collect();
+        assert_eq!(events1, events2);
+    }
+
+    #[test]
+    fn from_reader_invalid_utf8_in_paragraph() {
+        use std::io::Cursor;
+
+        let mut reader = HtmlReader::from_reader(Cursor::new(b"<p>\xFF</p>")).unwrap();
+        let mut found_error = false;
+        loop {
+            match reader.next_event() {
+                Err(Error::Parse { .. }) => {
+                    found_error = true;
+                    break;
+                }
+                Err(e) => panic!("unexpected error: {e:?}"),
+                Ok(None) => break,
+                Ok(Some(_)) => {}
+            }
+        }
+        assert!(found_error, "expected Error::Parse for invalid UTF-8");
     }
 }

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -176,7 +176,7 @@ async fn do_conversion(
 
     let join_result = tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64), HttpError> {
         let mut output_buffer = Vec::new();
-        let mut reader = docspec::AnyReader::new(input_format, &input_text);
+        let mut reader = docspec::AnyReader::from_str(input_format, &input_text);
         let mut sink = docspec::AnyWriter::new(output_format, &mut output_buffer);
 
         loop {

--- a/crates/docspec-markdown-reader/Cargo.toml
+++ b/crates/docspec-markdown-reader/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["parsing"]
 [dependencies]
 docspec-core = { workspace = true }
 pulldown-cmark = "0.13"
+self_cell = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-markdown-reader/README.md
+++ b/crates/docspec-markdown-reader/README.md
@@ -1,5 +1,68 @@
-# `docspec-markdown-reader`
+# docspec-markdown-reader
 
-Markdown to DocSpec event stream reader.
+Streaming Markdown to DocSpec event stream reader.
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation.
+See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation,
+architecture, and the event protocol.
+
+## Supported Elements
+
+- Headings (h1–h6)
+- Paragraphs
+- Block quotes
+- Code blocks (fenced and indented)
+- Bold, italic, inline code, strikethrough
+- Images
+- Hard and soft line breaks
+- Thematic breaks
+- Tables (GFM)
+- Bullet and numbered lists (nested)
+- Links (inline, reference, autolink)
+
+## Out of Scope (silently dropped)
+
+- Definition lists and footnotes
+- HTML blocks and inline HTML
+- Math blocks and inline math
+- Subscript and superscript formatting
+
+## Memory Model
+
+`MarkdownReader` owns its source `String` for the parser's lifetime. Events still flow
+one at a time via `next_event()`, but the full source text stays in memory until the
+reader is dropped. This is a constraint of `pulldown-cmark`, which is permanently
+borrow-based by design.
+
+For true constant-memory streaming, use `docspec-html-reader`'s `HtmlReader`, which
+reads through a 16 KB sliding-window buffer regardless of document size.
+
+## Quick Start
+
+```rust
+use docspec_markdown_reader::{MarkdownReader, EventSource};
+
+let mut reader = MarkdownReader::from_str("# Hello\n\nWorld");
+while let Some(event) = reader.next_event()? {
+    println!("{event:?}");
+}
+# Ok::<(), docspec_core::Error>(())
+```
+
+From a file or any `Read + Seek` source:
+
+```rust,no_run
+use std::fs::File;
+use docspec_markdown_reader::{MarkdownReader, EventSource};
+
+let file = File::open("document.md")?;
+let mut reader = MarkdownReader::from_reader(file)?;
+while let Some(event) = reader.next_event()? {
+    println!("{event:?}");
+}
+# Ok::<(), docspec_core::Error>(())
+```
+
+## See Also
+
+- [MANIFESTO.md](../../MANIFESTO.md) — philosophy and values
+- [EVENTS.md](../../EVENTS.md) — event types and well-formedness rules

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -11,7 +11,7 @@
 //! use docspec_markdown_reader::{MarkdownReader, EventSource};
 //!
 //! let markdown = "# Hello\n\nWorld";
-//! let mut reader = MarkdownReader::new(markdown);
+//! let mut reader = MarkdownReader::from_str(markdown);
 //!
 //! while let Some(event) = reader.next_event()? {
 //!     println!("{event:?}");
@@ -56,14 +56,46 @@
 //! - HTML blocks and inline HTML
 //! - Math blocks and inline math
 //! - Subscript and superscript formatting
+//!
+//! # Memory Model
+//!
+//! `MarkdownReader` owns its source text for the parser's lifetime. While events
+//! are emitted one at a time via [`EventSource::next_event`] (the stream-event
+//! guarantee is preserved), the source `String` is held in memory until the reader
+//! is dropped. This is a constraint of `pulldown-cmark`, which is permanently
+//! borrow-based by design (see [pulldown-cmark issue #463]).
+//!
+//! For contrast, `HtmlReader` (from `docspec-html-reader`) streams its source via a
+//! 16 KB sliding-window buffer and does not hold the full document in memory.
+//!
+//! [pulldown-cmark issue #463]: https://github.com/raphlinus/pulldown-cmark/issues/463
 
 extern crate alloc;
 
+#[cfg_attr(all(), allow(clippy::mem_forget))]
+mod parser_cell {
+    use self_cell::self_cell;
+
+    use super::MarkdownParser;
+
+    self_cell!(
+        pub(super) struct ParserCell {
+            owner: String,
+            #[covariant]
+            dependent: MarkdownParser,
+        }
+    );
+}
+
 use alloc::collections::VecDeque;
+use std::io::{Read, Seek};
 
 pub use docspec_core::EventSource;
 use docspec_core::{Depth, Event, ImageSource, ListStyleType, Result, TableHeaderScope, TextStyle};
+use parser_cell::ParserCell;
 use pulldown_cmark::{CodeBlockKind, CowStr, HeadingLevel, Options, Parser, Tag, TagEnd};
+
+struct MarkdownParser<'a>(Parser<'a>);
 
 /// Whether content is inside a block-level element.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -110,6 +142,45 @@ struct ImageBuffer {
     url: String,
 }
 
+enum MarkdownPulldownEvent {
+    Code(String),
+    End(TagEnd),
+    HardBreak,
+    Ignored,
+    Rule,
+    SoftBreak,
+    Start(MarkdownStartTag),
+    Text(String),
+}
+
+enum MarkdownStartTag {
+    BlockQuote,
+    CodeBlock {
+        syntax: Option<String>,
+    },
+    Emphasis,
+    Heading {
+        level: HeadingLevel,
+    },
+    Image {
+        dest_url: String,
+        title: Option<String>,
+    },
+    Item,
+    Link {
+        dest_url: String,
+        title: Option<String>,
+    },
+    List(Option<u64>),
+    Paragraph,
+    Strikethrough,
+    Strong,
+    Table,
+    TableCell,
+    TableHead,
+    TableRow,
+}
+
 /// Buffered link state during link inline content collection.
 struct LinkBuffer {
     /// Link target URL.
@@ -131,17 +202,19 @@ struct LinkBuffer {
 /// ```
 /// use docspec_markdown_reader::{MarkdownReader, EventSource};
 ///
-/// let mut reader = MarkdownReader::new("**bold** and *italic*");
+/// let mut reader = MarkdownReader::from_str("**bold** and *italic*");
 /// while let Some(event) = reader.next_event()? {
 ///     // Process events...
 /// }
 /// # Ok::<(), docspec_core::Error>(())
 /// ```
-pub struct MarkdownReader<'a> {
+pub struct MarkdownReader {
     /// Current block-level context.
     block_state: BlockState,
     /// Nesting depth for bold (strong) formatting.
     bold_depth: Depth,
+    /// Owned source text and parser borrowing from it.
+    cell: ParserCell,
     /// Buffered code block text (accumulated until `EndCodeBlock` to strip trailing newline).
     code_block_buffer: Option<String>,
     /// Buffered image being processed (alt text accumulation).
@@ -155,8 +228,6 @@ pub struct MarkdownReader<'a> {
     /// LIFO stack of list contexts. `len()` gives the current nesting depth;
     /// `level = list_stack.len().saturating_sub(1)` at item-emit time.
     list_stack: alloc::vec::Vec<ListContext>,
-    /// The pulldown-cmark parser.
-    parser: Parser<'a>,
     /// Document processing phase.
     phase: Phase,
     /// Queue of `DocSpec` events to emit.
@@ -165,7 +236,7 @@ pub struct MarkdownReader<'a> {
     strikethrough_depth: Depth,
 }
 
-impl<'a> MarkdownReader<'a> {
+impl MarkdownReader {
     fn close_current_item_if_open(&mut self) {
         if let Some(ctx) = self.list_stack.last_mut() {
             if ctx.item_open {
@@ -220,6 +291,61 @@ impl<'a> MarkdownReader<'a> {
             });
             self.block_state = BlockState::Explicit;
         }
+    }
+
+    fn from_owned_string(source: String) -> Self {
+        let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
+        let cell = ParserCell::new(source, |s| MarkdownParser(Parser::new_ext(s, options)));
+        Self {
+            block_state: BlockState::None,
+            bold_depth: Depth::default(),
+            cell,
+            code_block_buffer: None,
+            image: None,
+            in_table_head: false,
+            italic_depth: Depth::default(),
+            link: None,
+            list_stack: Vec::new(),
+            phase: Phase::NotStarted,
+            queue: VecDeque::new(),
+            strikethrough_depth: Depth::default(),
+        }
+    }
+
+    /// Creates a `MarkdownReader` from any `Read + Seek` source.
+    ///
+    /// Reads the entire source into memory (required by `pulldown_cmark`'s
+    /// borrow-based parser).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Io`](docspec_core::Error::Io) if reading fails.
+    #[inline]
+    pub fn from_reader<R: Read + Seek + Send + 'static>(mut reader: R) -> Result<Self> {
+        let mut source = String::new();
+        reader.read_to_string(&mut source)?;
+        Ok(Self::from_owned_string(source))
+    }
+
+    /// Creates a `MarkdownReader` from a string slice.
+    ///
+    /// The input is copied into an owned `String` for the parser's lifetime.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use docspec_markdown_reader::MarkdownReader;
+    ///
+    /// let reader = MarkdownReader::from_str("# Hello World");
+    /// ```
+    #[inline]
+    #[must_use]
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "constructor name is required for reader API consistency"
+    )]
+    pub fn from_str(input: &str) -> Self {
+        Self::from_owned_string(input.to_owned())
     }
 
     fn handle_code(&mut self, content: String) {
@@ -400,11 +526,7 @@ impl<'a> MarkdownReader<'a> {
 
     /// Emits `StartPreformatted` for a code block opening tag, initialising
     /// the internal code-block buffer for content accumulation.
-    fn handle_start_code_block(&mut self, kind: CodeBlockKind<'a>) {
-        let syntax = match kind {
-            CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.into_string()),
-            CodeBlockKind::Fenced(_) | CodeBlockKind::Indented => None,
-        };
+    fn handle_start_code_block(&mut self, syntax: Option<String>) {
         self.code_block_buffer = Some(String::new());
         self.push_event_start(Event::StartPreformatted { id: None, syntax });
     }
@@ -428,7 +550,7 @@ impl<'a> MarkdownReader<'a> {
     /// Initialises image state for alt-text accumulation when an image opening tag is
     /// encountered. The title is stored as `None` when the pulldown-cmark title string
     /// is empty.
-    fn handle_start_image(&mut self, dest_url: CowStr<'a>, title: CowStr<'a>) {
+    fn handle_start_image(&mut self, dest_url: String, title: Option<String>) {
         // Image-in-link extraction: close the link before processing the image so the
         // image can be emitted as a sibling block (BlockNote and similar schemas do not
         // allow block-level images inside inline links). When `link.started` is true, the
@@ -453,12 +575,8 @@ impl<'a> MarkdownReader<'a> {
 
         self.image = Some(ImageBuffer {
             alt_buf: String::new(),
-            title: if title.is_empty() {
-                None
-            } else {
-                Some(title.into_string())
-            },
-            url: dest_url.into_string(),
+            title,
+            url: dest_url,
         });
     }
 
@@ -466,15 +584,11 @@ impl<'a> MarkdownReader<'a> {
     ///
     /// Emission is deferred until the first inline event arrives (lazy emission).
     /// This allows image-in-link to be detected before any `StartLink` is emitted.
-    fn handle_start_link(&mut self, dest_url: CowStr<'a>, title: CowStr<'a>) {
+    fn handle_start_link(&mut self, dest_url: String, title: Option<String>) {
         self.link = Some(LinkBuffer {
-            href: dest_url.into_string(),
+            href: dest_url,
             started: false,
-            title: if title.is_empty() {
-                None
-            } else {
-                Some(title.into_string())
-            },
+            title,
         });
     }
 
@@ -509,36 +623,25 @@ impl<'a> MarkdownReader<'a> {
     /// Tags in the explicit ignore list below are known-unsupported elements whose
     /// structure is intentionally dropped (text content may still be extracted by
     /// other event handlers).
-    fn handle_start_tag(&mut self, tag: Tag<'a>) {
+    fn handle_start_tag(&mut self, tag: MarkdownStartTag) {
         match tag {
-            Tag::BlockQuote(_) => self.push_event_start(Event::StartBlockQuote { id: None }),
-            Tag::CodeBlock(kind) => self.handle_start_code_block(kind),
-            Tag::Emphasis => self.italic_depth.inc(),
-            Tag::Heading { level, .. } => self.handle_start_heading(level),
-            Tag::Image {
-                dest_url, title, ..
-            } => self.handle_start_image(dest_url, title),
-            Tag::Item => self.handle_item_start(),
-            Tag::Link {
-                dest_url, title, ..
-            } => self.handle_start_link(dest_url, title),
-            Tag::List(start_opt) => self.handle_list_start(start_opt),
-            Tag::Paragraph => self.block_state = BlockState::PendingExplicit,
-            Tag::Strikethrough => self.strikethrough_depth.inc(),
-            Tag::Strong => self.bold_depth.inc(),
-            Tag::Table(_) => self.push_event_start(Event::StartTable { id: None }),
-            Tag::TableCell => self.handle_start_table_cell(),
-            Tag::TableHead => self.handle_start_table_head(),
-            Tag::TableRow => self.push_event_start(Event::StartTableRow { id: None }),
-            // Tags intentionally ignored (structure dropped, text extracted elsewhere):
-            Tag::DefinitionList
-            | Tag::DefinitionListDefinition
-            | Tag::DefinitionListTitle
-            | Tag::FootnoteDefinition(_)
-            | Tag::HtmlBlock
-            | Tag::MetadataBlock(_)
-            | Tag::Subscript
-            | Tag::Superscript => {}
+            MarkdownStartTag::BlockQuote => {
+                self.push_event_start(Event::StartBlockQuote { id: None });
+            }
+            MarkdownStartTag::CodeBlock { syntax } => self.handle_start_code_block(syntax),
+            MarkdownStartTag::Emphasis => self.italic_depth.inc(),
+            MarkdownStartTag::Heading { level } => self.handle_start_heading(level),
+            MarkdownStartTag::Image { dest_url, title } => self.handle_start_image(dest_url, title),
+            MarkdownStartTag::Item => self.handle_item_start(),
+            MarkdownStartTag::Link { dest_url, title } => self.handle_start_link(dest_url, title),
+            MarkdownStartTag::List(start_opt) => self.handle_list_start(start_opt),
+            MarkdownStartTag::Paragraph => self.block_state = BlockState::PendingExplicit,
+            MarkdownStartTag::Strikethrough => self.strikethrough_depth.inc(),
+            MarkdownStartTag::Strong => self.bold_depth.inc(),
+            MarkdownStartTag::Table => self.push_event_start(Event::StartTable { id: None }),
+            MarkdownStartTag::TableCell => self.handle_start_table_cell(),
+            MarkdownStartTag::TableHead => self.handle_start_table_head(),
+            MarkdownStartTag::TableRow => self.push_event_start(Event::StartTableRow { id: None }),
         }
     }
 
@@ -563,41 +666,33 @@ impl<'a> MarkdownReader<'a> {
         }
     }
 
-    /// Creates a new `MarkdownReader` from the given Markdown string.
-    ///
-    /// The reader will emit `StartDocument` as its first event and `EndDocument`
-    /// as its last event, with the parsed content events in between.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use docspec_markdown_reader::MarkdownReader;
-    ///
-    /// let reader = MarkdownReader::new("# Hello World");
-    /// ```
-    #[inline]
-    #[must_use]
-    pub fn new(markdown: &'a str) -> Self {
-        let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH;
-        let parser = Parser::new_ext(markdown, options);
-        Self {
-            block_state: BlockState::None,
-            bold_depth: Depth::default(),
-            code_block_buffer: None,
-            image: None,
-            in_table_head: false,
-            italic_depth: Depth::default(),
-            link: None,
-            list_stack: Vec::new(),
-            parser,
-            phase: Phase::NotStarted,
-            queue: VecDeque::new(),
-            strikethrough_depth: Depth::default(),
-        }
+    fn next_pulldown_event(&mut self) -> Option<MarkdownPulldownEvent> {
+        self.cell.with_dependent_mut(|_, dep| {
+            dep.0.next().map(|event| match event {
+                pulldown_cmark::Event::Start(tag) => markdown_start_tag(tag)
+                    .map_or(MarkdownPulldownEvent::Ignored, MarkdownPulldownEvent::Start),
+                pulldown_cmark::Event::End(tag_end) => MarkdownPulldownEvent::End(tag_end),
+                pulldown_cmark::Event::Text(text) => {
+                    MarkdownPulldownEvent::Text(text.into_string())
+                }
+                pulldown_cmark::Event::Code(code) => {
+                    MarkdownPulldownEvent::Code(code.into_string())
+                }
+                pulldown_cmark::Event::HardBreak => MarkdownPulldownEvent::HardBreak,
+                pulldown_cmark::Event::SoftBreak => MarkdownPulldownEvent::SoftBreak,
+                pulldown_cmark::Event::Rule => MarkdownPulldownEvent::Rule,
+                pulldown_cmark::Event::DisplayMath(_)
+                | pulldown_cmark::Event::FootnoteReference(_)
+                | pulldown_cmark::Event::Html(_)
+                | pulldown_cmark::Event::InlineHtml(_)
+                | pulldown_cmark::Event::InlineMath(_)
+                | pulldown_cmark::Event::TaskListMarker(_) => MarkdownPulldownEvent::Ignored,
+            })
+        })
     }
 
     fn process_next_pulldown_event(&mut self) {
-        let Some(pm_event) = self.parser.next() else {
+        let Some(pm_event) = self.next_pulldown_event() else {
             if self.phase != Phase::Finished {
                 self.phase = Phase::Finished;
                 self.queue.push_back(Event::EndDocument);
@@ -606,11 +701,11 @@ impl<'a> MarkdownReader<'a> {
         };
 
         match pm_event {
-            pulldown_cmark::Event::Start(tag) => self.handle_start_tag(tag),
-            pulldown_cmark::Event::End(tag_end) => self.handle_end_tag(tag_end),
-            pulldown_cmark::Event::Text(text) => self.handle_text(text.into_string()),
-            pulldown_cmark::Event::Code(code) => self.handle_code(code.into_string()),
-            pulldown_cmark::Event::HardBreak => {
+            MarkdownPulldownEvent::Start(tag) => self.handle_start_tag(tag),
+            MarkdownPulldownEvent::End(tag_end) => self.handle_end_tag(tag_end),
+            MarkdownPulldownEvent::Text(text) => self.handle_text(text),
+            MarkdownPulldownEvent::Code(code) => self.handle_code(code),
+            MarkdownPulldownEvent::HardBreak => {
                 if let Some(img) = &mut self.image {
                     img.alt_buf.push(' ');
                 } else if self.block_state == BlockState::PendingExplicit {
@@ -620,7 +715,7 @@ impl<'a> MarkdownReader<'a> {
                     self.queue.push_back(Event::LineBreak);
                 }
             }
-            pulldown_cmark::Event::SoftBreak => {
+            MarkdownPulldownEvent::SoftBreak => {
                 if let Some(img) = &mut self.image {
                     img.alt_buf.push(' ');
                 } else if self.block_state == BlockState::PendingExplicit {
@@ -630,15 +725,10 @@ impl<'a> MarkdownReader<'a> {
                     self.queue.push_back(Event::SoftBreak);
                 }
             }
-            pulldown_cmark::Event::Rule => {
+            MarkdownPulldownEvent::Rule => {
                 self.queue.push_back(Event::ThematicBreak { id: None });
             }
-            pulldown_cmark::Event::DisplayMath(_)
-            | pulldown_cmark::Event::FootnoteReference(_)
-            | pulldown_cmark::Event::Html(_)
-            | pulldown_cmark::Event::InlineHtml(_)
-            | pulldown_cmark::Event::InlineMath(_)
-            | pulldown_cmark::Event::TaskListMarker(_) => {}
+            MarkdownPulldownEvent::Ignored => {}
         }
     }
 
@@ -656,7 +746,7 @@ impl<'a> MarkdownReader<'a> {
     }
 }
 
-impl EventSource for MarkdownReader<'_> {
+impl EventSource for MarkdownReader {
     #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
         if self.phase == Phase::NotStarted {
@@ -680,13 +770,68 @@ impl EventSource for MarkdownReader<'_> {
     }
 }
 
+fn markdown_start_tag(tag: Tag<'_>) -> Option<MarkdownStartTag> {
+    match tag {
+        Tag::BlockQuote(_) => Some(MarkdownStartTag::BlockQuote),
+        Tag::CodeBlock(kind) => Some(MarkdownStartTag::CodeBlock {
+            syntax: code_block_syntax(kind),
+        }),
+        Tag::Emphasis => Some(MarkdownStartTag::Emphasis),
+        Tag::Heading { level, .. } => Some(MarkdownStartTag::Heading { level }),
+        Tag::Image {
+            dest_url, title, ..
+        } => Some(MarkdownStartTag::Image {
+            dest_url: dest_url.into_string(),
+            title: cow_to_optional_string(title),
+        }),
+        Tag::Item => Some(MarkdownStartTag::Item),
+        Tag::Link {
+            dest_url, title, ..
+        } => Some(MarkdownStartTag::Link {
+            dest_url: dest_url.into_string(),
+            title: cow_to_optional_string(title),
+        }),
+        Tag::List(start_opt) => Some(MarkdownStartTag::List(start_opt)),
+        Tag::Paragraph => Some(MarkdownStartTag::Paragraph),
+        Tag::Strikethrough => Some(MarkdownStartTag::Strikethrough),
+        Tag::Strong => Some(MarkdownStartTag::Strong),
+        Tag::Table(_) => Some(MarkdownStartTag::Table),
+        Tag::TableCell => Some(MarkdownStartTag::TableCell),
+        Tag::TableHead => Some(MarkdownStartTag::TableHead),
+        Tag::TableRow => Some(MarkdownStartTag::TableRow),
+        Tag::DefinitionList
+        | Tag::DefinitionListDefinition
+        | Tag::DefinitionListTitle
+        | Tag::FootnoteDefinition(_)
+        | Tag::HtmlBlock
+        | Tag::MetadataBlock(_)
+        | Tag::Subscript
+        | Tag::Superscript => None,
+    }
+}
+
+fn code_block_syntax(kind: CodeBlockKind<'_>) -> Option<String> {
+    match kind {
+        CodeBlockKind::Fenced(lang) if !lang.is_empty() => Some(lang.into_string()),
+        CodeBlockKind::Fenced(_) | CodeBlockKind::Indented => None,
+    }
+}
+
+fn cow_to_optional_string(value: CowStr<'_>) -> Option<String> {
+    if value.is_empty() {
+        None
+    } else {
+        Some(value.into_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn handle_code_without_open_block_auto_opens_paragraph() {
-        let mut reader = MarkdownReader::new("");
+        let mut reader = MarkdownReader::from_str("");
         reader.handle_code("code".to_string());
 
         assert_eq!(reader.queue.len(), 2);
@@ -708,7 +853,7 @@ mod tests {
 
     #[test]
     fn handle_text_without_open_block_auto_opens_paragraph() {
-        let mut reader = MarkdownReader::new("");
+        let mut reader = MarkdownReader::from_str("");
         reader.handle_text("hello".to_string());
 
         assert_eq!(reader.queue.len(), 2);
@@ -726,5 +871,15 @@ mod tests {
                 style: TextStyle::default(),
             })
         );
+    }
+}
+
+#[cfg(test)]
+mod send_static_assertions {
+    fn assert_send_static<T: Send + 'static>() {}
+
+    #[test]
+    fn markdown_reader_is_send_static() {
+        assert_send_static::<crate::MarkdownReader>();
     }
 }

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -111,10 +111,11 @@ mod helpers {
 #[cfg(test)]
 mod tests {
     use super::helpers;
-    use docspec_core::{Event, EventSource as _, ImageSource, ListStyleType, TextStyle};
+    use docspec_core::{Error, Event, EventSource as _, ImageSource, ListStyleType, TextStyle};
     use docspec_markdown_reader::MarkdownReader;
+    use std::io::Cursor;
 
-    fn collect_events(reader: &mut MarkdownReader<'_>) -> Vec<Event> {
+    fn collect_events(reader: &mut MarkdownReader) -> Vec<Event> {
         let mut events = Vec::new();
         loop {
             let result = reader.next_event();
@@ -128,9 +129,44 @@ mod tests {
     }
 
     #[test]
+    fn from_reader_matches_from_str() {
+        let input = "# H\n\nParagraph";
+        let mut from_str = MarkdownReader::from_str(input);
+        let mut from_reader = MarkdownReader::from_reader(Cursor::new(input.as_bytes())).unwrap();
+
+        assert_eq!(
+            collect_events(&mut from_str),
+            collect_events(&mut from_reader)
+        );
+    }
+
+    #[test]
+    fn from_reader_invalid_utf8() {
+        let result = MarkdownReader::from_reader(Cursor::new(&[0xFF, 0xFE][..]));
+
+        assert!(matches!(result, Err(Error::Io { .. })));
+    }
+
+    #[test]
+    fn from_reader_one_megabyte() {
+        let big = "# Heading\n\nParagraph.\n".repeat(50_000);
+        let mut reader = MarkdownReader::from_reader(Cursor::new(big.into_bytes())).unwrap();
+        let mut count: usize = 0;
+        let mut last = None;
+
+        while let Some(event) = reader.next_event().unwrap() {
+            last = Some(event);
+            count += 1;
+        }
+
+        assert!(count > 50_000);
+        assert_eq!(last, Some(Event::EndDocument));
+    }
+
+    #[test]
     fn blockquote_content_extraction() {
         let markdown = "> Quoted text";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -155,7 +191,7 @@ mod tests {
 
     #[test]
     fn bold_and_italic_text() {
-        let mut reader = MarkdownReader::new("***both***");
+        let mut reader = MarkdownReader::from_str("***both***");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -172,7 +208,7 @@ mod tests {
 
     #[test]
     fn bold_text() {
-        let mut reader = MarkdownReader::new("**bold**");
+        let mut reader = MarkdownReader::from_str("**bold**");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -190,7 +226,7 @@ mod tests {
     #[test]
     fn document_structure_preserved() {
         let markdown = "# Title\n\nParagraph text.\n\n---\n\n## Subtitle";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -214,7 +250,7 @@ mod tests {
 
     #[test]
     fn empty_document() {
-        let mut reader = MarkdownReader::new("");
+        let mut reader = MarkdownReader::from_str("");
         let events = collect_events(&mut reader);
 
         assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
@@ -222,7 +258,7 @@ mod tests {
 
     #[test]
     fn hard_break() {
-        let mut reader = MarkdownReader::new("Line one  \nLine two");
+        let mut reader = MarkdownReader::from_str("Line one  \nLine two");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -241,7 +277,7 @@ mod tests {
 
     #[test]
     fn heading_level_1() {
-        let mut reader = MarkdownReader::new("# Hello");
+        let mut reader = MarkdownReader::from_str("# Hello");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -261,7 +297,7 @@ mod tests {
         let expected_levels: [u8; 5] = [2, 3, 4, 5, 6];
         for expected in expected_levels {
             let markdown = format!("{} Heading", "#".repeat(usize::from(expected)));
-            let mut reader = MarkdownReader::new(&markdown);
+            let mut reader = MarkdownReader::from_str(&markdown);
             let events = collect_events(&mut reader);
 
             assert_eq!(
@@ -280,7 +316,7 @@ mod tests {
     #[test]
     fn image_with_alt_and_title() {
         let mut reader =
-            MarkdownReader::new("![Alt text](https://example.com/img.png \"Image Title\")");
+            MarkdownReader::from_str("![Alt text](https://example.com/img.png \"Image Title\")");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -302,7 +338,7 @@ mod tests {
 
     #[test]
     fn image_with_alt_only() {
-        let mut reader = MarkdownReader::new("![Alt text only](https://example.com/img.png)");
+        let mut reader = MarkdownReader::from_str("![Alt text only](https://example.com/img.png)");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -324,7 +360,7 @@ mod tests {
 
     #[test]
     fn image_with_no_alt() {
-        let mut reader = MarkdownReader::new("![](https://example.com/img.png)");
+        let mut reader = MarkdownReader::from_str("![](https://example.com/img.png)");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -342,7 +378,7 @@ mod tests {
     #[test]
     fn images_fixture() {
         let markdown = include_str!("../../../tests/fixtures/markdown/images.md");
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -375,7 +411,7 @@ mod tests {
 
     #[test]
     fn inline_code() {
-        let mut reader = MarkdownReader::new("Use `code` here");
+        let mut reader = MarkdownReader::from_str("Use `code` here");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -394,7 +430,7 @@ mod tests {
 
     #[test]
     fn inline_code_inherits_bold() {
-        let mut reader = MarkdownReader::new("**bold `code` bold**");
+        let mut reader = MarkdownReader::from_str("**bold `code` bold**");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -413,7 +449,7 @@ mod tests {
 
     #[test]
     fn inline_code_inherits_italic() {
-        let mut reader = MarkdownReader::new("*italic `code` italic*");
+        let mut reader = MarkdownReader::from_str("*italic `code` italic*");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -432,7 +468,7 @@ mod tests {
 
     #[test]
     fn inline_code_inherits_strikethrough() {
-        let mut reader = MarkdownReader::new("~~strikethrough `code` strikethrough~~");
+        let mut reader = MarkdownReader::from_str("~~strikethrough `code` strikethrough~~");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -451,7 +487,7 @@ mod tests {
 
     #[test]
     fn italic_text() {
-        let mut reader = MarkdownReader::new("*italic*");
+        let mut reader = MarkdownReader::from_str("*italic*");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -469,7 +505,7 @@ mod tests {
     #[test]
     fn list_content_extraction() {
         let markdown = "- Item one\n- Item two";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -496,7 +532,7 @@ mod tests {
     #[test]
     fn nested_content_fixture() {
         let markdown = include_str!("../../../tests/fixtures/markdown/nested_content.md");
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         let text_contents: Vec<&str> = events
@@ -517,7 +553,7 @@ mod tests {
 
     #[test]
     fn nested_list_with_continuation_keeps_parent_item_open() {
-        let mut reader = MarkdownReader::new(
+        let mut reader = MarkdownReader::from_str(
             "- Outer A\n  - Inner nested\n\n  Continuation paragraph for Outer A\n- Outer B\n",
         );
         let events = collect_events(&mut reader);
@@ -536,7 +572,7 @@ mod tests {
 
     #[test]
     fn next_event_returns_none_after_end_document() {
-        let mut reader = MarkdownReader::new("");
+        let mut reader = MarkdownReader::from_str("");
         let events = collect_events(&mut reader);
 
         assert_eq!(events.len(), 2);
@@ -557,7 +593,7 @@ mod tests {
 
     #[test]
     fn paragraph() {
-        let mut reader = MarkdownReader::new("Hello world");
+        let mut reader = MarkdownReader::from_str("Hello world");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -574,7 +610,7 @@ mod tests {
 
     #[test]
     fn soft_break_emits_soft_break_event() {
-        let mut reader = MarkdownReader::new("Line one\nLine two");
+        let mut reader = MarkdownReader::from_str("Line one\nLine two");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -596,7 +632,7 @@ mod tests {
         // The image alt text flattens the soft break to a single space.
         // No SoftBreak event is emitted — the soft break is absorbed
         // into the image's alt buffer.
-        let mut reader = MarkdownReader::new("![alt one\nalt two](image.png)");
+        let mut reader = MarkdownReader::from_str("![alt one\nalt two](image.png)");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -613,7 +649,7 @@ mod tests {
 
     #[test]
     fn thematic_break() {
-        let mut reader = MarkdownReader::new("Before\n\n---\n\nAfter");
+        let mut reader = MarkdownReader::from_str("Before\n\n---\n\nAfter");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -634,7 +670,7 @@ mod tests {
 
     #[test]
     fn code_in_image_alt_appends_to_alt_buffer() {
-        let mut reader = MarkdownReader::new("![`code`](https://example.com/img.png)");
+        let mut reader = MarkdownReader::from_str("![`code`](https://example.com/img.png)");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -651,7 +687,7 @@ mod tests {
 
     #[test]
     fn html_events_silently_ignored() {
-        let mut reader = MarkdownReader::new("<div>hello</div>");
+        let mut reader = MarkdownReader::from_str("<div>hello</div>");
         let events = collect_events(&mut reader);
 
         assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
@@ -660,7 +696,7 @@ mod tests {
     #[test]
     fn blockquote_text_wrapped_in_auto_paragraph() {
         let markdown = "> Quoted";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -680,7 +716,7 @@ mod tests {
     #[test]
     fn list_item_emits_start_text_end_directly() {
         let markdown = "- Item";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -698,7 +734,7 @@ mod tests {
     #[test]
     fn fenced_code_block_with_language() {
         let markdown = "```rust\nfn main() {}\n```";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -716,7 +752,7 @@ mod tests {
     #[test]
     fn fenced_code_block_without_language() {
         let markdown = "```\nsome code\n```";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -734,7 +770,7 @@ mod tests {
     #[test]
     fn indented_code_block() {
         let markdown = "    indented code\n";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -755,7 +791,7 @@ mod tests {
         // The parser adds a newline terminator, but we should only remove that one,
         // not all trailing newlines
         let markdown = "```\ncode\n\n\n```";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         // The content should preserve the blank lines (two newlines after "code").
@@ -779,7 +815,7 @@ mod tests {
         // inline markdown inside code blocks, and the reader's code_block_buffer
         // branch never consults bold/italic depth.
         let markdown = "```\n*test* **bold** `code` _italic_ ~strike~\n```";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -803,7 +839,7 @@ mod tests {
         // followed by EndPreformatted with NO Text event in between
         // (the `if !content.is_empty()` guard at src/lib.rs:234 suppresses it).
         let markdown = "```\n```";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -820,7 +856,7 @@ mod tests {
     #[test]
     fn code_block_inside_list_item() {
         let markdown = "- item\n\n  ```\n  code\n  ```";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -842,7 +878,7 @@ mod tests {
 
     #[test]
     fn strikethrough_basic() {
-        let mut reader = MarkdownReader::new("~~struck~~");
+        let mut reader = MarkdownReader::from_str("~~struck~~");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -859,7 +895,7 @@ mod tests {
 
     #[test]
     fn strikethrough_with_bold() {
-        let mut reader = MarkdownReader::new("~~**bold struck**~~");
+        let mut reader = MarkdownReader::from_str("~~**bold struck**~~");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -876,7 +912,7 @@ mod tests {
 
     #[test]
     fn strikethrough_with_italic() {
-        let mut reader = MarkdownReader::new("~~*italic struck*~~");
+        let mut reader = MarkdownReader::from_str("~~*italic struck*~~");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -897,7 +933,7 @@ mod tests {
     #[test]
     fn strikethrough_in_paragraph() {
         let markdown = "This is ~~struck~~ text in a paragraph.";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -916,7 +952,7 @@ mod tests {
 
     #[test]
     fn strikethrough_with_bold_and_italic() {
-        let mut reader = MarkdownReader::new("~~***bold italic struck***~~");
+        let mut reader = MarkdownReader::from_str("~~***bold italic struck***~~");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -937,7 +973,7 @@ mod tests {
     #[test]
     fn simple_table_emits_structured_events() {
         let markdown = "| A | B |\n|---|---|\n| C | D |";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_table()));
@@ -951,7 +987,7 @@ mod tests {
     #[test]
     fn table_header_cells_have_column_scope() {
         let markdown = "| H1 | H2 |\n|----|----|";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(3), Some(&helpers::start_table_header()));
@@ -961,7 +997,7 @@ mod tests {
     #[test]
     fn table_body_cells_have_no_scope_field() {
         let markdown = "| H |\n|---|\n| C |";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(3), Some(&helpers::start_table_header()));
@@ -972,7 +1008,7 @@ mod tests {
     #[test]
     fn table_cell_text_emits_raw_not_wrapped() {
         let markdown = "| H |\n|---|\n| text |";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(8), Some(&helpers::start_table_cell()));
@@ -986,7 +1022,7 @@ mod tests {
     #[test]
     fn table_with_inline_formatting_in_cells() {
         let markdown = "| **bold** | `code` |\n|-----------|--------|\n| *italic* | plain |";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -1006,7 +1042,7 @@ mod tests {
     #[test]
     fn header_only_table() {
         let markdown = "| H1 | H2 |\n|----|----|";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_table()));
@@ -1019,7 +1055,7 @@ mod tests {
     #[test]
     fn table_with_empty_cells() {
         let markdown = "| A |  |\n|---|---|\n|  | B |";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(6), Some(&helpers::start_table_header()));
@@ -1031,7 +1067,7 @@ mod tests {
     #[test]
     fn multiple_tables_in_sequence() {
         let markdown = "| A |\n|---|\n| B |\n\n| C |\n|---|\n| D |";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_table()));
@@ -1042,7 +1078,7 @@ mod tests {
 
     #[test]
     fn simple_bullet_list_emits_unordered_items() {
-        let mut reader = MarkdownReader::new("- a\n- b\n- c");
+        let mut reader = MarkdownReader::from_str("- a\n- b\n- c");
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_unordered_list_item(0)));
@@ -1059,7 +1095,7 @@ mod tests {
 
     #[test]
     fn simple_numbered_list_emits_ordered_items() {
-        let mut reader = MarkdownReader::new("1. a\n2. b\n3. c");
+        let mut reader = MarkdownReader::from_str("1. a\n2. b\n3. c");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -1079,7 +1115,7 @@ mod tests {
 
     #[test]
     fn numbered_list_with_explicit_start() {
-        let mut reader = MarkdownReader::new("5. a\n6. b\n7. c");
+        let mut reader = MarkdownReader::from_str("5. a\n6. b\n7. c");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -1098,7 +1134,7 @@ mod tests {
 
     #[test]
     fn bullet_list_emits_disc_style() {
-        let mut reader = MarkdownReader::new("- a");
+        let mut reader = MarkdownReader::from_str("- a");
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_unordered_list_item(0)));
@@ -1106,7 +1142,7 @@ mod tests {
 
     #[test]
     fn ordered_list_emits_decimal_style() {
-        let mut reader = MarkdownReader::new("1. a");
+        let mut reader = MarkdownReader::from_str("1. a");
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -1117,7 +1153,7 @@ mod tests {
 
     #[test]
     fn nested_bullet_lists_emit_increasing_level() {
-        let mut reader = MarkdownReader::new("- A\n  - B\n  - C\n- D");
+        let mut reader = MarkdownReader::from_str("- A\n  - B\n  - C\n- D");
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_unordered_list_item(0)));
@@ -1132,7 +1168,7 @@ mod tests {
 
     #[test]
     fn mixed_nested_lists() {
-        let mut reader = MarkdownReader::new("- A\n  1. B\n  2. C\n- D");
+        let mut reader = MarkdownReader::from_str("- A\n  1. B\n  2. C\n- D");
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_unordered_list_item(0)));
@@ -1153,7 +1189,7 @@ mod tests {
 
     #[test]
     fn list_item_containing_only_nested_list_no_text() {
-        let mut reader = MarkdownReader::new("- \n  - Nested item\n- Sibling\n");
+        let mut reader = MarkdownReader::from_str("- \n  - Nested item\n- Sibling\n");
         let events = collect_events(&mut reader);
 
         // Outer item opens without any text of its own
@@ -1175,7 +1211,7 @@ mod tests {
 
     #[test]
     fn list_items_with_inline_formatting() {
-        let mut reader = MarkdownReader::new("- **bold** item\n- *italic* item");
+        let mut reader = MarkdownReader::from_str("- **bold** item\n- *italic* item");
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_unordered_list_item(0)));
@@ -1194,7 +1230,7 @@ mod tests {
 
     #[test]
     fn nested_list_with_hard_break_in_continuation() {
-        let mut reader = MarkdownReader::new("- A\n  - B\n\n  Line one  \n  Line two\n");
+        let mut reader = MarkdownReader::from_str("- A\n  - B\n\n  Line one  \n  Line two\n");
         let events = collect_events(&mut reader);
 
         // Continuation paragraph is inside parent item
@@ -1217,7 +1253,7 @@ mod tests {
 
     #[test]
     fn three_levels_deeply_nested_unordered_list() {
-        let mut reader = MarkdownReader::new("- A\n  - B\n    - C\n");
+        let mut reader = MarkdownReader::from_str("- A\n  - B\n    - C\n");
         let events = collect_events(&mut reader);
 
         assert_eq!(events.get(1), Some(&helpers::start_unordered_list_item(0)));
@@ -1240,7 +1276,7 @@ mod tests {
         // a well-formed event stream. The outer item's EndOrderedListItem must be
         // emitted AFTER the inner EndBlockQuote, not before.
         let markdown = "5) I2\n   > text\n   > - [f]\n";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -1291,7 +1327,7 @@ mod tests {
     #[test]
     fn link_simple() {
         let markdown = "[text](https://example.com)";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1320,7 +1356,7 @@ mod tests {
     #[test]
     fn link_with_title() {
         let markdown = r#"[text](https://example.com "a title")"#;
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1349,7 +1385,7 @@ mod tests {
     #[test]
     fn link_empty_text() {
         let markdown = "[](https://example.com)";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1374,7 +1410,7 @@ mod tests {
     #[test]
     fn link_styled_content() {
         let markdown = "[**bold** text](https://example.com)";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1407,7 +1443,7 @@ mod tests {
     #[test]
     fn link_with_code_span() {
         let markdown = "[`code`](https://example.com)";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1436,7 +1472,7 @@ mod tests {
     #[test]
     fn autolink() {
         let markdown = "<https://example.com>";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1465,7 +1501,7 @@ mod tests {
     #[test]
     fn link_in_heading() {
         let markdown = "# [text](https://example.com)";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1491,7 +1527,7 @@ mod tests {
     #[test]
     fn link_in_paragraph_with_surrounding_text() {
         let markdown = "before [link text](https://example.com) after";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1531,7 +1567,7 @@ mod tests {
         // Reader should emit: StartParagraph, StartLink, EndLink, Image, EndParagraph
         // (Image appears BEFORE EndParagraph because pulldown fires End(Image) before End(Paragraph))
         let markdown = "[![alt](img.png)](https://example.com)";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1564,7 +1600,7 @@ mod tests {
 
     #[test]
     fn inline_html_only_paragraph_emits_nothing() {
-        let mut reader = MarkdownReader::new("<span id=\"ferris\"></span>");
+        let mut reader = MarkdownReader::from_str("<span id=\"ferris\"></span>");
         let events = collect_events(&mut reader);
         assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
     }
@@ -1572,7 +1608,7 @@ mod tests {
     #[test]
     fn inline_html_between_paragraphs_preserves_surrounding() {
         let markdown = "Before\n\n<span id=\"ferris\"></span>\n\nAfter";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -1593,7 +1629,7 @@ mod tests {
     #[test]
     fn inline_html_with_text_still_emits_paragraph() {
         let markdown = "text <span></span> more";
-        let mut reader = MarkdownReader::new(markdown);
+        let mut reader = MarkdownReader::from_str(markdown);
         let events = collect_events(&mut reader);
 
         assert_eq!(
@@ -1613,21 +1649,21 @@ mod tests {
     fn inline_html_inside_emphasis_emits_nothing() {
         // pulldown-cmark emits: Start(Paragraph), Start(Emphasis), InlineHtml(...), InlineHtml(...), End(Emphasis), End(Paragraph)
         // No Text events are emitted, so the paragraph should be deferred and ultimately not emitted.
-        let mut reader = MarkdownReader::new("*<span></span>*");
+        let mut reader = MarkdownReader::from_str("*<span></span>*");
         let events = collect_events(&mut reader);
         assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
     }
 
     #[test]
     fn softbreak_only_after_html_filter_emits_nothing() {
-        let mut reader = MarkdownReader::new("<span></span>\n<span></span>");
+        let mut reader = MarkdownReader::from_str("<span></span>\n<span></span>");
         let events = collect_events(&mut reader);
         assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
     }
 
     #[test]
     fn image_only_paragraph_emits_paragraph_wrapper() {
-        let mut reader = MarkdownReader::new("![alt](img.png)");
+        let mut reader = MarkdownReader::from_str("![alt](img.png)");
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1643,21 +1679,21 @@ mod tests {
 
     #[test]
     fn hardbreak_only_paragraph_emits_nothing() {
-        let mut reader = MarkdownReader::new("  \n");
+        let mut reader = MarkdownReader::from_str("  \n");
         let events = collect_events(&mut reader);
         assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
     }
 
     #[test]
     fn inline_html_with_hardbreak_emits_nothing() {
-        let mut reader = MarkdownReader::new("<span></span>  \n<span></span>");
+        let mut reader = MarkdownReader::from_str("<span></span>  \n<span></span>");
         let events = collect_events(&mut reader);
         assert_eq!(events, vec![helpers::start_document(), Event::EndDocument]);
     }
 
     #[test]
     fn list_item_with_only_softbreak_emits_softbreak() {
-        let mut reader = MarkdownReader::new("- <span></span>\n  <span></span>");
+        let mut reader = MarkdownReader::from_str("- <span></span>\n  <span></span>");
         let events = collect_events(&mut reader);
         assert_eq!(
             events,
@@ -1673,7 +1709,7 @@ mod tests {
 
     #[test]
     fn list_item_with_text_and_softbreak_emits_text_and_break() {
-        let mut reader = MarkdownReader::new("- text\n  more");
+        let mut reader = MarkdownReader::from_str("- text\n  more");
         let events = collect_events(&mut reader);
         assert_eq!(
             events,

--- a/crates/docspec-wasm/src/lib.rs
+++ b/crates/docspec-wasm/src/lib.rs
@@ -13,7 +13,7 @@ use wasm_bindgen::prelude::*;
 /// parse error, invalid event sequence, or JSON serialization error.
 #[wasm_bindgen]
 pub fn convert_markdown_to_blocknote(markdown: &str) -> core::result::Result<String, JsValue> {
-    let reader = docspec::AnyReader::new(docspec::InputFormat::Markdown, markdown);
+    let reader = docspec::AnyReader::from_str(docspec::InputFormat::Markdown, markdown);
     let mut output = Vec::new();
     let sink = docspec::AnyWriter::new(docspec::OutputFormat::Blocknote, &mut output);
     docspec_core::pipe(reader, sink).map_err(|e| JsValue::from_str(&e.to_string()))?;

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -20,7 +20,7 @@ use docspec::writers::BlockNoteWriter;
 use docspec::{EventSink, EventSource, StackTrackingSink};
 
 let markdown = "# Hello\n\nWorld";
-let mut reader = MarkdownReader::new(markdown);
+let mut reader = MarkdownReader::from_str(markdown);
 let mut buf = Vec::<u8>::new();
 let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 
@@ -40,9 +40,9 @@ writer.finish()?;
 | `html`     | HTML (paragraphs only)                           | `docspec-html-reader`     |
 | `docx`     | DOCX (paragraphs and text only)                  | `docspec-docx-reader`     |
 
-`DocxReader` takes a file path or `Read + Seek` source (not `&str`), so it cannot be
-dispatched through the text-based `AnyReader` factory. Construct it directly with
-`DocxReader::from_path` or `DocxReader::from_reader`.
+`DocxReader` takes a file path or `Read + Seek` source. Construct it directly with
+`DocxReader::from_path` or `DocxReader::from_reader`. Support for dispatching
+`DocxReader` through `AnyReader::from_reader` is planned for a future release.
 
 ### Writers
 

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -1,5 +1,7 @@
 //! Reader factory for creating readers from input formats.
 
+use std::io::{Read, Seek};
+
 use docspec_core::{Event, EventSource, Result};
 
 #[cfg(feature = "html")]
@@ -11,27 +13,82 @@ use crate::format::InputFormat;
 
 /// Enum-dispatch reader for any registered input format.
 ///
-/// Constructed via [`AnyReader::new`]. Implements [`EventSource`] by delegating
-/// `next_event` to the inner concrete reader. Zero heap allocation, zero
-/// virtual-dispatch overhead.
+/// Constructed via [`AnyReader::from_str`] or [`AnyReader::from_reader`].
+/// Implements [`EventSource`] by delegating `next_event` to the inner concrete
+/// reader. Zero heap allocation, zero virtual-dispatch overhead.
+///
+/// Both `MarkdownReader` and `HtmlReader` are `Send + 'static`, so `AnyReader`
+/// is also `Send + 'static` — suitable for use across `tokio::task::spawn_blocking`
+/// boundaries.
 #[non_exhaustive]
-pub enum AnyReader<'a> {
+pub enum AnyReader {
     /// HTML reader from [`docspec_html_reader`] (paragraph-only; see crate docs).
     #[cfg(feature = "html")]
-    Html(HtmlReader<'a>),
+    Html(HtmlReader),
     /// Markdown reader from [`docspec_markdown_reader`].
     #[cfg(feature = "markdown")]
-    Markdown(MarkdownReader<'a>),
-    /// Phantom variant when no reader features are active.
-    #[cfg(not(any(feature = "markdown", feature = "html")))]
-    _Phantom(std::marker::PhantomData<&'a ()>),
+    Markdown(MarkdownReader),
 }
 
-impl<'a> AnyReader<'a> {
-    /// Construct a reader for the given format from an in-memory string.
+impl AnyReader {
+    /// Construct a reader for the given format from any `Read + Seek` source.
+    ///
+    /// The `Send + 'static` bounds are required so the resulting `AnyReader`
+    /// can be moved across `tokio::task::spawn_blocking` boundaries.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reading from `reader` fails (e.g., I/O error or
+    /// invalid UTF-8 for text formats).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::io::Cursor;
+    /// use docspec::AnyReader;
+    /// use docspec::InputFormat;
+    ///
+    /// # fn main() -> docspec::Result<()> {
+    /// let reader = AnyReader::from_reader(InputFormat::Markdown, Cursor::new("# Hello"))?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn from_reader<R: Read + Seek + Send + 'static>(
+        format: InputFormat,
+        reader: R,
+    ) -> Result<Self> {
+        #[cfg(not(any(feature = "markdown", feature = "html")))]
+        {
+            let _ = reader;
+            match format {}
+        }
+        #[cfg(any(feature = "markdown", feature = "html"))]
+        match format {
+            #[cfg(feature = "html")]
+            InputFormat::Html => Ok(Self::Html(HtmlReader::from_reader(reader)?)),
+            #[cfg(feature = "markdown")]
+            InputFormat::Markdown => Ok(Self::Markdown(MarkdownReader::from_reader(reader)?)),
+        }
+    }
+
+    /// Construct a reader for the given format from an in-memory string slice.
+    ///
+    /// The input is copied into an owned buffer internally. This is the
+    /// convenience constructor; for streaming from a `Read` source, use
+    /// [`AnyReader::from_reader`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use docspec::AnyReader;
+    /// use docspec::InputFormat;
+    ///
+    /// let reader = AnyReader::from_str(InputFormat::Markdown, "# Hello");
+    /// ```
     #[inline]
     #[must_use]
-    pub fn new(format: InputFormat, input: &'a str) -> Self {
+    pub fn from_str(format: InputFormat, input: &str) -> Self {
         #[cfg(not(any(feature = "markdown", feature = "html")))]
         {
             let _ = input;
@@ -40,23 +97,36 @@ impl<'a> AnyReader<'a> {
         #[cfg(any(feature = "markdown", feature = "html"))]
         match format {
             #[cfg(feature = "html")]
-            InputFormat::Html => Self::Html(HtmlReader::new(input)),
+            InputFormat::Html => Self::Html(HtmlReader::from_str(input)),
             #[cfg(feature = "markdown")]
-            InputFormat::Markdown => Self::Markdown(MarkdownReader::new(input)),
+            InputFormat::Markdown => Self::Markdown(MarkdownReader::from_str(input)),
         }
     }
 }
 
-impl EventSource for AnyReader<'_> {
+impl EventSource for AnyReader {
     #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
+        #[cfg(not(any(feature = "markdown", feature = "html")))]
+        {
+            match *self {}
+        }
+        #[cfg(any(feature = "markdown", feature = "html"))]
         match self {
             #[cfg(feature = "html")]
             Self::Html(r) => r.next_event(),
             #[cfg(feature = "markdown")]
             Self::Markdown(r) => r.next_event(),
-            #[cfg(not(any(feature = "markdown", feature = "html")))]
-            Self::_Phantom(_) => Ok(None),
         }
+    }
+}
+
+#[cfg(test)]
+mod send_static_assertions {
+    fn assert_send_static<T: Send + 'static>() {}
+    #[test]
+    fn any_reader_is_send_static() {
+        #[cfg(any(feature = "markdown", feature = "html"))]
+        assert_send_static::<crate::AnyReader>();
     }
 }

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -18,9 +18,10 @@
 //! | `html`         | HTML (paragraphs only)                              | `readers::HtmlReader`       |
 //! | `docx`         | DOCX (paragraphs and text only)                     | `readers::DocxReader`       |
 //!
-//! Note: [`readers::DocxReader`] takes a binary file or any `Read + Seek` source rather
-//! than a `&str`, so it is not dispatched through the text-based [`AnyReader`] factory.
+//! Note: [`readers::DocxReader`] takes a binary file or any `Read + Seek` source.
 //! Construct it directly with `DocxReader::from_path` or `DocxReader::from_reader`.
+//! Support for dispatching `DocxReader` through [`AnyReader::from_reader`] is planned
+//! for a future release.
 //!
 //! ## Writers
 //!
@@ -75,7 +76,7 @@
 //! use docspec::{EventSink, EventSource, StackTrackingSink};
 //!
 //! let markdown = "# Hello\n\nWorld";
-//! let mut reader = MarkdownReader::new(markdown);
+//! let mut reader = MarkdownReader::from_str(markdown);
 //! let mut buf = Vec::<u8>::new();
 //! let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 //!
@@ -116,8 +117,9 @@ pub mod readers {
     pub use docspec_html_reader::HtmlReader;
 
     /// Streaming DOCX reader. Available when the `docx` feature is enabled.
-    /// Takes a file path or `Read + Seek` source (not `&str`), so it is not
-    /// dispatched through the text-based [`crate::AnyReader`] factory. Emits
+    /// Takes a file path or `Read + Seek` source. Construct it directly with
+    /// `DocxReader::from_path` or `DocxReader::from_reader`. `AnyReader::from_reader`
+    /// support is planned for a future release. Emits
     /// only paragraphs and text; styles, tables, lists, images, headers/footers,
     /// metadata, and tracked changes are silently dropped.
     #[cfg(feature = "docx")]

--- a/crates/docspec/tests/blocknote_markdown_pipeline.rs
+++ b/crates/docspec/tests/blocknote_markdown_pipeline.rs
@@ -7,7 +7,7 @@ use docspec::writers::BlockNoteWriter;
 use docspec::{EventSink as _, EventSource as _, StackTrackingSink};
 
 fn try_run_pipeline(markdown: &str) -> Result<String, String> {
-    let mut reader = MarkdownReader::new(markdown);
+    let mut reader = MarkdownReader::from_str(markdown);
     let mut buf = Vec::<u8>::new();
     let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 

--- a/crates/docspec/tests/factory_reader.rs
+++ b/crates/docspec/tests/factory_reader.rs
@@ -14,9 +14,9 @@ mod tests {
     fn markdown_dispatch_emits_first_event() {
         use docspec_markdown_reader::MarkdownReader;
 
-        let mut reader = AnyReader::new(InputFormat::Markdown, "# h");
+        let mut reader = AnyReader::from_str(InputFormat::Markdown, "# h");
         let event = reader.next_event().expect("AnyReader should not fail");
-        let expected = MarkdownReader::new("# h")
+        let expected = MarkdownReader::from_str("# h")
             .next_event()
             .expect("direct reader should not fail");
         assert_eq!(event, expected);
@@ -27,9 +27,9 @@ mod tests {
     fn html_dispatch_emits_first_event() {
         use docspec_html_reader::HtmlReader;
 
-        let mut reader = AnyReader::new(InputFormat::Html, "<p>x</p>");
+        let mut reader = AnyReader::from_str(InputFormat::Html, "<p>x</p>");
         let event = reader.next_event().expect("AnyReader should not fail");
-        let expected = HtmlReader::new("<p>x</p>")
+        let expected = HtmlReader::from_str("<p>x</p>")
             .next_event()
             .expect("direct reader should not fail");
         assert_eq!(event, expected);
@@ -41,8 +41,8 @@ mod tests {
         use docspec_markdown_reader::MarkdownReader;
 
         let input = "# Hello\n\nWorld";
-        let mut any_reader = AnyReader::new(InputFormat::Markdown, input);
-        let mut direct_reader = MarkdownReader::new(input);
+        let mut any_reader = AnyReader::from_str(InputFormat::Markdown, input);
+        let mut direct_reader = MarkdownReader::from_str(input);
         loop {
             let any_event = any_reader.next_event().expect("AnyReader failed");
             let direct_event = direct_reader.next_event().expect("MarkdownReader failed");
@@ -59,8 +59,8 @@ mod tests {
         use docspec_html_reader::HtmlReader;
 
         let input = "<p>hello</p>";
-        let mut any_reader = AnyReader::new(InputFormat::Html, input);
-        let mut direct_reader = HtmlReader::new(input);
+        let mut any_reader = AnyReader::from_str(InputFormat::Html, input);
+        let mut direct_reader = HtmlReader::from_str(input);
         loop {
             let any_event = any_reader.next_event().expect("AnyReader failed");
             let direct_event = direct_reader.next_event().expect("HtmlReader failed");
@@ -75,13 +75,41 @@ mod tests {
     #[test]
     fn assert_is_event_source() {
         fn check<S: EventSource>(_: S) {}
-        check(AnyReader::new(InputFormat::Markdown, ""));
+        check(AnyReader::from_str(InputFormat::Markdown, ""));
     }
 
     #[cfg(feature = "html")]
     #[test]
     fn html_assert_is_event_source() {
         fn check<S: EventSource>(_: S) {}
-        check(AnyReader::new(InputFormat::Html, ""));
+        check(AnyReader::from_str(InputFormat::Html, ""));
+    }
+
+    #[cfg(feature = "markdown")]
+    #[test]
+    fn any_reader_from_reader_matches_from_str_markdown() {
+        use std::io::Cursor;
+
+        let input = "# Hello\n\nWorld";
+        let mut r1 = AnyReader::from_str(InputFormat::Markdown, input);
+        let mut r2 =
+            AnyReader::from_reader(InputFormat::Markdown, Cursor::new(input.as_bytes())).unwrap();
+        let events1: Vec<_> = core::iter::from_fn(|| r1.next_event().unwrap()).collect();
+        let events2: Vec<_> = core::iter::from_fn(|| r2.next_event().unwrap()).collect();
+        assert_eq!(events1, events2);
+    }
+
+    #[cfg(feature = "html")]
+    #[test]
+    fn any_reader_from_reader_matches_from_str_html() {
+        use std::io::Cursor;
+
+        let input = "<p>hello</p>";
+        let mut r1 = AnyReader::from_str(InputFormat::Html, input);
+        let mut r2 =
+            AnyReader::from_reader(InputFormat::Html, Cursor::new(input.as_bytes())).unwrap();
+        let events1: Vec<_> = core::iter::from_fn(|| r1.next_event().unwrap()).collect();
+        let events2: Vec<_> = core::iter::from_fn(|| r2.next_event().unwrap()).collect();
+        assert_eq!(events1, events2);
     }
 }


### PR DESCRIPTION
Unify `HtmlReader` and `MarkdownReader` around `from_str` / `from_path` / `from_reader`. Updates `AnyReader` factory and all call sites (CLI, HTTP, WASM) to match.