### PR TITLE
feat(docx-reader): emit Text("\t") for <w:tab>

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -9,13 +9,13 @@ architecture, and the event protocol.
 
 - Paragraphs (`<w:p>`) and direct text (`<w:t>` inside `<w:r>`)
 - Line breaks (`<w:br>`, including `w:type="page"` and `w:type="column"` — all emit `LineBreak`)
+- Tabs (`<w:tab>` — emitted as a `Text` event containing the single character `"\t"`)
 - Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`, `EndParagraph`, `EndDocument`
 - Compression: `Stored` and `Deflated` only
 
 ## Out of Scope (silently dropped)
 
 - Run styling (`<w:rPr>`, bold, italic, underline, etc.)
-- Tabs (`<w:tab>`)
 - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
 - Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`)
 - Lists

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -8,15 +8,15 @@
 //!
 //! # Scope
 //!
-//! **In scope**: Paragraphs (`<w:p>`), direct text (`<w:t>` inside `<w:r>`), and
+//! **In scope**: Paragraphs (`<w:p>`), direct text (`<w:t>` inside `<w:r>`),
 //! line breaks (`<w:br>` — including `w:type="page"` and `w:type="column"`, all
-//! emitted as `LineBreak`).
+//! emitted as `LineBreak`), and tabs (`<w:tab>`, emitted as a `Text` event
+//! whose content is the single character `"\t"`).
 //! Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`,
 //! `EndParagraph`, `EndDocument`.
 //!
 //! **Out of scope (silently dropped)**:
 //! - Run styling (`<w:rPr>`, bold, italic, etc.)
-//! - Tabs (`<w:tab>`)
 //! - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
 //! - Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`)
 //! - Lists
@@ -72,8 +72,9 @@ enum Phase {
 /// A streaming DOCX reader that implements [`EventSource`].
 ///
 /// `DocxReader` parses a DOCX archive and emits `DocSpec` events one at a time.
-/// Only `<w:p>` paragraph elements, `<w:t>` text elements, and `<w:br>` line
-/// breaks are recognized; all other elements are silently ignored.
+/// Only `<w:p>` paragraph elements, `<w:t>` text elements, `<w:br>` line
+/// breaks, and `<w:tab>` tabs are recognized; all other elements are silently
+/// ignored.
 ///
 /// # Streaming
 ///
@@ -216,6 +217,14 @@ impl DocxReader {
         self.queue.push_back(Event::LineBreak);
     }
 
+    fn emit_tab(&mut self) {
+        self.flush_pending_text();
+        self.queue.push_back(Event::Text {
+            content: "\t".to_string(),
+            style: TextStyle::default(),
+        });
+    }
+
     fn end_paragraph(&mut self) {
         self.queue.push_back(Event::EndParagraph);
         self.in_paragraph = false;
@@ -253,6 +262,7 @@ impl DocxReader {
                 self.queue.push_back(Event::EndParagraph);
             }
             b"br" if self.in_paragraph => self.emit_line_break(),
+            b"tab" if self.in_paragraph => self.emit_tab(),
             _ => {}
         }
     }
@@ -311,6 +321,7 @@ impl DocxReader {
                 self.pending_text.clear();
             }
             b"br" if self.in_paragraph => self.emit_line_break(),
+            b"tab" if self.in_paragraph => self.emit_tab(),
             _ => {}
         }
     }

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -1063,7 +1063,7 @@ mod events {
     }
 
     #[test]
-    fn w_tab_silently_ignored() {
+    fn w_tab_self_closing_emits_text_tab_between_text_runs() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:tab/><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
         );
@@ -1074,7 +1074,169 @@ mod events {
                 start_doc(),
                 start_para(),
                 text("a"),
+                text("\t"),
                 text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_between_separate_runs_emits_text_tab() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>foo</w:t></w:r><w:r><w:tab/></w:r><w:r><w:t>bar</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("foo"),
+                text("\t"),
+                text("bar"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_at_paragraph_start_emits_text_tab() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:tab/><w:t>after</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("\t"),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_at_paragraph_end_emits_text_tab() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>before</w:t><w:tab/></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("before"),
+                text("\t"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_only_paragraph_emits_text_tab() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:tab/></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("\t"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_with_end_tag_emits_single_text_tab() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:tab></w:tab><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                text("\t"),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_outside_paragraph_is_silently_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tab/><w:p><w:r><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_inside_ignored_subtree_is_silently_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>kept</w:t></w:r><w:ins><w:r><w:tab/></w:r></w:ins></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("kept"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn w_tab_inside_table_is_silently_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>a</w:t><w:tab/><w:t>b</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(events, vec![start_doc(), Event::EndDocument]);
+    }
+
+    #[test]
+    fn multiple_w_tab_in_sequence_emit_multiple_text_tabs() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:tab/><w:tab/><w:tab/></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("\t"),
+                text("\t"),
+                text("\t"),
                 Event::EndParagraph,
                 Event::EndDocument,
             ]


### PR DESCRIPTION
## Summary

Recognize `<w:tab>` elements inside paragraphs and emit a `Text` event whose content is the single character `"\t"`. Second in the small DOCX-reader feature series after `<w:br>` (#235); the only other "table-stakes" gap of comparable size.

Previously, `<w:tab>` was in the default fall-through arm and silently swallowed. The event model has no dedicated `Tab` variant — and per `EVENTS.md` whitespace is significant — so the tab is emitted as a single-character `Text` event. Reader-only change; no coordinated `docspec-core` change required (mirrors the deferral approach the `<w:br>` PR took for `PageBreak`).

## Behavior

| Scenario | Emits |
|---|---|
| `<w:tab/>` inside `<w:p>` | `Text("\t")` |
| `<w:tab></w:tab>` (non-self-closing) inside `<w:p>` | `Text("\t")` (once) |
| `<w:tab/>` outside any `<w:p>` | dropped |
| `<w:tab/>` inside ignored container (`<w:tbl>`, `<w:ins>`, `<w:del>`, `<w:hyperlink>`, `<w:drawing>`, …) | dropped |

## Changes

- `src/lib.rs`: new `emit_tab` helper; new `b"tab"` match arms in `handle_start` and `handle_empty`. Guards mirror existing suppression rules (`in_paragraph && in_ignored_subtree == 0`). `flush_pending_text` is called first so any in-flight `<w:t>` content is emitted before the tab. A **separate** `Text` event (rather than appending `"\t"` to `pending_text`) is required because `pending_text` is cleared on the next `<w:t>` start arm and on `end_paragraph` — appending would silently lose the tab.
- `src/lib.rs`: crate-level and struct-level doc comments updated to move `<w:tab>` from out-of-scope to in-scope.
- `README.md`: corresponding scope-list update.
- `tests/reader.rs`: replaced `w_tab_silently_ignored` (which asserted the old silent-drop behavior) with `w_tab_self_closing_emits_text_tab_between_text_runs` plus 9 additional focused `w_tab_*` tests covering every new branch, mirroring the `w_br_*` set from #235.

## Tests

```
test result: ok. 75 passed; 0 failed; 0 ignored
```

10 new test cases, exact-value assertions per `TESTING.md`:

- `w_tab_self_closing_emits_text_tab_between_text_runs`
- `w_tab_between_separate_runs_emits_text_tab`
- `w_tab_at_paragraph_start_emits_text_tab`
- `w_tab_at_paragraph_end_emits_text_tab`
- `w_tab_only_paragraph_emits_text_tab`
- `w_tab_with_end_tag_emits_single_text_tab`
- `w_tab_outside_paragraph_is_silently_dropped`
- `w_tab_inside_ignored_subtree_is_silently_dropped`
- `w_tab_inside_table_is_silently_dropped`
- `multiple_w_tab_in_sequence_emit_multiple_text_tabs`

## Verification

- `cargo fmt -p docspec-docx-reader --check`: clean
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`: clean
- `cargo test -p docspec-docx-reader`: 75 passed
- `cargo test -p docspec --features docx`: 9 passed (facade integration unaffected)
- `cargo build --workspace --all-features`: clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p docspec-docx-reader --no-deps`: clean

## Semver notes

Purely additive: the reader now emits `Text` events at additional positions in its output stream. `Event` is already `#[non_exhaustive]`, and the variant emitted (`Event::Text`) was already part of the reader's output. No public API surface change.

## Out of scope

- Run styling (`<w:rPr>`, bold, italic, underline) — still silently dropped, separate work; requires a run-property state machine and multiple `TextStyle` attributes.
- Heading mapping from `<w:pStyle>` — requires reading `styles.xml` and mapping style IDs to heading levels.
- Tables, lists, hyperlinks, drawings — larger structural work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * DOCX reader now supports tab characters within paragraphs. Tabs are recognized and properly emitted as text events containing the tab character.

* **Documentation**
  * Updated documentation to clarify supported DOCX features, including the newly supported tab handling behavior and document event emission patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->