### PR TITLE
feat(docx-reader): emit LineBreak for <w:br>

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -8,13 +8,13 @@ architecture, and the event protocol.
 ## Supported
 
 - Paragraphs (`<w:p>`) and direct text (`<w:t>` inside `<w:r>`)
-- Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `EndParagraph`, `EndDocument`
+- Line breaks (`<w:br>`, including `w:type="page"` and `w:type="column"` — all emit `LineBreak`)
+- Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`, `EndParagraph`, `EndDocument`
 - Compression: `Stored` and `Deflated` only
 
 ## Out of Scope (silently dropped)
 
 - Run styling (`<w:rPr>`, bold, italic, underline, etc.)
-- Line and page breaks (`<w:br>`)
 - Tabs (`<w:tab>`)
 - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
 - Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`)

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -8,12 +8,14 @@
 //!
 //! # Scope
 //!
-//! **In scope**: Paragraphs (`<w:p>`) and direct text (`<w:t>` inside `<w:r>`).
-//! Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `EndParagraph`, `EndDocument`.
+//! **In scope**: Paragraphs (`<w:p>`), direct text (`<w:t>` inside `<w:r>`), and
+//! line breaks (`<w:br>` — including `w:type="page"` and `w:type="column"`, all
+//! emitted as `LineBreak`).
+//! Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`,
+//! `EndParagraph`, `EndDocument`.
 //!
 //! **Out of scope (silently dropped)**:
 //! - Run styling (`<w:rPr>`, bold, italic, etc.)
-//! - Line and page breaks (`<w:br>`)
 //! - Tabs (`<w:tab>`)
 //! - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
 //! - Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`)
@@ -70,8 +72,8 @@ enum Phase {
 /// A streaming DOCX reader that implements [`EventSource`].
 ///
 /// `DocxReader` parses a DOCX archive and emits `DocSpec` events one at a time.
-/// Only `<w:p>` paragraph elements and `<w:t>` text elements are recognized;
-/// all other elements are silently ignored.
+/// Only `<w:p>` paragraph elements, `<w:t>` text elements, and `<w:br>` line
+/// breaks are recognized; all other elements are silently ignored.
 ///
 /// # Streaming
 ///
@@ -209,6 +211,11 @@ impl DocxReader {
         self.in_ignored_subtree == 0 && self.in_paragraph && self.in_text
     }
 
+    fn emit_line_break(&mut self) {
+        self.flush_pending_text();
+        self.queue.push_back(Event::LineBreak);
+    }
+
     fn end_paragraph(&mut self) {
         self.queue.push_back(Event::EndParagraph);
         self.in_paragraph = false;
@@ -245,6 +252,7 @@ impl DocxReader {
                 });
                 self.queue.push_back(Event::EndParagraph);
             }
+            b"br" if self.in_paragraph => self.emit_line_break(),
             _ => {}
         }
     }
@@ -302,6 +310,7 @@ impl DocxReader {
                 self.in_text = true;
                 self.pending_text.clear();
             }
+            b"br" if self.in_paragraph => self.emit_line_break(),
             _ => {}
         }
     }

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -1063,9 +1063,9 @@ mod events {
     }
 
     #[test]
-    fn w_br_and_w_tab_silently_ignored() {
+    fn w_tab_silently_ignored() {
         let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:br/><w:t>b</w:t><w:tab/><w:t>c</w:t></w:r></w:p></w:body></w:document>"#,
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:tab/><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(
@@ -1075,7 +1075,227 @@ mod events {
                 start_para(),
                 text("a"),
                 text("b"),
-                text("c"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_self_closing_emits_line_break_between_text_runs() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:br/><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::LineBreak,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_between_separate_runs_emits_line_break() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>foo</w:t></w:r><w:r><w:br/></w:r><w:r><w:t>bar</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("foo"),
+                Event::LineBreak,
+                text("bar"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_at_paragraph_start_emits_line_break() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:br/><w:t>after</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::LineBreak,
+                text("after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_at_paragraph_end_emits_line_break() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>before</w:t><w:br/></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("before"),
+                Event::LineBreak,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_only_paragraph_emits_line_break() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:br/></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::LineBreak,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_with_end_tag_emits_single_line_break() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:br></w:br><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::LineBreak,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_with_page_type_emits_line_break() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:br w:type="page"/><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::LineBreak,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_with_column_type_emits_line_break() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:br w:type="column"/><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::LineBreak,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_outside_paragraph_is_silently_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:br/><w:p><w:r><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_inside_ignored_subtree_is_silently_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>kept</w:t></w:r><w:ins><w:r><w:br/></w:r></w:ins></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("kept"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_br_inside_table_is_silently_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>a</w:t><w:br/><w:t>b</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(events, vec![start_doc(), Event::EndDocument]);
+    }
+
+    #[test]
+    fn multiple_w_br_in_sequence_emit_multiple_line_breaks() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:br/><w:br/><w:br/></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::LineBreak,
+                Event::LineBreak,
+                Event::LineBreak,
                 Event::EndParagraph,
                 Event::EndDocument,
             ]


### PR DESCRIPTION
## Summary

Recognize `<w:br>` elements inside paragraphs and emit `LineBreak`. First in a series of small DOCX-reader feature additions; covers the easiest "table-stakes" gap.

Previously, `<w:br>` was in the default fall-through arm and silently swallowed, even though `LineBreak` already exists in the event model and is documented in `EVENTS.md` as "explicit hard break within a paragraph (e.g. markdown two-space-newline, HTML `<br>`)" — DOCX `<w:br>` is exactly that semantic.

## Behavior

| Scenario | Emits |
|---|---|
| `<w:br/>` inside `<w:p>` | `LineBreak` |
| `<w:br></w:br>` (non-self-closing) inside `<w:p>` | `LineBreak` (once) |
| `<w:br w:type="page"/>` inside `<w:p>` | `LineBreak` |
| `<w:br w:type="column"/>` inside `<w:p>` | `LineBreak` |
| `<w:br/>` outside any `<w:p>` | dropped |
| `<w:br/>` inside ignored container (`<w:tbl>`, `<w:ins>`, `<w:del>`, `<w:hyperlink>`, `<w:drawing>`, …) | dropped |

All three OOXML break types (default `textWrapping`, `page`, `column`) map to `LineBreak`. No new event variant required.

## Changes

- `src/lib.rs`: new `emit_line_break` helper; new `b"br"` match arms in `handle_start` (covers `<w:br></w:br>`) and `handle_empty` (covers `<w:br/>`). Guards mirror existing suppression rules (`in_paragraph && in_ignored_subtree == 0`). `flush_pending_text` is called first so any in-flight `<w:t>` content is emitted before the break.
- `src/lib.rs`: crate-level and struct-level doc comments updated to move `<w:br>` from out-of-scope to in-scope.
- `README.md`: corresponding scope-list update.
- `tests/reader.rs`: split the previous combined `w_br_and_w_tab_silently_ignored` test into a dedicated `w_tab_silently_ignored` (unchanged behavior) plus 12 focused `w_br_*` tests covering every new branch.

## Tests

```
test result: ok. 66 passed; 0 failed; 0 ignored
```

13 new test cases, exact-value assertions per `TESTING.md`:

- `w_br_self_closing_emits_line_break_between_text_runs`
- `w_br_between_separate_runs_emits_line_break`
- `w_br_at_paragraph_start_emits_line_break`
- `w_br_at_paragraph_end_emits_line_break`
- `w_br_only_paragraph_emits_line_break`
- `w_br_with_end_tag_emits_single_line_break`
- `w_br_with_page_type_emits_line_break`
- `w_br_with_column_type_emits_line_break`
- `w_br_outside_paragraph_is_silently_dropped`
- `w_br_inside_ignored_subtree_is_silently_dropped`
- `w_br_inside_table_is_silently_dropped`
- `multiple_w_br_in_sequence_emit_multiple_line_breaks`
- `w_tab_silently_ignored` (refocused)

## Verification

- `cargo fmt -p docspec-docx-reader --check`: clean
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`: clean
- `cargo test -p docspec-docx-reader`: 66 passed
- `cargo test -p docspec --features docx`: 9 passed (facade integration unaffected)
- `cargo build --workspace --all-features`: clean

## Semver notes

Purely additive: the reader now emits one additional event variant (`LineBreak`) in its output stream. `Event` is already `#[non_exhaustive]` so downstream writers cannot exhaustively match on it without a wildcard arm. No public API surface change.

## Out of scope

- `<w:tab/>` — still silently dropped, separate work.
- Page break vs. soft break differentiation — the event model only has `LineBreak` / `SoftBreak`; both DOCX page and column breaks are user-inserted hard breaks, so `LineBreak` is the correct mapping. A future `PageBreak` event variant would require coordinated changes in `docspec-core` first.
