### PR TITLE
refactor: enforce dead_code lint and drop unused CliError variants

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,7 @@ self_cell = "1.2"
 [workspace.lints.rust]
 unsafe_code = "forbid"
 missing_docs = "deny"
-# Reason: Public functions in docspec-cli format module are intentionally exposed for use by future tasks (e.g., T9 uses resolve_input_format and resolve_output_format)
-dead_code = "allow"
+dead_code = "deny"
 
 [workspace.lints.clippy]
 # Verified against clippy 0.1.92 (2025-12-08)

--- a/crates/docspec-cli/src/error.rs
+++ b/crates/docspec-cli/src/error.rs
@@ -25,17 +25,6 @@ pub enum CliError {
         message: String,
     },
 
-    /// Format reader or writer is not yet implemented.
-    #[deprecated(
-        since = "1.0.3",
-        note = "use `ReaderNotImplemented` or `WriterNotImplemented` for direction-correct error messages"
-    )]
-    #[error("{format} reader not yet implemented")]
-    FormatNotSupported {
-        /// The format that is not supported.
-        format: String,
-    },
-
     /// HTTP server error.
     #[cfg(feature = "http")]
     #[error("HTTP server error: {0}")]
@@ -45,23 +34,9 @@ pub enum CliError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 
-    /// Reader for the requested input format is not yet implemented.
-    #[error("{format} reader not yet implemented")]
-    ReaderNotImplemented {
-        /// The input format that has no registered reader.
-        format: String,
-    },
-
     /// Input and output paths are the same file.
     #[error("input and output paths refer to the same file")]
     SameInputOutput,
-
-    /// Writer for the requested output format is not yet implemented.
-    #[error("{format} writer not yet implemented")]
-    WriterNotImplemented {
-        /// The output format that has no registered writer.
-        format: String,
-    },
 }
 
 #[cfg(test)]
@@ -83,31 +58,6 @@ mod tests {
             message: "cannot detect format".to_string(),
         };
         assert_eq!(err.to_string(), "cannot detect format");
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn display_format_not_supported_error() {
-        let err = CliError::FormatNotSupported {
-            format: "blocknote".to_string(),
-        };
-        assert_eq!(err.to_string(), "blocknote reader not yet implemented");
-    }
-
-    #[test]
-    fn display_reader_not_implemented_error() {
-        let err = CliError::ReaderNotImplemented {
-            format: "blocknote".to_string(),
-        };
-        assert_eq!(err.to_string(), "blocknote reader not yet implemented");
-    }
-
-    #[test]
-    fn display_writer_not_implemented_error() {
-        let err = CliError::WriterNotImplemented {
-            format: "markdown".to_string(),
-        };
-        assert_eq!(err.to_string(), "markdown writer not yet implemented");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Enforces `dead_code = "deny"` at the workspace level, removing a stale `dead_code = "allow"` whose justification no longer held, and drops the three CliError variants that allow was actually masking.

## Background

`Cargo.toml` previously contained:

```toml
# Reason: Public functions in docspec-cli format module are intentionally exposed for use by future tasks (e.g., T9 uses resolve_input_format and resolve_output_format)
dead_code = "allow"
```

That reason no longer holds:

- `resolve_input_format` and `resolve_output_format` are wired through `crates/docspec-cli/src/main.rs` (via `commands::convert::run`) and are not dead.
- The variants the workspace-wide allow was *actually* masking are three CliError variants in `crates/docspec-cli/src/error.rs` that have never been constructed in any reachable code path:
  - `FormatNotSupported` — already `#[deprecated(since = "1.0.3")]`
  - `ReaderNotImplemented`
  - `WriterNotImplemented`

`docspec-cli` is a binary-only crate (no `lib.rs`), so these variants have no external visibility — `pub` here means "visible to other modules in the binary", not part of any public library API. The deprecation cycle and the "future task" rationale therefore don't apply: nothing downstream can match against these.

## Change

1. `Cargo.toml`: `dead_code = "allow"` → `dead_code = "deny"`, drop the stale `Reason:` comment.
2. `crates/docspec-cli/src/error.rs`: remove the three unused variants and their corresponding `#[cfg(test)]` unit tests. The `#[allow(deprecated)]` attribute on the test for `FormatNotSupported` goes too.

If a future format reader/writer needs these variants, they can be reintroduced together with the code path that constructs them.

## Verification

All workspace-default `just` checks pass locally:

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (all suites green, including `display_*` / `from_*` tests in `docspec-cli/src/error.rs` that remain)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps`

## Scope

Single commit, two files. Intentionally minimal — other cleanup candidates (large monolithic source files, weak `.is_ok()` test assertions, naming inconsistencies in format detection helpers) are deliberately out of scope and left for follow-up PRs.
