### PR TITLE
ci(release): loosen semver lints for reader constructor refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,9 @@ large_enum_variant = "allow"
 feature_not_enabled_by_default = { required-update = "minor" }
 enum_variant_added = { required-update = "minor" }
 enum_marked_non_exhaustive = { required-update = "minor" }
+auto_trait_impl_removed = { required-update = "minor" }
+inherent_method_missing = { required-update = "minor" }
+type_mismatched_generic_lifetimes = { required-update = "minor" }
 
 [workspace.metadata.dist]
 # Cargo-dist version


### PR DESCRIPTION
Treats `auto_trait_impl_removed`, `inherent_method_missing`, and `type_mismatched_generic_lifetimes` as minor bumps via `[workspace.metadata.cargo-semver-checks.lints]`, matching the existing entries.

Unblocks the next release PR from proposing v2.0.0 over the reader constructor refactor.