### PR TITLE
feat: add DOCX input support across facade, CLI, and HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -478,6 +478,8 @@ dependencies = [
  "docspec-oxa-writer",
  "docspec-pandoc-native-writer",
  "serde_json",
+ "tempfile",
+ "zip",
 ]
 
 [[package]]
@@ -506,6 +508,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror",
+ "zip",
 ]
 
 [[package]]
@@ -564,6 +567,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "zip",
 ]
 
 [[package]]

--- a/crates/docspec-cli/Cargo.toml
+++ b/crates/docspec-cli/Cargo.toml
@@ -31,6 +31,7 @@ predicates = "3"
 tempfile = "3"
 serde_json = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking"] }
+zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -27,7 +27,7 @@ docspec convert [OPTIONS] [INPUT]
 #### Options
 
 - `-o, --output <FILE>` — Output file (stdout if omitted)
-- `-f, --from <FORMAT>` — Input format (auto-detected from extension if omitted). Valid values: `markdown`, `html`
+- `-f, --from <FORMAT>` — Input format (auto-detected from extension if omitted). Valid values: `markdown`, `html`, `docx`
 - `-t, --to <FORMAT>` — Output format (auto-detected from extension if omitted). Valid values: `blocknote`, `html`, `oxa`, `pandoc-native`
 - `--color <WHEN>` — When to use colors: `auto`, `always`, `never` (default: `auto`)
 - `-h, --help` — Print help
@@ -61,11 +61,13 @@ The resulting binary will only support `docspec convert`; running `docspec http`
 
 - `markdown` — Full Markdown support including headings, lists, tables, and inline formatting
 - `html` — HTML input (see note below)
+- `docx` — DOCX input (paragraphs and text only)
 
-> **Note:** HTML input and output currently preserve only paragraph text. Other HTML input
+> **Note:** HTML and DOCX input currently preserve only paragraph text. Other HTML input
 > elements and non-paragraph output events (headings, lists, tables, formatting tags, etc.)
-> are silently dropped. For fuller feature coverage, use Markdown input with BlockNote JSON
-> output.
+> are silently dropped. DOCX input preserves only paragraphs and text; styles, tables, lists,
+> images, headers/footers, and tracked changes are silently dropped. For fuller feature
+> coverage, use Markdown input with BlockNote JSON output.
 
 ## Examples
 
@@ -79,6 +81,12 @@ Convert an HTML file to BlockNote JSON (paragraphs only):
 
 ```bash
 docspec convert --from html --to blocknote input.html --output output.json
+```
+
+Convert a DOCX file to BlockNote JSON (paragraphs only):
+
+```bash
+docspec --from docx --to blocknote input.docx --output output.json
 ```
 
 Convert Markdown from stdin to BlockNote JSON on stdout:

--- a/crates/docspec-cli/src/args.rs
+++ b/crates/docspec-cli/src/args.rs
@@ -32,7 +32,7 @@ pub enum Commands {
 #[derive(clap::Args, Debug)]
 #[command(
     about = "Convert documents between formats using streaming event pipeline",
-    long_about = "Convert documents between formats using streaming event pipeline.\n\nSupports converting Markdown or HTML input to BlockNote JSON, HTML, oxa.dev JSON, or Pandoc native output.\n\nNote: HTML input and output currently preserve only paragraph text. Other HTML input\nelements and non-paragraph output events (headings, lists, tables, formatting, etc.)\nare silently dropped. Use BlockNote JSON output for fuller feature coverage."
+    long_about = "Convert documents between formats using streaming event pipeline.\n\nSupports converting Markdown, HTML, or DOCX input to BlockNote JSON, HTML, oxa.dev JSON, or Pandoc native output.\n\nNote: HTML and DOCX input currently preserve only paragraph text. Other HTML input\nelements and non-paragraph output events (headings, lists, tables, formatting, etc.)\nare silently dropped. DOCX input preserves only paragraphs and text; styles, tables,\nlists, images, headers/footers, and tracked changes are silently dropped. Use BlockNote\nJSON output for fuller feature coverage."
 )]
 pub struct ConvertArgs {
     /// When to use colors.
@@ -90,6 +90,9 @@ pub enum ColorChoice {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[non_exhaustive]
 pub enum CliInputFormat {
+    /// DOCX format (paragraphs and text only).
+    #[value(name = "docx")]
+    Docx,
     /// HTML format (paragraph-only; `<p>` elements and text within them only).
     #[value(name = "html")]
     Html,

--- a/crates/docspec-cli/src/commands/convert.rs
+++ b/crates/docspec-cli/src/commands/convert.rs
@@ -1,7 +1,7 @@
 //! `docspec convert` subcommand: convert documents between formats.
 
 use std::fs::File;
-use std::io::{BufWriter, Read as _, Write};
+use std::io::{BufWriter, Cursor, Read as _, Write};
 
 use docspec::{AnyReader, AnyWriter};
 
@@ -11,12 +11,10 @@ use crate::format;
 
 /// Runs the streaming conversion pipeline.
 fn run_pipeline<W: Write>(
-    input_format: docspec::InputFormat,
-    content: &str,
+    reader: AnyReader,
     output_format: docspec::OutputFormat,
     output: W,
 ) -> Result<()> {
-    let reader = AnyReader::from_str(input_format, content);
     let sink = AnyWriter::new(output_format, output);
     docspec_core::pipe(reader, sink).map_err(Into::into)
 }
@@ -54,36 +52,27 @@ pub fn run(args: ConvertArgs) -> Result<()> {
     )?;
 
     // Read input AFTER format validation
-    let raw_content = match input_path.as_ref() {
-        None => {
-            let mut buf = String::new();
-            std::io::stdin().lock().read_to_string(&mut buf)?;
-            buf
+    let reader = match input_path.as_ref() {
+        Some(path) if path.as_os_str() != "-" => AnyReader::from_path(input_format, path)?,
+        _ => {
+            let mut buf = Vec::new();
+            std::io::stdin().lock().read_to_end(&mut buf)?;
+            AnyReader::from_reader(input_format, Cursor::new(buf))?
         }
-        Some(path) if path.as_os_str() == "-" => {
-            let mut buf = String::new();
-            std::io::stdin().lock().read_to_string(&mut buf)?;
-            buf
-        }
-        Some(path) => std::fs::read_to_string(path)?,
     };
-    let content = raw_content
-        .strip_prefix('\u{FEFF}')
-        .unwrap_or(&raw_content)
-        .to_string();
 
-    output_path.as_ref().map_or_else(
-        || {
+    match output_path.as_ref() {
+        None => {
             let mut stdout = std::io::stdout().lock();
-            run_pipeline(input_format, &content, output_format, &mut stdout)?;
+            run_pipeline(reader, output_format, &mut stdout)?;
             write_cli_terminating_newline(&mut stdout)
-        },
-        |path| {
+        }
+        Some(path) => {
             let mut writer = BufWriter::new(File::create(path)?);
-            run_pipeline(input_format, &content, output_format, &mut writer)?;
+            run_pipeline(reader, output_format, &mut writer)?;
             write_cli_terminating_newline(&mut writer)?;
             writer.flush()?;
             Ok(())
-        },
-    )
+        }
+    }
 }

--- a/crates/docspec-cli/src/conversions.rs
+++ b/crates/docspec-cli/src/conversions.rs
@@ -10,6 +10,7 @@ impl From<CliInputFormat> for InputFormat {
         match f {
             CliInputFormat::Markdown => Self::Markdown,
             CliInputFormat::Html => Self::Html,
+            CliInputFormat::Docx => Self::Docx,
         }
     }
 }
@@ -41,6 +42,11 @@ mod tests {
     #[test]
     fn from_html_converts_to_facade_html() {
         assert_eq!(InputFormat::from(CliInputFormat::Html), InputFormat::Html);
+    }
+
+    #[test]
+    fn from_docx_converts_to_facade_docx() {
+        assert_eq!(InputFormat::from(CliInputFormat::Docx), InputFormat::Docx);
     }
 
     #[test]

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -1,5 +1,10 @@
-#![allow(clippy::unwrap_used, clippy::expect_used)]
 //! Integration tests for the `docspec` CLI binary.
+
+#![allow(
+    clippy::arbitrary_source_item_ordering,
+    clippy::expect_used,
+    clippy::unwrap_used
+)]
 
 use std::io::Write as _;
 
@@ -7,6 +12,7 @@ use assert_cmd::Command;
 use predicates::prelude::PredicateBooleanExt as _;
 use predicates::str::contains;
 use tempfile::NamedTempFile;
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
 fn docspec_cmd() -> Command {
     let result = Command::cargo_bin("docspec");
@@ -54,6 +60,21 @@ fn read_output(path: &std::path::Path) -> String {
         result.as_ref().err()
     );
     result.unwrap_or_else(|_| std::process::abort())
+}
+
+const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
+    use std::io::Cursor;
+    let buf = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(buf);
+    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    writer.start_file("_rels/.rels", opts).unwrap();
+    writer.write_all(rels_xml.as_bytes()).unwrap();
+    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    writer.start_file("word/document.xml", opts_doc).unwrap();
+    writer.write_all(document_xml.as_bytes()).unwrap();
+    writer.finish().unwrap().into_inner()
 }
 
 #[cfg(test)]
@@ -559,5 +580,83 @@ mod tests {
             .assert()
             .failure()
             .stderr(predicates::str::contains("subcommand").or(predicates::str::contains("Usage")));
+    }
+
+    #[test]
+    fn convert_docx_file_to_blocknote_stdout() {
+        let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>"#;
+        let bytes = synth_docx(SIMPLE_RELS, doc_xml);
+        let input = markdown_tempfile(&bytes, ".docx");
+
+        docspec_cmd()
+            .arg("convert")
+            .arg(input.path())
+            .args(["--to", "blocknote"])
+            .assert()
+            .success()
+            .stdout(contains("paragraph"));
+    }
+
+    #[test]
+    fn convert_docx_stdin_to_blocknote_stdout() {
+        let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>"#;
+        let bytes = synth_docx(SIMPLE_RELS, doc_xml);
+
+        docspec_cmd()
+            .args(["convert", "--from", "docx", "--to", "blocknote"])
+            .write_stdin(bytes)
+            .assert()
+            .success()
+            .stdout(contains("paragraph"));
+    }
+
+    #[test]
+    fn docx_stdin_without_from_flag_errors() {
+        let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>"#;
+        let bytes = synth_docx(SIMPLE_RELS, doc_xml);
+
+        docspec_cmd()
+            .args(["convert", "--to", "blocknote"])
+            .write_stdin(bytes)
+            .assert()
+            .failure()
+            .stderr(contains("cannot detect input format"));
+    }
+
+    #[test]
+    fn bom_prefixed_markdown_file_strips_bom() {
+        let content = b"\xef\xbb\xbf# Hello";
+        let input = markdown_tempfile(content, ".md");
+
+        docspec_cmd()
+            .arg("convert")
+            .arg(input.path())
+            .args(["--to", "blocknote"])
+            .assert()
+            .success()
+            .stdout(contains("Hello"))
+            .stdout(predicates::str::contains("\u{FEFF}Hello").not());
+    }
+
+    #[test]
+    fn bom_prefixed_markdown_stdin_strips_bom() {
+        let content = b"\xef\xbb\xbf# Hello";
+
+        docspec_cmd()
+            .args(["convert", "--from", "markdown", "--to", "blocknote"])
+            .write_stdin(content.as_ref())
+            .assert()
+            .success()
+            .stdout(contains("Hello"))
+            .stdout(predicates::str::contains("\u{FEFF}Hello").not());
+    }
+
+    #[test]
+    fn clap_rejects_unknown_input_format() {
+        docspec_cmd()
+            .args(["convert", "--from", "pdf", "--to", "blocknote"])
+            .assert()
+            .failure()
+            .stderr(contains("pdf"));
     }
 }

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -100,7 +100,7 @@ pub struct DocxReader {
     /// Queue of `DocSpec` events to emit.
     queue: VecDeque<Event>,
     /// The quick-xml reader streaming from the document entry.
-    xml: quick_xml::Reader<BufReader<Box<dyn Read>>>,
+    xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
 }
 
 impl fmt::Debug for DocxReader {
@@ -142,7 +142,7 @@ impl DocxReader {
     /// `_rels/.rels` is missing or malformed, or if the document target entry
     /// cannot be opened. Returns [`Error::Io`] for I/O failures.
     #[inline]
-    pub fn from_reader<R: Read + Seek + 'static>(mut reader: R) -> Result<Self> {
+    pub fn from_reader<R: Read + Seek + Send + 'static>(mut reader: R) -> Result<Self> {
         let mut archive = zip::ZipArchive::new(&mut reader).map_err(|err| match err {
             zip::result::ZipError::InvalidArchive(_)
             | zip::result::ZipError::UnsupportedArchive(_) => Error::Parse {
@@ -178,7 +178,7 @@ impl DocxReader {
 
         let limited = reader.take(compressed_size);
 
-        let stream: Box<dyn Read> = if method == zip::CompressionMethod::Stored {
+        let stream: Box<dyn Read + Send> = if method == zip::CompressionMethod::Stored {
             Box::new(limited)
         } else if method == zip::CompressionMethod::Deflated {
             Box::new(flate2::read::DeflateDecoder::new(limited))
@@ -425,6 +425,12 @@ mod tests {
     use super::*;
 
     const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+    #[test]
+    fn docx_reader_is_send_static() {
+        fn assert_send_static<T: Send + 'static>() {}
+        assert_send_static::<DocxReader>();
+    }
 
     fn synth_docx_for_unit_test(
         rels_xml: &str,

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -4,6 +4,7 @@
     clippy::expect_used,
     clippy::indexing_slicing,
     clippy::panic,
+    clippy::std_instead_of_core,
     clippy::tests_outside_test_module,
     clippy::unwrap_used
 )]
@@ -35,10 +36,10 @@ fn synth_docx_roundtrips_through_zip_archive() {
 }
 
 mod constructor {
-    use core::cell::Cell;
     use std::io::Cursor;
     use std::io::{Read, Seek};
-    use std::rc::Rc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
 
     use docspec_core::{Error, Event, EventSource as _};
     use docspec_docx_reader::DocxReader;
@@ -258,11 +259,12 @@ mod constructor {
                 b"<?xml version=\"1.0\"?><w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:body></w:body></w:document>",
             ),
         ]);
+
         let fail_at = document_data_start(&bytes);
-        let fail_enabled = Rc::new(Cell::new(false));
-        let failing_reader = FailingReader::new(bytes, fail_at, Rc::clone(&fail_enabled));
+        let fail_enabled = Arc::new(AtomicBool::new(false));
+        let failing_reader = FailingReader::new(bytes, fail_at, Arc::clone(&fail_enabled));
         let mut reader = DocxReader::from_reader(failing_reader).expect("from_reader");
-        fail_enabled.set(true);
+        fail_enabled.store(true, Ordering::SeqCst);
 
         assert_eq!(
             reader.next_event().expect("start document"),
@@ -294,12 +296,12 @@ mod constructor {
 
     struct FailingReader {
         cursor: Cursor<Vec<u8>>,
-        fail_enabled: Rc<Cell<bool>>,
+        fail_enabled: Arc<AtomicBool>,
         fail_at: u64,
     }
 
     impl FailingReader {
-        fn new(bytes: Vec<u8>, fail_at: u64, fail_enabled: Rc<Cell<bool>>) -> Self {
+        fn new(bytes: Vec<u8>, fail_at: u64, fail_enabled: Arc<AtomicBool>) -> Self {
             Self {
                 cursor: Cursor::new(bytes),
                 fail_enabled,
@@ -310,7 +312,7 @@ mod constructor {
 
     impl Read for FailingReader {
         fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-            if self.fail_enabled.get() && self.cursor.position() >= self.fail_at {
+            if self.fail_enabled.load(Ordering::SeqCst) && self.cursor.position() >= self.fail_at {
                 return Err(std::io::Error::other("forced read failure"));
             }
             self.cursor.read(buf)

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -54,6 +54,7 @@ tower = { version = "0.5", features = ["util"] }
 serde_json = "1"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
 uuid = "1"
+zip = { version = "8", default-features = false, features = ["deflate"] }
 sentry = { version = "0.48", default-features = false, features = [
   "backtrace",
   "contexts",

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -2,7 +2,7 @@
 
 Library providing an Axum-based HTTP server that wraps a DocSpec conversion pipeline. Designed for embedding in custom binaries or running via the unified `docspec http` subcommand.
 
-Send markdown (`Content-Type: text/markdown`) or HTML (`Content-Type: text/html`), receive BlockNote JSON (default), HTML (`Accept: text/html`), oxa.dev JSON (`Accept: application/vnd.oxa+json`), or Pandoc native (`Accept: application/vnd.pandoc.native`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
+Send markdown (`Content-Type: text/markdown`), HTML (`Content-Type: text/html`), or DOCX (`Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document`), receive BlockNote JSON (default), HTML (`Accept: text/html`), oxa.dev JSON (`Accept: application/vnd.oxa+json`), or Pandoc native (`Accept: application/vnd.pandoc.native`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
 
 > **HTML is paragraph-only.** The HTML reader currently parses `<p>` elements only, and the HTML writer currently emits only paragraph events. Other HTML input elements and non-paragraph output events (headings, lists, tables, formatting, etc.) are silently dropped. See [docspec-html-reader](../docspec-html-reader/README.md) and [docspec-html-writer](../docspec-html-writer/README.md).
 
@@ -31,6 +31,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Once the server is running, send documents with curl:
+
+```bash
+# Convert Markdown to BlockNote JSON
+curl -X POST \
+     -H 'Content-Type: text/markdown' \
+     -d '# Hello' \
+     http://localhost:3000/conversion
+
+# Convert HTML to BlockNote JSON
+curl -X POST \
+     -H 'Content-Type: text/html' \
+     -d '<p>Hello</p>' \
+     http://localhost:3000/conversion
+
+# Convert DOCX to BlockNote JSON
+curl -X POST \
+     -H 'Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document' \
+     --data-binary @document.docx \
+     http://localhost:3000/conversion
+```
+
 ## Public API
 
 | Item | Kind | Description |
@@ -46,7 +68,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 | Method  | Path        | Description                                                      |
 | ------- | ----------- | ---------------------------------------------------------------- |
-| POST    | /conversion | Convert markdown or HTML to BlockNote (default), HTML, oxa.dev JSON, or Pandoc native |
+| POST    | /conversion | Convert markdown, HTML, or DOCX to BlockNote (default), HTML, oxa.dev JSON, or Pandoc native |
 | OPTIONS | /conversion | Preflight / allowed methods                                      |
 | GET     | /health     | Liveness check                                                   |
 | HEAD    | /health     | Liveness check (no body)                                         |
@@ -71,8 +93,8 @@ All errors use RFC 7807 Problem Details JSON (`application/problem+json; charset
 | 404  | Unknown path                                             |
 | 405  | Wrong method (response includes `Allow` header)          |
 | 406  | `Accept` header excludes all supported output types      |
-| 415  | `Content-Type` must be `text/markdown` or `text/html`    |
-| 422  | Input parse error (malformed markdown or HTML)           |
+| 415  | `Content-Type` must be `text/markdown`, `text/html`, or `application/vnd.openxmlformats-officedocument.wordprocessingml.document` |
+| 422  | Input parse error (malformed markdown, HTML, or DOCX)    |
 | 500  | Internal conversion error                                |
 
 Accepted `Accept` values for `/conversion`: `text/html` (HTML), `application/vnd.oxa+json` (oxa.dev), `application/vnd.pandoc.native` (Pandoc native), `application/vnd.docspec.blocknote+json`, `application/vnd.blocknote+json` (BlockNote alias), `application/*`, or `*/*`. Wildcards and missing `Accept` default to BlockNote for back-compat. Anything else returns 406.
@@ -135,7 +157,7 @@ These follow Sentry's standard conventions:
 
 `docspec-http` does NOT send the following to Sentry:
 
-- Request bodies (markdown or HTML documents)
+- Request bodies (markdown, HTML, or DOCX documents)
 - Response bodies (BlockNote JSON, HTML, oxa.dev JSON, or Pandoc native)
 - PII (Sentry default: `send_default_pii = false`)
 - DSN values (never logged or echoed)
@@ -180,7 +202,7 @@ The server handles SIGINT and SIGTERM. In-flight requests complete before the pr
 
 **`error_class`**: `body_not_utf8`, `empty_body`, `internal`, `method_not_allowed`, `not_acceptable`, `not_found`, `unprocessable`, `unsupported_media_type`, `none` (only when `result=success`)
 
-**`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `text/html` (the request's Content-Type matched the HTML reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
+**`input_mime_type`**: `text/markdown` (the request's Content-Type matched the markdown reader), `text/html` (the request's Content-Type matched the HTML reader), `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (the request's Content-Type matched the DOCX reader), `unsupported` (Content-Type header present but not a supported input format), `none` (Content-Type header absent).
 
 **`output_mime_type`**: `application/vnd.docspec.blocknote+json` (conversion succeeded; output produced by the BlockNote writer), `text/html` (conversion succeeded; output produced by the HTML writer), `application/vnd.oxa+json` (conversion succeeded; output produced by the oxa.dev writer), `application/vnd.pandoc.native` (conversion succeeded; output produced by the Pandoc native writer), `none` (no output produced — any error path).
 
@@ -192,7 +214,7 @@ The server handles SIGINT and SIGTERM. In-flight requests complete before the pr
 
 ### Cardinality Guarantees
 
-`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 4 values (`text/markdown`, `text/html`, `unsupported`, `none`). `output_mime_type` is bounded to 5 values (`application/vnd.docspec.blocknote+json`, `text/html`, `application/vnd.oxa+json`, `application/vnd.pandoc.native`, `none`). Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
+`path` is bounded to `{"/conversion", "/health", "unknown"}`. `error_class` is bounded to 9 values. `result` is bounded to 3 values. Per-request identifiers (`X-Request-ID`, `X-Trace-ID`) are never used as labels. `input_mime_type` is bounded to 5 values (`text/markdown`, `text/html`, `application/vnd.openxmlformats-officedocument.wordprocessingml.document`, `unsupported`, `none`). `output_mime_type` is bounded to 5 values (`application/vnd.docspec.blocknote+json`, `text/html`, `application/vnd.oxa+json`, `application/vnd.pandoc.native`, `none`). Both come from a fixed set of `&'static str` constants in the source — never from raw header values.
 
 ### Scrape Model
 

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -125,7 +125,7 @@ pub enum HttpError {
         /// Explanation of what made the input invalid.
         detail: String,
     },
-    /// The `Content-Type` header is neither `text/markdown` nor `text/html`.
+    /// The `Content-Type` header is not one of the supported types: `text/markdown`, `text/html`, or `application/vnd.openxmlformats-officedocument.wordprocessingml.document`.
     ///
     /// → HTTP 415 Unsupported Media Type.
     UnsupportedMediaType {
@@ -185,7 +185,7 @@ impl IntoResponse for HttpError {
             Self::UnsupportedMediaType { received: None } => (
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
                 "Unsupported Media Type",
-                Cow::Borrowed("Content-Type must be text/markdown or text/html"),
+                Cow::Borrowed("Content-Type must be text/markdown, text/html, or application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
                 None,
             ),
             Self::UnsupportedMediaType {
@@ -194,7 +194,7 @@ impl IntoResponse for HttpError {
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
                 "Unsupported Media Type",
                 Cow::Owned(format!(
-                    "Content-Type must be text/markdown or text/html, got {content_type}"
+                    "Content-Type must be text/markdown, text/html, or application/vnd.openxmlformats-officedocument.wordprocessingml.document, got {content_type}"
                 )),
                 None,
             ),
@@ -479,7 +479,7 @@ mod tests {
                 "type": "about:blank",
                 "title": "Unsupported Media Type",
                 "status": 415,
-                "detail": "Content-Type must be text/markdown or text/html, got application/json",
+                "detail": "Content-Type must be text/markdown, text/html, or application/vnd.openxmlformats-officedocument.wordprocessingml.document, got application/json",
             })
         );
     }

--- a/crates/docspec-http/src/format.rs
+++ b/crates/docspec-http/src/format.rs
@@ -9,6 +9,13 @@ pub const HEALTH_BODY: &str = "Healthy.";
 /// The MIME type accepted as request body.
 pub const INPUT_MIME_MARKDOWN: &str = "text/markdown";
 
+/// The MIME type accepted as request body for HTML input.
+pub const INPUT_MIME_HTML: &str = "text/html";
+
+/// MIME type for DOCX documents. Strict — must be sent verbatim with no parameters.
+pub const INPUT_MIME_DOCX_PRIMARY: &str =
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
 /// Accepted alias for the output MIME type (input-only; server always returns primary).
 pub const OUTPUT_MIME_ALIAS: &str = "application/vnd.blocknote+json";
 

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -5,10 +5,16 @@ use axum::{
     http::{header, HeaderMap, HeaderValue, Response, StatusCode},
     response::IntoResponse,
 };
-use docspec::OutputFormat;
+use docspec::{InputFormat, OutputFormat};
 use docspec_core::{EventSink as _, EventSource as _};
 
 use crate::{error::HttpError, mime_parser};
+
+enum Utf8Prevalidation {
+    Required,
+    SkippedBinary,
+    SkippedFutureFormat,
+}
 
 /// Handle `OPTIONS /conversion` — returns allowed methods.
 #[allow(clippy::unused_async)]
@@ -169,14 +175,36 @@ async fn do_conversion(
     )
     .record(body_len_bytes);
 
-    let input_text = String::from_utf8(body.into()).map_err(|error| {
-        tracing::debug!(error = %error, "request body is not valid UTF-8");
-        HttpError::BodyNotUtf8
-    })?;
+    let utf8_prevalidation = match input_format {
+        InputFormat::Markdown | InputFormat::Html => Utf8Prevalidation::Required,
+        InputFormat::Docx => {
+            // Binary format; UTF-8 prevalidation does not apply.
+            Utf8Prevalidation::SkippedBinary
+        }
+        _ => {
+            // Future InputFormat variants. Conservative policy: skip UTF-8
+            // prevalidation and let the reader surface its own error.
+            // Update this arm deliberately when a new format is added.
+            Utf8Prevalidation::SkippedFutureFormat
+        }
+    };
+
+    if matches!(utf8_prevalidation, Utf8Prevalidation::Required) {
+        core::str::from_utf8(&body).map_err(|_error| {
+            tracing::debug!("request body is not valid UTF-8");
+            HttpError::BodyNotUtf8
+        })?;
+    }
 
     let join_result = tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64), HttpError> {
         let mut output_buffer = Vec::new();
-        let mut reader = docspec::AnyReader::from_str(input_format, &input_text);
+        let mut reader = docspec::AnyReader::from_reader(input_format, std::io::Cursor::new(body))
+            .map_err(|error| {
+                tracing::debug!(error = %error, "reader construction failed");
+                HttpError::Unprocessable {
+                    detail: error.to_string(),
+                }
+            })?;
         let mut sink = docspec::AnyWriter::new(output_format, &mut output_buffer);
 
         loop {

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -84,6 +84,10 @@ pub const INPUT_MIME_MARKDOWN: &str = "text/markdown";
 /// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was text/html.
 pub const INPUT_MIME_HTML: &str = "text/html";
 
+/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was a DOCX document.
+pub const INPUT_MIME_DOCX: &str =
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
 /// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was present but not a supported reader format.
 pub const INPUT_MIME_UNSUPPORTED: &str = "unsupported";
 

--- a/crates/docspec-http/src/mime_parser.rs
+++ b/crates/docspec-http/src/mime_parser.rs
@@ -57,13 +57,15 @@ pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<OutputForm
 /// Validates the `Content-Type` header for the `/conversion` endpoint and
 /// resolves it to the matching reader format.
 ///
-/// Accepts `text/markdown` ([`InputFormat::Markdown`]) and `text/html`
-/// ([`InputFormat::Html`]), each with no charset, or with `charset=utf-8`
-/// (case-insensitive). Any other charset is rejected — the handler always
-/// decodes the body as UTF-8, so a non-UTF-8 charset is unsupportable.
-/// Returns `Err` if the header is missing, malformed, the MIME type is
-/// neither `text/markdown` nor `text/html`, the charset is anything other
-/// than `utf-8`, or an unknown parameter is present.
+/// Accepts `text/markdown` ([`InputFormat::Markdown`]), `text/html`
+/// ([`InputFormat::Html`]), and
+/// `application/vnd.openxmlformats-officedocument.wordprocessingml.document`
+/// ([`InputFormat::Docx`]). Text types accept no charset, or `charset=utf-8`
+/// (case-insensitive). DOCX is a binary format — no parameters are allowed at
+/// all. Any other charset is rejected — the handler always decodes the body as
+/// UTF-8, so a non-UTF-8 charset is unsupportable. Returns `Err` if the header
+/// is missing, malformed, the MIME type is unsupported, the charset is anything
+/// other than `utf-8` for text types, or any parameter is present on DOCX.
 ///
 /// # Errors
 ///
@@ -86,6 +88,18 @@ pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<Input
             .ok_or_else(|| HttpError::UnsupportedMediaType {
                 received: Some(header_str.to_owned()),
             })?;
+    // DOCX: strict — no parameters allowed (binary format; charset is meaningless)
+    if parsed.type_() == mime::APPLICATION
+        && parsed.subtype().as_str()
+            == "vnd.openxmlformats-officedocument.wordprocessingml.document"
+    {
+        if parsed.params().next().is_some() {
+            return Err(HttpError::UnsupportedMediaType {
+                received: Some(header_str.to_owned()),
+            });
+        }
+        return Ok(InputFormat::Docx);
+    }
     let format = match (parsed.type_(), parsed.subtype().as_str()) {
         (mime::TEXT, "markdown") => InputFormat::Markdown,
         (mime::TEXT, "html") => InputFormat::Html,
@@ -118,8 +132,8 @@ pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<Input
 /// Returns the bounded `input_mime_type` label value for a `Content-Type` header.
 ///
 /// This function is intentionally MORE permissive than [`validate_content_type`]:
-/// it returns the matching label for any `text/markdown` or `text/html` value
-/// regardless of charset or other parameters, because the label answers
+/// it returns the matching label for any `text/markdown`, `text/html`, or DOCX
+/// value regardless of charset or other parameters, because the label answers
 /// "what did the client try to send?" rather than "is it valid?".
 ///
 /// # Label values
@@ -127,6 +141,7 @@ pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<Input
 /// - [`crate::metrics::INPUT_MIME_NONE`] — header absent
 /// - [`crate::metrics::INPUT_MIME_MARKDOWN`] — `text/markdown` (any params)
 /// - [`crate::metrics::INPUT_MIME_HTML`] — `text/html` (any params)
+/// - [`crate::metrics::INPUT_MIME_DOCX`] — `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (any params)
 /// - [`crate::metrics::INPUT_MIME_UNSUPPORTED`] — anything else
 #[must_use]
 #[inline]
@@ -143,6 +158,9 @@ pub fn bucket_input_mime(header_value: Option<&HeaderValue>) -> &'static str {
     match (parsed.type_(), parsed.subtype().as_str()) {
         (mime::TEXT, "markdown") => crate::metrics::INPUT_MIME_MARKDOWN,
         (mime::TEXT, "html") => crate::metrics::INPUT_MIME_HTML,
+        (mime::APPLICATION, "vnd.openxmlformats-officedocument.wordprocessingml.document") => {
+            crate::metrics::INPUT_MIME_DOCX
+        }
         _ => crate::metrics::INPUT_MIME_UNSUPPORTED,
     }
 }

--- a/crates/docspec-http/tests/common/mod.rs
+++ b/crates/docspec-http/tests/common/mod.rs
@@ -8,14 +8,20 @@
 //! blocking work must record metrics in the async context (this matches
 //! the production pattern established in the conversion handler).
 #![allow(
+    clippy::arbitrary_source_item_ordering,
+    clippy::expect_used,
+    clippy::impl_trait_in_params,
+    clippy::shadow_unrelated,
     clippy::tests_outside_test_module,
     clippy::unwrap_used,
-    clippy::expect_used,
     dead_code
 )]
 
+use std::io::Write as _;
+
 use axum::{body::Body, http::Request, Router};
 use metrics_exporter_prometheus::PrometheusHandle;
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
 
 /// Builds a single-threaded Tokio runtime for synchronous integration tests.
 ///
@@ -106,4 +112,42 @@ where
     let (recorder, handle) = docspec_http::metrics::build_recorder().expect("test recorder builds");
     let result = metrics::with_local_recorder(&recorder, body);
     (handle, result)
+}
+
+/// Minimal `_rels/.rels` XML for a DOCX archive pointing at `word/document.xml`.
+pub const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+/// Builds a minimal 2-entry DOCX ZIP archive (Deflated) from raw XML strings.
+///
+/// # Panics
+///
+/// Panics if the ZIP writer fails (should never happen in tests).
+pub fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
+    use std::io::Cursor;
+    let buf = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(buf);
+    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    writer.start_file("_rels/.rels", opts).unwrap();
+    writer.write_all(rels_xml.as_bytes()).unwrap();
+    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    writer.start_file("word/document.xml", opts_doc).unwrap();
+    writer.write_all(document_xml.as_bytes()).unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+/// Builds a valid DOCX conversion request.
+///
+/// # Panics
+///
+/// Panics if the request builder rejects the supplied body.
+pub fn docx_request(body: impl Into<Body>) -> Request<Body> {
+    request(
+        "POST",
+        "/conversion",
+        &[(
+            "content-type",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        )],
+        body,
+    )
 }

--- a/crates/docspec-http/tests/http_integration.rs
+++ b/crates/docspec-http/tests/http_integration.rs
@@ -2,9 +2,10 @@
 
 // Reason: integration tests use standard test patterns with expect/unwrap.
 #![allow(
+    clippy::arbitrary_source_item_ordering,
+    clippy::expect_used,
     clippy::tests_outside_test_module,
-    clippy::unwrap_used,
-    clippy::expect_used
+    clippy::unwrap_used
 )]
 
 mod common;
@@ -208,9 +209,79 @@ async fn post_conversion_missing_content_type() {
             "type": "about:blank",
             "title": "Unsupported Media Type",
             "status": 415,
-            "detail": "Content-Type must be text/markdown or text/html",
+            "detail": "Content-Type must be text/markdown, text/html, or application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         })
     );
+}
+
+const DOCX_MIME: &str = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+fn hello_docx_bytes() -> Vec<u8> {
+    let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body></w:document>"#;
+    common::synth_docx(common::SIMPLE_RELS, doc_xml)
+}
+
+#[tokio::test]
+async fn post_conversion_docx_happy_path() {
+    let response = app()
+        .oneshot(common::docx_request(hello_docx_bytes()))
+        .await
+        .expect("request succeeds");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_body_json(response.into_body()).await;
+    let body_str = body.to_string();
+    assert!(
+        body_str.contains("paragraph"),
+        "expected paragraph in: {body_str}"
+    );
+}
+
+#[tokio::test]
+async fn post_conversion_docx_with_charset_param_rejected_415() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", &format!("{DOCX_MIME}; charset=utf-8"))],
+        hello_docx_bytes(),
+    );
+    let response = app().oneshot(request).await.expect("request succeeds");
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn post_conversion_docx_with_arbitrary_param_rejected_415() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", &format!("{DOCX_MIME}; foo=bar"))],
+        hello_docx_bytes(),
+    );
+    let response = app().oneshot(request).await.expect("request succeeds");
+    assert_eq!(response.status(), StatusCode::UNSUPPORTED_MEDIA_TYPE);
+}
+
+#[tokio::test]
+async fn post_conversion_docx_invalid_zip_returns_422() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", DOCX_MIME)],
+        b"not a zip".to_vec(),
+    );
+    let response = app().oneshot(request).await.expect("request succeeds");
+    assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+}
+
+#[tokio::test]
+async fn post_conversion_docx_empty_body_returns_400() {
+    let request = common::request(
+        "POST",
+        "/conversion",
+        &[("content-type", DOCX_MIME)],
+        b"".to_vec(),
+    );
+    let response = app().oneshot(request).await.expect("request succeeds");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]
@@ -233,7 +304,7 @@ async fn post_conversion_wrong_content_type() {
             "type": "about:blank",
             "title": "Unsupported Media Type",
             "status": 415,
-            "detail": "Content-Type must be text/markdown or text/html, got application/json",
+            "detail": "Content-Type must be text/markdown, text/html, or application/vnd.openxmlformats-officedocument.wordprocessingml.document, got application/json",
         })
     );
 }
@@ -258,7 +329,7 @@ async fn post_conversion_multipart_content_type() {
             "type": "about:blank",
             "title": "Unsupported Media Type",
             "status": 415,
-            "detail": "Content-Type must be text/markdown or text/html, got multipart/form-data; boundary=x",
+            "detail": "Content-Type must be text/markdown, text/html, or application/vnd.openxmlformats-officedocument.wordprocessingml.document, got multipart/form-data; boundary=x",
         })
     );
 }

--- a/crates/docspec-http/tests/metrics_conversion.rs
+++ b/crates/docspec-http/tests/metrics_conversion.rs
@@ -473,3 +473,54 @@ fn pandoc_native_success_records_pandoc_native_output_mime() {
         r#"docspec_conversions_total{result="success",error_class="none",input_mime_type="text/markdown",output_mime_type="application/vnd.pandoc.native"} 1"#,
     );
 }
+
+// ─── Test 17: DOCX success increments conversions_total ──────────────────────
+
+/// A successful DOCX conversion increments `docspec_conversions_total` with
+/// the full DOCX MIME as `input_mime_type` and `result="success"`.
+#[test]
+fn docx_success_increments_conversions_total() {
+    let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body></w:document>"#;
+    let bytes = common::synth_docx(common::SIMPLE_RELS, doc_xml);
+
+    let rt = common::runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(common::docx_request(bytes)))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert_metric_line(
+        &rendered,
+        r#"docspec_conversions_total{result="success",error_class="none",input_mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",output_mime_type="application/vnd.docspec.blocknote+json"} 1"#,
+    );
+}
+
+// ─── Test 18: DOCX input records DOCX input_mime_type ────────────────────────
+
+/// A successful DOCX conversion records the full DOCX MIME as `input_mime_type`
+/// in the rendered Prometheus metrics.
+#[test]
+fn metrics_label_for_docx_input() {
+    let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>Hello</w:t></w:r></w:p></w:body></w:document>"#;
+    let bytes = common::synth_docx(common::SIMPLE_RELS, doc_xml);
+
+    let rt = common::runtime();
+    let (recorder, handle) = docspec_http::metrics::build_recorder().expect("builds");
+    let router = docspec_http::router::router_with_metrics(handle.clone());
+
+    metrics::with_local_recorder(&recorder, || {
+        rt.block_on(router.oneshot(common::docx_request(bytes)))
+    })
+    .expect("oneshot succeeds");
+
+    let rendered = handle.render();
+    assert!(
+        rendered
+            .contains("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        "DOCX MIME should appear in metrics: {rendered}"
+    );
+}

--- a/crates/docspec-http/tests/mime_parser.rs
+++ b/crates/docspec-http/tests/mime_parser.rs
@@ -270,3 +270,60 @@ fn accept_application_wildcard_returns_blocknote() {
         OutputFormat::Blocknote
     );
 }
+
+// ─── validate_content_type: DOCX ─────────────────────────────────────────────
+
+#[test]
+fn content_type_docx_returns_docx_format() {
+    let header = HeaderValue::from_static(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+    assert_eq!(
+        validate_content_type(Some(&header)).unwrap(),
+        InputFormat::Docx
+    );
+}
+
+#[test]
+fn content_type_docx_with_charset_rejects() {
+    let header = HeaderValue::from_static(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document; charset=utf-8",
+    );
+    assert!(matches!(
+        validate_content_type(Some(&header)),
+        Err(HttpError::UnsupportedMediaType { received: Some(_) })
+    ));
+}
+
+#[test]
+fn content_type_docx_with_arbitrary_param_rejects() {
+    let header = HeaderValue::from_static(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document; foo=bar",
+    );
+    assert!(matches!(
+        validate_content_type(Some(&header)),
+        Err(HttpError::UnsupportedMediaType { received: Some(_) })
+    ));
+}
+
+#[test]
+fn bucket_input_mime_docx_returns_docx_label() {
+    let header = HeaderValue::from_static(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    );
+    assert_eq!(
+        docspec_http::mime_parser::bucket_input_mime(Some(&header)),
+        docspec_http::metrics::INPUT_MIME_DOCX
+    );
+}
+
+#[test]
+fn bucket_input_mime_docx_with_params_returns_docx_label() {
+    let header = HeaderValue::from_static(
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document; charset=utf-8",
+    );
+    assert_eq!(
+        docspec_http::mime_parser::bucket_input_mime(Some(&header)),
+        docspec_http::metrics::INPUT_MIME_DOCX
+    );
+}

--- a/crates/docspec-wasm/src/lib.rs
+++ b/crates/docspec-wasm/src/lib.rs
@@ -13,7 +13,8 @@ use wasm_bindgen::prelude::*;
 /// parse error, invalid event sequence, or JSON serialization error.
 #[wasm_bindgen]
 pub fn convert_markdown_to_blocknote(markdown: &str) -> core::result::Result<String, JsValue> {
-    let reader = docspec::AnyReader::from_str(docspec::InputFormat::Markdown, markdown);
+    let reader = docspec::AnyReader::from_str(docspec::InputFormat::Markdown, markdown)
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
     let mut output = Vec::new();
     let sink = docspec::AnyWriter::new(docspec::OutputFormat::Blocknote, &mut output);
     docspec_core::pipe(reader, sink).map_err(|e| JsValue::from_str(&e.to_string()))?;

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -51,6 +51,8 @@ docspec-pandoc-native-writer = { workspace = true, optional = true }
 
 [dev-dependencies]
 serde_json = "1"
+tempfile = "3"
+zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -40,9 +40,18 @@ writer.finish()?;
 | `html`     | HTML (paragraphs only)                           | `docspec-html-reader`     |
 | `docx`     | DOCX (paragraphs and text only)                  | `docspec-docx-reader`     |
 
-`DocxReader` takes a file path or `Read + Seek` source. Construct it directly with
-`DocxReader::from_path` or `DocxReader::from_reader`. Support for dispatching
-`DocxReader` through `AnyReader::from_reader` is planned for a future release.
+`DocxReader` is dispatched through `AnyReader::from_reader` and `AnyReader::from_path`.
+Use `AnyReader::from_path(InputFormat::Docx, path)` to open a DOCX file, or
+`AnyReader::from_reader(InputFormat::Docx, cursor)` to read from an in-memory buffer.
+
+```rust
+use docspec::{AnyReader, InputFormat};
+
+# fn main() -> docspec::Result<()> {
+let reader = AnyReader::from_path(InputFormat::Docx, "document.docx")?;
+# Ok(())
+# }
+```
 
 ### Writers
 

--- a/crates/docspec/src/factory/bom_stripping_reader.rs
+++ b/crates/docspec/src/factory/bom_stripping_reader.rs
@@ -1,0 +1,150 @@
+//! Internal helper: wraps a `Read + Seek` source and silently consumes a
+//! leading UTF-8 byte-order mark (U+FEFF, bytes `0xEF 0xBB 0xBF`) on the
+//! first read, leaving the position immediately after the BOM. If no BOM
+//! is present, the reader rewinds to the start so the caller sees the
+//! original bytes unchanged.
+//!
+//! Private to the facade — used by [`crate::factory::reader::AnyReader::from_reader`]
+//! to apply BOM-stripping uniformly across all text-format readers without
+//! requiring each concrete reader to implement BOM handling.
+
+use std::io::{Read, Seek, SeekFrom};
+
+use docspec_core::Result;
+
+/// Detects and skips a leading UTF-8 BOM on the wrapped reader.
+///
+/// Construction performs the BOM check eagerly via [`Self::new`].
+/// After construction, the reader is positioned either just past the BOM
+/// (if present) or back at byte 0 (if no BOM was found). All subsequent
+/// `Read` operations transparently forward to the inner reader.
+#[derive(Debug)]
+pub(in crate::factory) struct BomStrippingReader<R: Read + Seek> {
+    inner: R,
+}
+
+impl<R: Read + Seek> BomStrippingReader<R> {
+    /// Wraps `reader` and consumes a leading UTF-8 BOM if present.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the underlying reader returns an I/O error during the
+    /// BOM probe or the subsequent seek-back.
+    pub(in crate::factory) fn new(mut reader: R) -> Result<Self> {
+        let mut probe = [u8::default(); 3];
+        let start = reader
+            .stream_position()
+            .map_err(|source| docspec_core::Error::Io { source })?;
+        let read_count = read_up_to_3(&mut reader, &mut probe)
+            .map_err(|source| docspec_core::Error::Io { source })?;
+        let has_bom = read_count == 3 && probe == [0xEF, 0xBB, 0xBF];
+        if !has_bom {
+            // Rewind to the original position so the caller sees every byte.
+            reader
+                .seek(SeekFrom::Start(start))
+                .map_err(|source| docspec_core::Error::Io { source })?;
+        }
+        Ok(Self { inner: reader })
+    }
+}
+
+impl<R: Read + Seek> Read for BomStrippingReader<R> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl<R: Read + Seek> Seek for BomStrippingReader<R> {
+    #[inline]
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+/// Reads up to 3 bytes into `buf`, handling short reads gracefully.
+///
+/// Returns the number of bytes actually read (0, 1, 2, or 3). Unlike
+/// `read_exact`, this never returns `UnexpectedEof` for inputs shorter than
+/// 3 bytes — those are valid text (e.g. empty input, one character).
+fn read_up_to_3<R: Read>(reader: &mut R, buf: &mut [u8; 3]) -> std::io::Result<usize> {
+    let mut filled = usize::default();
+    while filled < 3 {
+        let remaining = buf.get_mut(filled..).ok_or_else(|| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "BOM probe index exceeds buffer length",
+            )
+        })?;
+        match reader.read(remaining) {
+            Ok(0) => break,
+            Ok(n) => filled = filled.saturating_add(n),
+            Err(error) if error.kind() == std::io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(filled)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use std::io::{Cursor, Read as _};
+
+    use super::*;
+
+    #[test]
+    fn strips_bom_when_present() {
+        let mut reader = BomStrippingReader::new(Cursor::new(b"\xEF\xBB\xBF# Hello".to_vec()))
+            .expect("BOM probe succeeds");
+        let mut out = String::new();
+        reader.read_to_string(&mut out).expect("read succeeds");
+        assert_eq!(out, "# Hello");
+    }
+
+    #[test]
+    fn passes_through_when_no_bom() {
+        let mut reader =
+            BomStrippingReader::new(Cursor::new(b"# Hello".to_vec())).expect("probe succeeds");
+        let mut out = String::new();
+        reader.read_to_string(&mut out).expect("read succeeds");
+        assert_eq!(out, "# Hello");
+    }
+
+    #[test]
+    fn handles_empty_input() {
+        let mut reader = BomStrippingReader::new(Cursor::new(Vec::<u8>::new())).expect("probe");
+        let mut out = String::new();
+        reader.read_to_string(&mut out).expect("read");
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn handles_short_input_no_bom() {
+        let mut reader =
+            BomStrippingReader::new(Cursor::new(b"hi".to_vec())).expect("probe succeeds");
+        let mut out = String::new();
+        reader.read_to_string(&mut out).expect("read");
+        assert_eq!(out, "hi");
+    }
+
+    #[test]
+    fn handles_bom_only_input() {
+        let mut reader =
+            BomStrippingReader::new(Cursor::new(b"\xEF\xBB\xBF".to_vec())).expect("probe succeeds");
+        let mut out = String::new();
+        reader.read_to_string(&mut out).expect("read");
+        assert_eq!(out, "");
+    }
+
+    #[test]
+    fn handles_partial_bom_sequence() {
+        // Bytes that look like start of BOM but are not — must NOT strip
+        let mut reader =
+            BomStrippingReader::new(Cursor::new(b"\xEF\xBB X".to_vec())).expect("probe succeeds");
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).expect("read succeeds");
+        assert_eq!(out, b"\xEF\xBB X");
+    }
+}

--- a/crates/docspec/src/factory/mod.rs
+++ b/crates/docspec/src/factory/mod.rs
@@ -1,2 +1,3 @@
+mod bom_stripping_reader;
 pub mod reader;
 pub mod writer;

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -1,9 +1,13 @@
 //! Reader factory for creating readers from input formats.
 
+#[cfg(feature = "docx")]
+use std::io::Cursor;
 use std::io::{Read, Seek};
 
 use docspec_core::{Event, EventSource, Result};
 
+#[cfg(feature = "docx")]
+use docspec_docx_reader::DocxReader;
 #[cfg(feature = "html")]
 use docspec_html_reader::HtmlReader;
 #[cfg(feature = "markdown")]
@@ -13,15 +17,18 @@ use crate::format::InputFormat;
 
 /// Enum-dispatch reader for any registered input format.
 ///
-/// Constructed via [`AnyReader::from_str`] or [`AnyReader::from_reader`].
-/// Implements [`EventSource`] by delegating `next_event` to the inner concrete
-/// reader. Zero heap allocation, zero virtual-dispatch overhead.
+/// Constructed via [`AnyReader::from_str`], [`AnyReader::from_reader`], or
+/// [`AnyReader::from_path`]. Implements [`EventSource`] by delegating `next_event`
+/// to the inner concrete reader. Zero heap allocation, zero virtual-dispatch overhead.
 ///
-/// Both `MarkdownReader` and `HtmlReader` are `Send + 'static`, so `AnyReader`
-/// is also `Send + 'static` — suitable for use across `tokio::task::spawn_blocking`
-/// boundaries.
+/// `MarkdownReader`, `HtmlReader`, and `DocxReader` are all `Send + 'static`, so
+/// `AnyReader` is also `Send + 'static` — suitable for use across
+/// `tokio::task::spawn_blocking` boundaries.
 #[non_exhaustive]
 pub enum AnyReader {
+    /// DOCX reader from [`docspec_docx_reader`].
+    #[cfg(feature = "docx")]
+    Docx(DocxReader),
     /// HTML reader from [`docspec_html_reader`] (paragraph-only; see crate docs).
     #[cfg(feature = "html")]
     Html(HtmlReader),
@@ -31,10 +38,39 @@ pub enum AnyReader {
 }
 
 impl AnyReader {
+    /// Construct a reader by opening a file at `path`. The file is opened with
+    /// `File::open` and passed to [`from_reader`](Self::from_reader). Works for
+    /// all formats including DOCX.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if the file cannot be opened or if the format-specific
+    /// reader construction fails.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use docspec::AnyReader;
+    /// use docspec::InputFormat;
+    ///
+    /// # fn main() -> docspec::Result<()> {
+    /// let reader = AnyReader::from_path(InputFormat::Docx, "document.docx")?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn from_path<P: AsRef<std::path::Path>>(format: InputFormat, path: P) -> Result<Self> {
+        let file = std::fs::File::open(path.as_ref())
+            .map_err(|source| docspec_core::Error::Io { source })?;
+        Self::from_reader(format, file)
+    }
+
     /// Construct a reader for the given format from any `Read + Seek` source.
     ///
     /// The `Send + 'static` bounds are required so the resulting `AnyReader`
     /// can be moved across `tokio::task::spawn_blocking` boundaries.
+    /// Text-format readers (Markdown, Html) automatically strip a leading UTF-8
+    /// BOM (U+FEFF). Binary formats (DOCX) pass the bytes through unchanged.
     ///
     /// # Errors
     ///
@@ -58,25 +94,41 @@ impl AnyReader {
         format: InputFormat,
         reader: R,
     ) -> Result<Self> {
-        #[cfg(not(any(feature = "markdown", feature = "html")))]
+        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
         {
             let _ = reader;
             match format {}
         }
-        #[cfg(any(feature = "markdown", feature = "html"))]
+        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
         match format {
+            #[cfg(feature = "docx")]
+            InputFormat::Docx => Ok(Self::Docx(DocxReader::from_reader(reader)?)),
             #[cfg(feature = "html")]
-            InputFormat::Html => Ok(Self::Html(HtmlReader::from_reader(reader)?)),
+            InputFormat::Html => {
+                let stripped =
+                    crate::factory::bom_stripping_reader::BomStrippingReader::new(reader)?;
+                Ok(Self::Html(HtmlReader::from_reader(stripped)?))
+            }
             #[cfg(feature = "markdown")]
-            InputFormat::Markdown => Ok(Self::Markdown(MarkdownReader::from_reader(reader)?)),
+            InputFormat::Markdown => {
+                let stripped =
+                    crate::factory::bom_stripping_reader::BomStrippingReader::new(reader)?;
+                Ok(Self::Markdown(MarkdownReader::from_reader(stripped)?))
+            }
         }
     }
 
     /// Construct a reader for the given format from an in-memory string slice.
     ///
-    /// The input is copied into an owned buffer internally. This is the
-    /// convenience constructor; for streaming from a `Read` source, use
-    /// [`AnyReader::from_reader`].
+    /// For text formats (`Markdown`, `Html`), strips a leading UTF-8 BOM (U+FEFF)
+    /// before constructing the reader. For binary formats (`Docx`), the string
+    /// bytes are passed directly to [`from_reader`](Self::from_reader) via a
+    /// `Cursor`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if reader construction fails (e.g., I/O error or invalid
+    /// format-specific content).
     ///
     /// # Example
     ///
@@ -84,22 +136,35 @@ impl AnyReader {
     /// use docspec::AnyReader;
     /// use docspec::InputFormat;
     ///
-    /// let reader = AnyReader::from_str(InputFormat::Markdown, "# Hello");
+    /// # fn main() -> docspec::Result<()> {
+    /// let reader = AnyReader::from_str(InputFormat::Markdown, "# Hello")?;
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
-    #[must_use]
-    pub fn from_str(format: InputFormat, input: &str) -> Self {
-        #[cfg(not(any(feature = "markdown", feature = "html")))]
+    pub fn from_str(format: InputFormat, input: &str) -> Result<Self> {
+        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
         {
             let _ = input;
             match format {}
         }
-        #[cfg(any(feature = "markdown", feature = "html"))]
+        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
         match format {
+            #[cfg(feature = "docx")]
+            InputFormat::Docx => {
+                // DOCX is a binary format; dispatch via from_reader with the raw bytes.
+                Self::from_reader(format, Cursor::new(input.as_bytes().to_vec()))
+            }
             #[cfg(feature = "html")]
-            InputFormat::Html => Self::Html(HtmlReader::from_str(input)),
+            InputFormat::Html => {
+                let stripped = crate::format::strip_bom(input);
+                Ok(Self::Html(HtmlReader::from_str(stripped)))
+            }
             #[cfg(feature = "markdown")]
-            InputFormat::Markdown => Self::Markdown(MarkdownReader::from_str(input)),
+            InputFormat::Markdown => {
+                let stripped = crate::format::strip_bom(input);
+                Ok(Self::Markdown(MarkdownReader::from_str(stripped)))
+            }
         }
     }
 }
@@ -107,12 +172,14 @@ impl AnyReader {
 impl EventSource for AnyReader {
     #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
-        #[cfg(not(any(feature = "markdown", feature = "html")))]
+        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
         {
             match *self {}
         }
-        #[cfg(any(feature = "markdown", feature = "html"))]
+        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
         match self {
+            #[cfg(feature = "docx")]
+            Self::Docx(r) => r.next_event(),
             #[cfg(feature = "html")]
             Self::Html(r) => r.next_event(),
             #[cfg(feature = "markdown")]
@@ -126,7 +193,12 @@ mod send_static_assertions {
     fn assert_send_static<T: Send + 'static>() {}
     #[test]
     fn any_reader_is_send_static() {
-        #[cfg(any(feature = "markdown", feature = "html"))]
+        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+        assert_send_static::<crate::AnyReader>();
+    }
+    #[cfg(feature = "docx")]
+    #[test]
+    fn docx_variant_is_send_static() {
         assert_send_static::<crate::AnyReader>();
     }
 }

--- a/crates/docspec/src/format.rs
+++ b/crates/docspec/src/format.rs
@@ -4,6 +4,9 @@ use std::path::Path;
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum InputFormat {
+    /// DOCX format (paragraphs and text only). Available when the `docx` feature is enabled.
+    #[cfg(feature = "docx")]
+    Docx,
     /// HTML (paragraph-only; `<p>` elements and text within them only).
     /// Available when the `html` feature is enabled.
     #[cfg(feature = "html")]
@@ -41,10 +44,12 @@ pub enum OutputFormat {
 pub fn detect_input_format(path: &Path) -> Option<InputFormat> {
     let ext = path.extension()?.to_str()?.to_ascii_lowercase();
     match ext.as_str() {
-        #[cfg(feature = "markdown")]
-        "md" | "markdown" => Some(InputFormat::Markdown),
+        #[cfg(feature = "docx")]
+        "docx" => Some(InputFormat::Docx),
         #[cfg(feature = "html")]
         "html" | "htm" => Some(InputFormat::Html),
+        #[cfg(feature = "markdown")]
+        "md" | "markdown" => Some(InputFormat::Markdown),
         _ => None,
     }
 }
@@ -62,12 +67,65 @@ pub fn detect_input_format(path: &Path) -> Option<InputFormat> {
 pub fn detect_output_format(path: &Path) -> Option<OutputFormat> {
     let ext = path.extension()?.to_str()?.to_ascii_lowercase();
     match ext.as_str() {
-        #[cfg(feature = "blocknote-writer")]
-        "json" => Some(OutputFormat::Blocknote),
         #[cfg(feature = "html-writer")]
         "html" | "htm" => Some(OutputFormat::Html),
+        #[cfg(feature = "blocknote-writer")]
+        "json" => Some(OutputFormat::Blocknote),
         #[cfg(feature = "pandoc-native-writer")]
         "native" => Some(OutputFormat::PandocNative),
         _ => None,
+    }
+}
+
+/// Strip a UTF-8 byte-order mark (U+FEFF) from the start of `input`, if present.
+///
+/// Returns a subslice of `input` with the leading BOM removed, or `input`
+/// unchanged if no BOM is present.
+#[inline]
+#[must_use]
+pub fn strip_bom(input: &str) -> &str {
+    input.strip_prefix('\u{FEFF}').unwrap_or(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_bom_empty_string() {
+        assert_eq!(strip_bom(""), "");
+    }
+
+    #[test]
+    fn strip_bom_no_bom() {
+        assert_eq!(strip_bom("hello"), "hello");
+    }
+
+    #[test]
+    fn strip_bom_with_bom() {
+        assert_eq!(strip_bom("\u{FEFF}hello"), "hello");
+    }
+
+    #[test]
+    fn strip_bom_bom_only() {
+        assert_eq!(strip_bom("\u{FEFF}"), "");
+    }
+
+    #[cfg(feature = "docx")]
+    #[test]
+    fn detect_input_format_recognizes_docx() {
+        use std::path::Path;
+        assert_eq!(
+            detect_input_format(Path::new("a.docx")),
+            Some(InputFormat::Docx)
+        );
+        assert_eq!(
+            detect_input_format(Path::new("a.DOCX")),
+            Some(InputFormat::Docx)
+        );
+        assert_eq!(
+            detect_input_format(Path::new("a.DocX")),
+            Some(InputFormat::Docx)
+        );
     }
 }

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -18,10 +18,10 @@
 //! | `html`         | HTML (paragraphs only)                              | `readers::HtmlReader`       |
 //! | `docx`         | DOCX (paragraphs and text only)                     | `readers::DocxReader`       |
 //!
-//! Note: [`readers::DocxReader`] takes a binary file or any `Read + Seek` source.
-//! Construct it directly with `DocxReader::from_path` or `DocxReader::from_reader`.
-//! Support for dispatching `DocxReader` through [`AnyReader::from_reader`] is planned
-//! for a future release.
+//! [`readers::DocxReader`] is dispatched through [`AnyReader::from_reader`] and
+//! [`AnyReader::from_path`]. Use `AnyReader::from_path(InputFormat::Docx, path)` to
+//! open a DOCX file, or `AnyReader::from_reader(InputFormat::Docx, cursor)` to read
+//! from an in-memory buffer.
 //!
 //! ## Writers
 //!
@@ -117,11 +117,10 @@ pub mod readers {
     pub use docspec_html_reader::HtmlReader;
 
     /// Streaming DOCX reader. Available when the `docx` feature is enabled.
-    /// Takes a file path or `Read + Seek` source. Construct it directly with
-    /// `DocxReader::from_path` or `DocxReader::from_reader`. `AnyReader::from_reader`
-    /// support is planned for a future release. Emits
-    /// only paragraphs and text; styles, tables, lists, images, headers/footers,
-    /// metadata, and tracked changes are silently dropped.
+    /// Dispatched through [`crate::AnyReader::from_reader`] and
+    /// [`crate::AnyReader::from_path`]. Emits only paragraphs and text; styles,
+    /// tables, lists, images, headers/footers, metadata, and tracked changes are
+    /// silently dropped.
     #[cfg(feature = "docx")]
     #[cfg_attr(docsrs, doc(cfg(feature = "docx")))]
     pub use docspec_docx_reader::DocxReader;

--- a/crates/docspec/tests/factory_reader.rs
+++ b/crates/docspec/tests/factory_reader.rs
@@ -14,7 +14,7 @@ mod tests {
     fn markdown_dispatch_emits_first_event() {
         use docspec_markdown_reader::MarkdownReader;
 
-        let mut reader = AnyReader::from_str(InputFormat::Markdown, "# h");
+        let mut reader = AnyReader::from_str(InputFormat::Markdown, "# h").unwrap();
         let event = reader.next_event().expect("AnyReader should not fail");
         let expected = MarkdownReader::from_str("# h")
             .next_event()
@@ -27,7 +27,7 @@ mod tests {
     fn html_dispatch_emits_first_event() {
         use docspec_html_reader::HtmlReader;
 
-        let mut reader = AnyReader::from_str(InputFormat::Html, "<p>x</p>");
+        let mut reader = AnyReader::from_str(InputFormat::Html, "<p>x</p>").unwrap();
         let event = reader.next_event().expect("AnyReader should not fail");
         let expected = HtmlReader::from_str("<p>x</p>")
             .next_event()
@@ -41,7 +41,7 @@ mod tests {
         use docspec_markdown_reader::MarkdownReader;
 
         let input = "# Hello\n\nWorld";
-        let mut any_reader = AnyReader::from_str(InputFormat::Markdown, input);
+        let mut any_reader = AnyReader::from_str(InputFormat::Markdown, input).unwrap();
         let mut direct_reader = MarkdownReader::from_str(input);
         loop {
             let any_event = any_reader.next_event().expect("AnyReader failed");
@@ -59,7 +59,7 @@ mod tests {
         use docspec_html_reader::HtmlReader;
 
         let input = "<p>hello</p>";
-        let mut any_reader = AnyReader::from_str(InputFormat::Html, input);
+        let mut any_reader = AnyReader::from_str(InputFormat::Html, input).unwrap();
         let mut direct_reader = HtmlReader::from_str(input);
         loop {
             let any_event = any_reader.next_event().expect("AnyReader failed");
@@ -75,14 +75,14 @@ mod tests {
     #[test]
     fn assert_is_event_source() {
         fn check<S: EventSource>(_: S) {}
-        check(AnyReader::from_str(InputFormat::Markdown, ""));
+        check(AnyReader::from_str(InputFormat::Markdown, "").unwrap());
     }
 
     #[cfg(feature = "html")]
     #[test]
     fn html_assert_is_event_source() {
         fn check<S: EventSource>(_: S) {}
-        check(AnyReader::from_str(InputFormat::Html, ""));
+        check(AnyReader::from_str(InputFormat::Html, "").unwrap());
     }
 
     #[cfg(feature = "markdown")]
@@ -91,12 +91,41 @@ mod tests {
         use std::io::Cursor;
 
         let input = "# Hello\n\nWorld";
-        let mut r1 = AnyReader::from_str(InputFormat::Markdown, input);
+        let mut r1 = AnyReader::from_str(InputFormat::Markdown, input).unwrap();
         let mut r2 =
             AnyReader::from_reader(InputFormat::Markdown, Cursor::new(input.as_bytes())).unwrap();
         let events1: Vec<_> = core::iter::from_fn(|| r1.next_event().unwrap()).collect();
         let events2: Vec<_> = core::iter::from_fn(|| r2.next_event().unwrap()).collect();
         assert_eq!(events1, events2);
+    }
+
+    #[cfg(feature = "markdown")]
+    #[test]
+    fn any_reader_from_reader_strips_bom_markdown() {
+        use docspec_core::Event;
+        use std::io::Cursor;
+
+        let input = b"\xEF\xBB\xBF# Hello".to_vec();
+        let mut reader = AnyReader::from_reader(InputFormat::Markdown, Cursor::new(input))
+            .expect("from_reader succeeds");
+
+        let events: Vec<_> = core::iter::from_fn(|| reader.next_event().unwrap()).collect();
+        let has_heading = events
+            .iter()
+            .any(|event| matches!(event, Event::StartHeading { .. }));
+        assert!(
+            has_heading,
+            "expected StartHeading event after BOM strip; events: {events:?}"
+        );
+
+        let bom_in_text = events.iter().any(|event| match event {
+            Event::Text { content, .. } => content.starts_with('\u{FEFF}'),
+            _ => false,
+        });
+        assert!(
+            !bom_in_text,
+            "BOM should not appear in any Text event content"
+        );
     }
 
     #[cfg(feature = "html")]
@@ -105,7 +134,7 @@ mod tests {
         use std::io::Cursor;
 
         let input = "<p>hello</p>";
-        let mut r1 = AnyReader::from_str(InputFormat::Html, input);
+        let mut r1 = AnyReader::from_str(InputFormat::Html, input).unwrap();
         let mut r2 =
             AnyReader::from_reader(InputFormat::Html, Cursor::new(input.as_bytes())).unwrap();
         let events1: Vec<_> = core::iter::from_fn(|| r1.next_event().unwrap()).collect();

--- a/crates/docspec/tests/readers_docx.rs
+++ b/crates/docspec/tests/readers_docx.rs
@@ -1,7 +1,13 @@
 //! Integration tests for the DOCX reader re-exported through the docspec facade.
 
 #![cfg(feature = "docx")]
-#![allow(clippy::expect_used, clippy::unwrap_used)]
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::tests_outside_test_module,
+    clippy::shadow_unrelated,
+    clippy::unused_trait_names
+)]
 
 #[cfg(test)]
 mod tests {
@@ -33,4 +39,120 @@ mod tests {
         let err = result.expect_err("non-zip input must produce an error");
         assert_eq!(err.to_string(), "parse error: not a valid ZIP archive");
     }
+}
+
+use std::io::{Cursor, Write as _};
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+
+const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(buf);
+    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    writer.start_file("_rels/.rels", opts).unwrap();
+    writer.write_all(rels_xml.as_bytes()).unwrap();
+    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    writer.start_file("word/document.xml", opts_doc).unwrap();
+    writer.write_all(document_xml.as_bytes()).unwrap();
+    writer.finish().unwrap().into_inner()
+}
+
+#[test]
+fn any_reader_from_reader_docx_hello() {
+    use docspec::{AnyReader, InputFormat};
+    use docspec_core::{Event, EventSource as _};
+
+    let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hello</w:t></w:r></w:p></w:body></w:document>"#;
+    let bytes = synth_docx(SIMPLE_RELS, doc_xml);
+    let mut reader = AnyReader::from_reader(InputFormat::Docx, Cursor::new(bytes)).unwrap();
+
+    let events: Vec<_> = core::iter::from_fn(|| reader.next_event().unwrap()).collect();
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, Event::StartDocument { .. })));
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, Event::StartParagraph { .. })));
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, Event::Text { content, .. } if content == "hello")));
+    assert!(events.iter().any(|e| matches!(e, Event::EndParagraph)));
+    assert!(events.iter().any(|e| matches!(e, Event::EndDocument)));
+}
+
+#[test]
+fn any_reader_from_reader_docx_invalid_zip() {
+    use docspec::{AnyReader, InputFormat};
+
+    let result = AnyReader::from_reader(InputFormat::Docx, Cursor::new(b"not a zip".to_vec()));
+    let err = result.err().expect("invalid zip must produce an error");
+    assert!(
+        err.to_string().to_lowercase().contains("zip")
+            || err.to_string().to_lowercase().contains("archive"),
+        "error should mention ZIP/archive: {err}"
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn any_reader_from_path_markdown() {
+    use docspec::{AnyReader, InputFormat};
+    use docspec_core::EventSource as _;
+
+    let mut file = tempfile::Builder::new().suffix(".md").tempfile().unwrap();
+    std::io::Write::write_all(&mut file, b"# Hello").unwrap();
+    let path = file.path().to_path_buf();
+
+    let mut reader = AnyReader::from_path(InputFormat::Markdown, &path).unwrap();
+    let first = reader.next_event().unwrap();
+    assert!(first.is_some(), "should emit at least one event");
+}
+
+#[test]
+fn any_reader_from_path_docx() {
+    use docspec::{AnyReader, InputFormat};
+    use docspec_core::{Event, EventSource as _};
+
+    let doc_xml = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>file</w:t></w:r></w:p></w:body></w:document>"#;
+    let bytes = synth_docx(SIMPLE_RELS, doc_xml);
+
+    let mut file = tempfile::Builder::new().suffix(".docx").tempfile().unwrap();
+    std::io::Write::write_all(&mut file, &bytes).unwrap();
+    let path = file.path().to_path_buf();
+
+    let mut reader = AnyReader::from_path(InputFormat::Docx, &path).unwrap();
+    let events: Vec<_> = core::iter::from_fn(|| reader.next_event().unwrap()).collect();
+    assert!(events
+        .iter()
+        .any(|e| matches!(e, Event::Text { content, .. } if content == "file")));
+}
+
+#[test]
+fn any_reader_from_path_missing_file() {
+    use docspec::{AnyReader, InputFormat};
+    use docspec_core::Error;
+    use std::io::ErrorKind;
+
+    let result = AnyReader::from_path(InputFormat::Docx, "/nonexistent/path/does/not/exist.docx");
+    let err = result.err().expect("missing file must produce an error");
+    assert!(
+        matches!(&err, Error::Io { source } if source.kind() == ErrorKind::NotFound),
+        "expected Error::Io with NotFound, got: {err:?}"
+    );
+}
+
+#[cfg(feature = "markdown")]
+#[test]
+fn any_reader_strip_bom_markdown() {
+    use docspec::{AnyReader, InputFormat};
+    use docspec_core::{Event, EventSource as _};
+
+    let input = "\u{FEFF}# Hi";
+    let mut reader = AnyReader::from_str(InputFormat::Markdown, input).unwrap();
+    let events: Vec<_> = core::iter::from_fn(|| reader.next_event().unwrap()).collect();
+    let has_hi = events
+        .iter()
+        .any(|e| matches!(e, Event::Text { content, .. } if content == "Hi"));
+    assert!(has_hi, "BOM should be stripped; events: {events:?}");
 }


### PR DESCRIPTION
Wires DOCX input through the `AnyReader` facade, the CLI (`--from docx`), and the HTTP API (strict `application/vnd.openxmlformats-officedocument.wordprocessingml.document` content type).

Centralises BOM handling in the facade via a private `BomStrippingReader` adapter so all text-format readers strip BOM uniformly.

Non-breaking. No new production dependencies.
