### PR TITLE
feat(docx-reader): emit table events

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -10,14 +10,17 @@ architecture, and the event protocol.
 - Paragraphs (`<w:p>`) and direct text (`<w:t>` inside `<w:r>`)
 - Line breaks (`<w:br>`, including `w:type="page"` and `w:type="column"` — all emit `LineBreak`)
 - Tabs (`<w:tab>` — emitted as a `Text` event containing the single character `"\t"`)
-- Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`, `EndParagraph`, `EndDocument`
+- Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`) — emitted as structural events only; cell merging, header rows, and table styles are not represented
+- Emits: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`
 - Compression: `Stored` and `Deflated` only
 
 ## Out of Scope (silently dropped)
 
 - Run styling (`<w:rPr>`, bold, italic, underline, etc.)
 - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
-- Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`)
+- Cell merging (`<w:gridSpan>`, `<w:vMerge>`) — every cell emits with `colspan: None` and `rowspan: None`
+- Header rows (`<w:tblHeader>`) — every cell emits as `StartTableCell`, never `StartTableHeader`
+- Table, row, and cell properties (`<w:tblPr>`, `<w:trPr>`, `<w:tcPr>`, `<w:tblGrid>`)
 - Lists
 - Hyperlinks (`<w:hyperlink>`)
 - Drawings and images (`<w:drawing>`, `<w:pict>`)

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -10,15 +10,23 @@
 //!
 //! **In scope**: Paragraphs (`<w:p>`), direct text (`<w:t>` inside `<w:r>`),
 //! line breaks (`<w:br>` — including `w:type="page"` and `w:type="column"`, all
-//! emitted as `LineBreak`), and tabs (`<w:tab>`, emitted as a `Text` event
-//! whose content is the single character `"\t"`).
+//! emitted as `LineBreak`), tabs (`<w:tab>`, emitted as a `Text` event whose
+//! content is the single character `"\t"`), and tables (`<w:tbl>`, `<w:tr>`,
+//! `<w:tc>` — emitted as structural events only; cell merging, header rows, and
+//! table styles are not represented).
 //! Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`,
-//! `EndParagraph`, `EndDocument`.
+//! `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`,
+//! `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`.
 //!
 //! **Out of scope (silently dropped)**:
 //! - Run styling (`<w:rPr>`, bold, italic, etc.)
 //! - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
-//! - Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`)
+//! - Cell merging (`<w:gridSpan>`, `<w:vMerge>`) — every cell emits with
+//!   `colspan: None` and `rowspan: None`
+//! - Header rows (`<w:tblHeader>`) — every cell emits as `StartTableCell`,
+//!   never `StartTableHeader`
+//! - Table, row, and cell properties (`<w:tblPr>`, `<w:trPr>`, `<w:tcPr>`,
+//!   `<w:tblGrid>`)
 //! - Lists
 //! - Hyperlinks (`<w:hyperlink>`)
 //! - Drawings and images (`<w:drawing>`, `<w:pict>`)
@@ -72,9 +80,9 @@ enum Phase {
 /// A streaming DOCX reader that implements [`EventSource`].
 ///
 /// `DocxReader` parses a DOCX archive and emits `DocSpec` events one at a time.
-/// Only `<w:p>` paragraph elements, `<w:t>` text elements, `<w:br>` line
-/// breaks, and `<w:tab>` tabs are recognized; all other elements are silently
-/// ignored.
+/// `<w:p>` paragraphs, `<w:t>` text, `<w:br>` line breaks, `<w:tab>` tabs, and
+/// table elements (`<w:tbl>`, `<w:tr>`, `<w:tc>`) are recognized; all other
+/// elements are silently ignored.
 ///
 /// # Streaming
 ///
@@ -89,7 +97,8 @@ enum Phase {
 pub struct DocxReader {
     /// Reusable buffer for quick-xml event reading.
     buf: Vec<u8>,
-    /// Depth counter for ignored subtrees (tables, tracked changes, etc.).
+    /// Depth counter for ignored subtrees (tracked changes, hyperlinks,
+    /// drawings, table/row/cell property containers, etc.).
     /// Incremented on Start of an ignored container, decremented on End.
     in_ignored_subtree: u32,
     /// Whether the reader is currently inside a `<w:p>` element.
@@ -279,6 +288,9 @@ impl DocxReader {
                 self.flush_pending_text();
                 self.in_text = false;
             }
+            b"tbl" => self.queue.push_back(Event::EndTable),
+            b"tr" => self.queue.push_back(Event::EndTableRow),
+            b"tc" => self.queue.push_back(Event::EndTableCell),
             _ => {}
         }
     }
@@ -322,6 +334,13 @@ impl DocxReader {
             }
             b"br" if self.in_paragraph => self.emit_line_break(),
             b"tab" if self.in_paragraph => self.emit_tab(),
+            b"tbl" => self.queue.push_back(Event::StartTable { id: None }),
+            b"tr" => self.queue.push_back(Event::StartTableRow { id: None }),
+            b"tc" => self.queue.push_back(Event::StartTableCell {
+                colspan: None,
+                id: None,
+                rowspan: None,
+            }),
             _ => {}
         }
     }
@@ -413,10 +432,7 @@ impl EventSource for DocxReader {
 fn is_ignored_container(local: &[u8]) -> bool {
     matches!(
         local,
-        b"tbl"
-            | b"tr"
-            | b"tc"
-            | b"sdt"
+        b"sdt"
             | b"hyperlink"
             | b"drawing"
             | b"pict"
@@ -425,6 +441,10 @@ fn is_ignored_container(local: &[u8]) -> bool {
             | b"del"
             | b"moveFrom"
             | b"moveTo"
+            | b"tblPr"
+            | b"trPr"
+            | b"tcPr"
+            | b"tblGrid"
     )
 }
 

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -627,9 +627,9 @@ mod events {
     }
 
     #[test]
-    fn ignored_empty_container_does_not_emit_paragraph() {
+    fn self_closing_ignored_container_emits_no_events() {
         let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl/></w:body></w:document>"#,
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:hyperlink/></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(events, vec![start_doc(), Event::EndDocument]);
@@ -667,15 +667,6 @@ mod events {
     fn wt_outside_wp_is_silently_dropped() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:t>orphan</w:t></w:body></w:document>"#,
-        );
-        let events = drive(&mut reader);
-        assert_eq!(events, vec![start_doc(), Event::EndDocument]);
-    }
-
-    #[test]
-    fn table_cells_do_not_emit_paragraphs() {
-        let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(events, vec![start_doc(), Event::EndDocument]);
@@ -1215,12 +1206,33 @@ mod events {
     }
 
     #[test]
-    fn w_tab_inside_table_is_silently_dropped() {
+    fn w_tab_inside_table_cell_emits_text_tab() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>a</w:t><w:tab/><w:t>b</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
-        assert_eq!(events, vec![start_doc(), Event::EndDocument]);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartTable { id: None },
+                Event::StartTableRow { id: None },
+                Event::StartTableCell {
+                    colspan: None,
+                    id: None,
+                    rowspan: None,
+                },
+                start_para(),
+                text("a"),
+                text("\t"),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
     }
 
     #[test]
@@ -1436,12 +1448,33 @@ mod events {
     }
 
     #[test]
-    fn w_br_inside_table_is_silently_dropped() {
+    fn w_br_inside_table_cell_emits_line_break() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>a</w:t><w:br/><w:t>b</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
-        assert_eq!(events, vec![start_doc(), Event::EndDocument]);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartTable { id: None },
+                Event::StartTableRow { id: None },
+                Event::StartTableCell {
+                    colspan: None,
+                    id: None,
+                    rowspan: None,
+                },
+                start_para(),
+                text("a"),
+                Event::LineBreak,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
     }
 
     #[test]
@@ -1459,6 +1492,260 @@ mod events {
                 Event::LineBreak,
                 Event::LineBreak,
                 Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    fn start_table() -> Event {
+        Event::StartTable { id: None }
+    }
+
+    fn start_row() -> Event {
+        Event::StartTableRow { id: None }
+    }
+
+    fn start_cell() -> Event {
+        Event::StartTableCell {
+            colspan: None,
+            id: None,
+            rowspan: None,
+        }
+    }
+
+    #[test]
+    fn simple_table_emits_full_structure() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("cell"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn multi_row_multi_cell_table_emits_full_structure() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>b</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>c</w:t></w:r></w:p></w:tc><w:tc><w:p><w:r><w:t>d</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("a"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                start_cell(),
+                start_para(),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("c"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                start_cell(),
+                start_para(),
+                text("d"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_cell_emits_paragraph_pair() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p/></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn multiple_paragraphs_in_cell_emit_multiple_paragraphs() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>first</w:t></w:r></w:p><w:p><w:r><w:t>second</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("first"),
+                Event::EndParagraph,
+                start_para(),
+                text("second"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_table_emits_nested_events() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("inner"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn table_inside_ignored_subtree_is_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>before</w:t></w:r></w:p><w:ins><w:tbl><w:tr><w:tc><w:p><w:r><w:t>inserted</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:ins><w:p><w:r><w:t>after</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("before"),
+                Event::EndParagraph,
+                start_para(),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn table_row_and_cell_properties_emit_no_events() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tblPr><w:tblStyle w:val="TableGrid"/><w:tblW w:w="5000" w:type="pct"/></w:tblPr><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tcPr><w:tcW w:w="2500" w:type="pct"/><w:gridSpan w:val="2"/><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("cell"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn table_grid_emits_no_events() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tblGrid><w:gridCol w:w="2880"/><w:gridCol w:w="2880"/></w:tblGrid><w:tr><w:tc><w:p><w:r><w:t>a</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("a"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_inside_cell_is_still_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>keep</w:t></w:r><w:hyperlink><w:r><w:t>link</w:t></w:r></w:hyperlink></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("keep"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
                 Event::EndDocument,
             ]
         );


### PR DESCRIPTION
## Summary

Recognize `<w:tbl>`, `<w:tr>`, `<w:tc>` and emit the corresponding structural table events. Naive scope: structural events only. Cell merging (`<w:gridSpan>`, `<w:vMerge>`), header rows (`<w:tblHeader>`), and table styles are not represented and remain out of scope; every cell emits with `colspan: None`, `rowspan: None`, and as `StartTableCell` rather than `StartTableHeader`.

Previously, `<w:tbl>` / `<w:tr>` / `<w:tc>` were in `is_ignored_container()` and their entire subtrees were silently dropped. The four table-related event variants (`StartTable`, `StartTableRow`, `StartTableCell`, plus their `End*` pairs) already exist in `docspec-core`; this PR just wires them up.

## Behavior

| Scenario | Emits |
|---|---|
| `<w:tbl><w:tr><w:tc><w:p>…</w:p></w:tc></w:tr></w:tbl>` | `StartTable` → `StartTableRow` → `StartTableCell` → paragraph events → `EndTableCell` → `EndTableRow` → `EndTable` |
| Multi-row / multi-cell tables | Each `<w:tr>` and `<w:tc>` emits its own structural pair |
| Empty cell (`<w:tc><w:p/></w:tc>`) | Cell pair with an empty paragraph pair inside |
| Multiple `<w:p>` in one cell | Each paragraph emits its own pair inside the cell |
| Nested `<w:tbl>` inside `<w:tc>` | Nested table events; writers decide how to render (BlockNote drops nested via `table_depth` guard) |
| `<w:tblPr>`, `<w:trPr>`, `<w:tcPr>`, `<w:tblGrid>` | Subtree silently dropped (added to `is_ignored_container`) |
| `<w:tbl>` inside ignored container (`<w:ins>`, `<w:del>`, etc.) | Entire table dropped |
| `<w:hyperlink>` inside `<w:tc>` | Hyperlink subtree dropped, cell content otherwise emits |
| `<w:br/>` / `<w:tab/>` inside a cell paragraph | Emits `LineBreak` / `Text("\t")` as usual |

`colspan`, `rowspan`, and `id` are always `None`. All cells emit as `StartTableCell` — `StartTableHeader` is never produced.

## Changes

- `src/lib.rs`: new `b"tbl"` / `b"tr"` / `b"tc"` match arms in `handle_start` and `handle_end` that push the corresponding `Start*` / `End*` events. `id`, `colspan`, `rowspan` are all `None`.
- `src/lib.rs`: `is_ignored_container()` no longer lists `tbl`/`tr`/`tc`. It now lists `tblPr`/`trPr`/`tcPr`/`tblGrid` so table/row/cell property containers (and any of their attribute-bearing empty children — `tblStyle`, `tblW`, `tblHeader`, `tcW`, `gridSpan`, `vMerge`, `tcBorders`, `shd`, `gridCol`, …) are silently dropped as a single subtree, keeping the event stream clean.
- `src/lib.rs`: crate-level and `DocxReader` struct doc comments updated to move tables into the in-scope list and to enumerate the explicitly-unsupported aspects (cell merging, header rows, properties).
- `src/lib.rs`: `in_ignored_subtree` field doc updated to reflect that tables are no longer in the ignored set.
- `README.md`: corresponding scope-list update.
- `tests/reader.rs`: 9 new focused tests for table behavior; updated `w_br_inside_table` and `w_tab_inside_table` (now `_emits_line_break` / `_emits_text_tab`) to assert the new pass-through behavior; replaced the obsolete `table_cells_do_not_emit_paragraphs` with the new positive-shape coverage; refocused `self_closing_ignored_container_emits_no_events` to use `<w:hyperlink/>` since `<w:tbl/>` is no longer ignored.

## Tests

```
test result: ok. 83 passed; 0 failed; 0 ignored
```

9 new test cases, exact-value assertions per `TESTING.md`:

- `simple_table_emits_full_structure`
- `multi_row_multi_cell_table_emits_full_structure`
- `empty_cell_emits_paragraph_pair`
- `multiple_paragraphs_in_cell_emit_multiple_paragraphs`
- `nested_table_emits_nested_events`
- `table_inside_ignored_subtree_is_dropped`
- `table_row_and_cell_properties_emit_no_events`
- `table_grid_emits_no_events`
- `hyperlink_inside_cell_is_still_dropped`

Plus three updated tests reflecting the new pass-through behavior:

- `w_br_inside_table_cell_emits_line_break` (was `w_br_inside_table_is_silently_dropped`)
- `w_tab_inside_table_cell_emits_text_tab` (was `w_tab_inside_table_is_silently_dropped`)
- `self_closing_ignored_container_emits_no_events` (was `ignored_empty_container_does_not_emit_paragraph`; switched fixture from `<w:tbl/>` to `<w:hyperlink/>` since `<w:tbl/>` no longer triggers the ignored-container path)

The obsolete `table_cells_do_not_emit_paragraphs` test (asserting the previous "all tables silently dropped" behavior) was removed; `simple_table_emits_full_structure` covers the same input with the new expectations.

## Verification

- `cargo fmt -p docspec-docx-reader --check`: clean
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings`: clean
- `cargo test -p docspec-docx-reader`: 83 passed
- `cargo test --workspace`: all crates passing (no downstream regressions; facade, CLI, HTTP, BlockNote writer unaffected)

## Out of scope (deliberate, follow-up work)

- **Cell merging**: `<w:gridSpan>` and `<w:vMerge>` are silently dropped via `tcPr` containment. Representing `colspan` is mechanical; `rowspan` requires resolving `vMerge` continuation state across rows, which conflicts with the streaming invariant and likely needs an event-model decision (e.g. a `MergeState` discriminator or a continuation event variant). Out of scope here on purpose.
- **Header rows**: `<w:tblHeader>` row flag and the row→cell `StartTableHeader` mapping are not represented. Would require either row-level metadata in `StartTableRow` or a 1-row look-ahead inside the reader.
- **Table / row / cell styles**: `<w:tblStyle>`, `<w:tblBorders>`, `<w:shd>`, alignment, widths, etc. are silently dropped; these depend on `<w:rPr>` / style-resolution work that is broadly out of scope for the reader today.
- **Nested-table fidelity in writers**: the reader emits nested-table events correctly; BlockNote writer drops them on its end via `table_depth` (existing behavior, unchanged).

## Semver notes

Additive only. No public API changes — `DocxReader` is still constructed and driven identically; the event stream simply gains additional event types for inputs that previously produced nothing. Consumers that pattern-match exhaustively on `Event` already had to handle all `Table*` variants because the markdown reader emits them.
