### PR TITLE
DOCX: w:rPr and w:pPr properties

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -11,13 +11,23 @@ architecture, and the event protocol.
 - Line breaks (`<w:br>`, including `w:type="page"` and `w:type="column"` — all emit `LineBreak`)
 - Tabs (`<w:tab>` — emitted as a `Text` event containing the single character `"\t"`)
 - Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`) — emitted as structural events only; cell merging, header rows, and table styles are not represented
+- Run properties (`<w:rPr>`): `<w:b>` (bold), `<w:i>` (italic), `<w:u>` (underline — any `w:val` other than `none`), `<w:strike>` (strikethrough), `<w:dstrike>` (double-strike, collapses to strikethrough), `<w:vertAlign>` (`subscript` and `superscript` only; `baseline` resets to neither)
+- Paragraph properties (`<w:pPr>`): `<w:jc>` (alignment — `left`/`start` to Left, `right`/`end` to Right, `center` to Center, `both`/`distribute` to Justify)
+- Empty `<w:rPr/>` and `<w:pPr/>` are treated as no properties (default style / alignment None)
+- A `<w:rPr>` or `<w:pPr>` that appears after content in the same parent is silently ignored (per the OOXML spec, both must be the first child element)
 - Emits: `StartDocument`, `StartParagraph`, `Text`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`
 - Compression: `Stored` and `Deflated` only
 
 ## Out of Scope (silently dropped)
 
-- Run styling (`<w:rPr>`, bold, italic, underline, etc.)
 - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
+- Style references (`<w:rStyle>`, `<w:pStyle>`)
+- Run formatting not listed above: `<w:color>`, `<w:sz>`, `<w:szCs>`, `<w:rFonts>`, `<w:shd>`, `<w:highlight>`, `<w:caps>`, `<w:smallCaps>`, `<w:position>`, `<w:spacing>`, `<w:kern>`, `<w:lang>`, `<w:noProof>`
+- Revision tracking (`<w:rPrChange>`, `<w:pPrChange>`)
+- Advanced paragraph layout beyond alignment: `<w:numPr>`, `<w:ind>`, `<w:tabs>`, `<w:framePr>`, `<w:sectPr>`
+- `<w:rPr>` nested inside `<w:pPr>` (paragraph mark / pilcrow run properties)
+- BiDi-aware logical alignment (`start`/`end` flipping based on paragraph direction is not tracked)
+- Math (`m:rPr`) and DrawingML (`a:rPr`) namespaces
 - Cell merging (`<w:gridSpan>`, `<w:vMerge>`) — every cell emits with `colspan: None` and `rowspan: None`
 - Header rows (`<w:tblHeader>`) — every cell emits as `StartTableCell`, never `StartTableHeader`
 - Table, row, and cell properties (`<w:tblPr>`, `<w:trPr>`, `<w:tcPr>`, `<w:tblGrid>`)

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -55,6 +55,7 @@
 
 extern crate alloc;
 
+mod properties;
 mod rels;
 
 use alloc::collections::VecDeque;
@@ -63,8 +64,8 @@ use std::io::{BufReader, Read, Seek};
 use std::path::Path;
 
 pub use docspec_core::EventSource;
-use docspec_core::{Error, Event, Result, TextStyle};
-use quick_xml::events::{BytesCData, BytesRef, BytesText};
+use docspec_core::{Error, Event, Result, TextAlignment, TextStyle};
+use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText};
 
 /// Document processing phase.
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -94,6 +95,10 @@ enum Phase {
 ///
 /// Returns [`Error::Io`] for I/O failures and [`Error::Parse`] for malformed
 /// archives or XML.
+#[expect(
+    clippy::struct_excessive_bools,
+    reason = "DocxReader tracks six independent boolean parser states; grouping them would obscure the streaming state machine"
+)]
 pub struct DocxReader {
     /// Reusable buffer for quick-xml event reading.
     buf: Vec<u8>,
@@ -105,12 +110,26 @@ pub struct DocxReader {
     in_paragraph: bool,
     /// Whether the reader is currently inside a `<w:t>` element.
     in_text: bool,
+    /// Whether currently inside a `<w:pPr>` element that is still legal (first child of paragraph).
+    in_ppr: bool,
+    /// Paragraph alignment captured from `<w:jc>` while inside `<w:pPr>`.
+    pending_paragraph_alignment: Option<TextAlignment>,
+    /// True once `StartParagraph` has been queued for the current paragraph.
+    paragraph_started_emitted: bool,
+    /// Whether currently inside a `<w:rPr>` element that is still legal (first child of run).
+    in_rpr: bool,
+    /// Run style accumulated while inside `<w:rPr>`.
+    pending_run_style: TextStyle,
     /// Text collected for the current `<w:t>` element.
     pending_text: String,
+    /// Run style frozen at `</w:rPr>`, applied to subsequent text emissions in the same run.
+    current_run_style: TextStyle,
     /// Document processing phase.
     phase: Phase,
     /// Queue of `DocSpec` events to emit.
     queue: VecDeque<Event>,
+    /// True once the first content event of the current run has been queued.
+    run_content_emitted: bool,
     /// The quick-xml reader streaming from the document entry.
     xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
 }
@@ -123,9 +142,19 @@ impl fmt::Debug for DocxReader {
             .field("in_ignored_subtree", &self.in_ignored_subtree)
             .field("in_paragraph", &self.in_paragraph)
             .field("in_text", &self.in_text)
+            .field("in_ppr", &self.in_ppr)
+            .field(
+                "pending_paragraph_alignment",
+                &self.pending_paragraph_alignment,
+            )
+            .field("paragraph_started_emitted", &self.paragraph_started_emitted)
+            .field("in_rpr", &self.in_rpr)
+            .field("pending_run_style", &self.pending_run_style)
             .field("pending_text", &self.pending_text)
+            .field("current_run_style", &self.current_run_style)
             .field("phase", &"<phase>")
             .field("queue", &self.queue)
+            .field("run_content_emitted", &self.run_content_emitted)
             .field("xml", &"<quick_xml::Reader>")
             .finish()
     }
@@ -208,9 +237,16 @@ impl DocxReader {
             in_ignored_subtree: 0,
             in_paragraph: false,
             in_text: false,
+            in_ppr: false,
+            pending_paragraph_alignment: None,
+            paragraph_started_emitted: false,
+            in_rpr: false,
+            pending_run_style: TextStyle::default(),
             pending_text: String::new(),
+            current_run_style: TextStyle::default(),
             phase: Phase::NotStarted,
             queue: VecDeque::new(),
+            run_content_emitted: false,
             xml,
         })
     }
@@ -222,12 +258,16 @@ impl DocxReader {
     }
 
     fn emit_line_break(&mut self) {
+        self.ensure_paragraph_started();
         self.flush_pending_text();
+        self.run_content_emitted = true;
         self.queue.push_back(Event::LineBreak);
     }
 
     fn emit_tab(&mut self) {
+        self.ensure_paragraph_started();
         self.flush_pending_text();
+        self.run_content_emitted = true;
         self.queue.push_back(Event::Text {
             content: "\t".to_string(),
             style: TextStyle::default(),
@@ -235,17 +275,21 @@ impl DocxReader {
     }
 
     fn end_paragraph(&mut self) {
+        self.ensure_paragraph_started();
         self.queue.push_back(Event::EndParagraph);
         self.in_paragraph = false;
         self.in_text = false;
         self.pending_text.clear();
+        self.in_ppr = false;
+        self.pending_paragraph_alignment = None;
+        self.paragraph_started_emitted = false;
     }
 
     fn flush_pending_text(&mut self) {
         if !self.pending_text.is_empty() {
             self.queue.push_back(Event::Text {
                 content: core::mem::take(&mut self.pending_text),
-                style: TextStyle::default(),
+                style: self.current_run_style.clone(),
             });
         }
     }
@@ -260,9 +304,51 @@ impl DocxReader {
         Ok(())
     }
 
-    fn handle_empty(&mut self, local: &[u8]) {
+    fn handle_empty(&mut self, tag: &BytesStart<'_>) {
+        let local_name = tag.local_name();
+        let local = local_name.as_ref();
         match local {
             value if self.in_ignored_subtree > 0 || is_ignored_container(value) => {}
+            b"pPr" if self.in_paragraph && !self.paragraph_started_emitted => {
+                self.ensure_paragraph_started();
+            }
+            b"jc" if self.in_ppr => {
+                let val = read_val_attribute(tag);
+                self.pending_paragraph_alignment =
+                    val.as_deref().and_then(properties::parse_alignment);
+            }
+            b"rPr" if self.in_ppr => {}
+            b"rPr" if self.in_paragraph && !self.in_ppr && !self.in_rpr => {}
+            b"b" if self.in_rpr => {
+                self.pending_run_style.bold = parse_on_off_attribute(tag);
+            }
+            b"i" if self.in_rpr => {
+                self.pending_run_style.italic = parse_on_off_attribute(tag);
+            }
+            b"strike" | b"dstrike" if self.in_rpr => {
+                self.pending_run_style.strikethrough = parse_on_off_attribute(tag);
+            }
+            b"u" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                self.pending_run_style.underline = properties::parse_underline_on(val.as_deref());
+            }
+            b"vertAlign" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                match properties::parse_vert_align(val.as_deref()) {
+                    properties::VertAlign::Subscript => {
+                        self.pending_run_style.subscript = true;
+                        self.pending_run_style.superscript = false;
+                    }
+                    properties::VertAlign::Superscript => {
+                        self.pending_run_style.superscript = true;
+                        self.pending_run_style.subscript = false;
+                    }
+                    properties::VertAlign::None => {
+                        self.pending_run_style.subscript = false;
+                        self.pending_run_style.superscript = false;
+                    }
+                }
+            }
             b"p" if !self.in_paragraph => {
                 self.queue.push_back(Event::StartParagraph {
                     alignment: None,
@@ -284,6 +370,20 @@ impl DocxReader {
 
         match local {
             b"p" if self.in_paragraph => self.end_paragraph(),
+            b"pPr" if self.in_ppr => {
+                self.ensure_paragraph_started();
+                self.in_ppr = false;
+            }
+            b"rPr" if self.in_rpr => {
+                self.current_run_style = self.pending_run_style.clone();
+                self.in_rpr = false;
+            }
+            b"r" => {
+                self.current_run_style = TextStyle::default();
+                self.pending_run_style = TextStyle::default();
+                self.run_content_emitted = false;
+                self.in_rpr = false;
+            }
             b"t" if self.in_text => {
                 self.flush_pending_text();
                 self.in_text = false;
@@ -319,7 +419,9 @@ impl DocxReader {
         Ok(())
     }
 
-    fn handle_start(&mut self, local: &[u8]) {
+    fn handle_start(&mut self, tag: &BytesStart<'_>) {
+        let local_name = tag.local_name();
+        let local = local_name.as_ref();
         if self.in_ignored_subtree > 0 {
             self.in_ignored_subtree = self.in_ignored_subtree.saturating_add(1);
             return;
@@ -327,10 +429,71 @@ impl DocxReader {
 
         match local {
             value if is_ignored_container(value) => self.in_ignored_subtree = 1,
+            b"pPr" if self.in_paragraph => {
+                if self.paragraph_started_emitted {
+                    // Out-of-order pPr: StartParagraph already emitted; silently consume
+                    self.in_ignored_subtree = 1;
+                } else {
+                    self.in_ppr = true;
+                    self.pending_paragraph_alignment = None;
+                }
+            }
+            b"jc" if self.in_ppr => {
+                let val = read_val_attribute(tag);
+                self.pending_paragraph_alignment =
+                    val.as_deref().and_then(properties::parse_alignment);
+            }
+            b"rPr" if self.in_ppr => {
+                self.in_ignored_subtree = 1;
+            }
+            b"rPr" if self.in_paragraph && !self.in_ppr && !self.in_rpr => {
+                if self.run_content_emitted {
+                    // Out-of-order rPr: content already emitted in this run; silently consume
+                    self.in_ignored_subtree = 1;
+                } else {
+                    self.in_rpr = true;
+                    self.pending_run_style = TextStyle::default();
+                }
+            }
+            b"b" if self.in_rpr => {
+                self.pending_run_style.bold = parse_on_off_attribute(tag);
+            }
+            b"i" if self.in_rpr => {
+                self.pending_run_style.italic = parse_on_off_attribute(tag);
+            }
+            b"strike" | b"dstrike" if self.in_rpr => {
+                self.pending_run_style.strikethrough = parse_on_off_attribute(tag);
+            }
+            b"u" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                self.pending_run_style.underline = properties::parse_underline_on(val.as_deref());
+            }
+            b"vertAlign" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                match properties::parse_vert_align(val.as_deref()) {
+                    properties::VertAlign::Subscript => {
+                        self.pending_run_style.subscript = true;
+                        self.pending_run_style.superscript = false;
+                    }
+                    properties::VertAlign::Superscript => {
+                        self.pending_run_style.superscript = true;
+                        self.pending_run_style.subscript = false;
+                    }
+                    properties::VertAlign::None => {
+                        self.pending_run_style.subscript = false;
+                        self.pending_run_style.superscript = false;
+                    }
+                }
+            }
             b"p" if !self.in_paragraph => self.start_paragraph(),
+            b"r" if self.in_paragraph => {
+                self.ensure_paragraph_started();
+            }
             b"t" if self.in_paragraph => {
+                self.ensure_paragraph_started();
                 self.in_text = true;
                 self.pending_text.clear();
+                self.run_content_emitted = true;
             }
             b"br" if self.in_paragraph => self.emit_line_break(),
             b"tab" if self.in_paragraph => self.emit_tab(),
@@ -373,9 +536,9 @@ impl DocxReader {
             .into_owned();
 
         match event {
-            quick_xml::events::Event::Start(tag) => self.handle_start(tag.local_name().as_ref()),
+            quick_xml::events::Event::Start(tag) => self.handle_start(&tag),
             quick_xml::events::Event::End(tag) => self.handle_end(tag.local_name().as_ref()),
-            quick_xml::events::Event::Empty(tag) => self.handle_empty(tag.local_name().as_ref()),
+            quick_xml::events::Event::Empty(tag) => self.handle_empty(&tag),
             quick_xml::events::Event::Text(text) => {
                 self.handle_text(&text)?;
             }
@@ -395,13 +558,22 @@ impl DocxReader {
     }
 
     fn start_paragraph(&mut self) {
-        self.queue.push_back(Event::StartParagraph {
-            alignment: None,
-            id: None,
-        });
         self.in_paragraph = true;
         self.in_text = false;
         self.pending_text.clear();
+        self.paragraph_started_emitted = false;
+        self.pending_paragraph_alignment = None;
+    }
+
+    /// Queues `StartParagraph` once paragraph properties have been parsed.
+    fn ensure_paragraph_started(&mut self) {
+        if self.in_paragraph && !self.paragraph_started_emitted {
+            self.queue.push_back(Event::StartParagraph {
+                alignment: self.pending_paragraph_alignment.clone(),
+                id: None,
+            });
+            self.paragraph_started_emitted = true;
+        }
     }
 }
 
@@ -446,6 +618,18 @@ fn is_ignored_container(local: &[u8]) -> bool {
             | b"tcPr"
             | b"tblGrid"
     )
+}
+
+fn read_val_attribute(tag: &BytesStart<'_>) -> Option<String> {
+    let a = tag.try_get_attribute(b"w:val").ok().flatten()?;
+    core::str::from_utf8(a.value.as_ref())
+        .ok()
+        .map(str::to_owned)
+}
+
+fn parse_on_off_attribute(tag: &BytesStart<'_>) -> bool {
+    let val = read_val_attribute(tag);
+    properties::parse_on_off(val.as_deref())
 }
 
 fn parse_error(message: String) -> Error {

--- a/crates/docspec-docx-reader/src/properties.rs
+++ b/crates/docspec-docx-reader/src/properties.rs
@@ -1,0 +1,199 @@
+//! OOXML value parsers for run and paragraph properties.
+
+use docspec_core::TextAlignment;
+
+/// Parses an `ST_OnOff` value (ECMA-376 §22.9.2.7).
+///
+/// Element-present with no `w:val` = ON. Unknown values treated as ON (lenient).
+pub fn parse_on_off(val: Option<&str>) -> bool {
+    !matches!(val, Some("false" | "0" | "off"))
+}
+
+/// Vertical alignment for text (subscript, superscript, or baseline).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VertAlign {
+    /// Baseline (default, no vertical shift).
+    None,
+    /// Subscript (below baseline).
+    Subscript,
+    /// Superscript (above baseline).
+    Superscript,
+}
+
+/// Parses a `ST_VerticalAlignRun` value. `baseline` and unknown values map to `None`.
+pub fn parse_vert_align(val: Option<&str>) -> VertAlign {
+    match val {
+        Some("subscript") => VertAlign::Subscript,
+        Some("superscript") => VertAlign::Superscript,
+        _ => VertAlign::None,
+    }
+}
+
+/// Parses `w:u` underline state. Unlike `ST_OnOff`, element-present with no `w:val` = OFF.
+/// Only a non-`"none"` `w:val` enables underline (ECMA-376 §17.3.2.40).
+pub fn parse_underline_on(val: Option<&str>) -> bool {
+    match val {
+        None | Some("none") => false,
+        Some(_) => true,
+    }
+}
+
+/// Parses `w:jc` paragraph alignment. `start`→Left, `end`→Right (no `BiDi` tracking).
+pub fn parse_alignment(val: &str) -> Option<TextAlignment> {
+    match val {
+        "left" | "start" => Some(TextAlignment::Left),
+        "right" | "end" => Some(TextAlignment::Right),
+        "center" => Some(TextAlignment::Center),
+        "both" | "distribute" => Some(TextAlignment::Justify),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ============================================================================
+    // parse_on_off tests (8 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_on_off_none_returns_true() {
+        assert!(parse_on_off(None));
+    }
+
+    #[test]
+    fn parse_on_off_true_returns_true() {
+        assert!(parse_on_off(Some("true")));
+    }
+
+    #[test]
+    fn parse_on_off_one_returns_true() {
+        assert!(parse_on_off(Some("1")));
+    }
+
+    #[test]
+    fn parse_on_off_on_returns_true() {
+        assert!(parse_on_off(Some("on")));
+    }
+
+    #[test]
+    fn parse_on_off_false_returns_false() {
+        assert!(!parse_on_off(Some("false")));
+    }
+
+    #[test]
+    fn parse_on_off_zero_returns_false() {
+        assert!(!parse_on_off(Some("0")));
+    }
+
+    #[test]
+    fn parse_on_off_off_returns_false() {
+        assert!(!parse_on_off(Some("off")));
+    }
+
+    #[test]
+    fn parse_on_off_unknown_returns_true() {
+        assert!(parse_on_off(Some("unknown")));
+    }
+
+    // ============================================================================
+    // parse_underline_on tests (4 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_underline_on_none_returns_false() {
+        assert!(!parse_underline_on(None));
+    }
+
+    #[test]
+    fn parse_underline_on_none_value_returns_false() {
+        assert!(!parse_underline_on(Some("none")));
+    }
+
+    #[test]
+    fn parse_underline_on_single_returns_true() {
+        assert!(parse_underline_on(Some("single")));
+    }
+
+    #[test]
+    fn parse_underline_on_double_returns_true() {
+        assert!(parse_underline_on(Some("double")));
+    }
+
+    // ============================================================================
+    // parse_vert_align tests (5 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_vert_align_subscript_returns_subscript() {
+        assert_eq!(parse_vert_align(Some("subscript")), VertAlign::Subscript);
+    }
+
+    #[test]
+    fn parse_vert_align_superscript_returns_superscript() {
+        assert_eq!(
+            parse_vert_align(Some("superscript")),
+            VertAlign::Superscript
+        );
+    }
+
+    #[test]
+    fn parse_vert_align_baseline_returns_none() {
+        assert_eq!(parse_vert_align(Some("baseline")), VertAlign::None);
+    }
+
+    #[test]
+    fn parse_vert_align_none_returns_none() {
+        assert_eq!(parse_vert_align(None), VertAlign::None);
+    }
+
+    #[test]
+    fn parse_vert_align_unknown_returns_none() {
+        assert_eq!(parse_vert_align(Some("unknown")), VertAlign::None);
+    }
+
+    // ============================================================================
+    // parse_alignment tests (8 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_alignment_left_returns_left() {
+        assert_eq!(parse_alignment("left"), Some(TextAlignment::Left));
+    }
+
+    #[test]
+    fn parse_alignment_start_returns_left() {
+        assert_eq!(parse_alignment("start"), Some(TextAlignment::Left));
+    }
+
+    #[test]
+    fn parse_alignment_right_returns_right() {
+        assert_eq!(parse_alignment("right"), Some(TextAlignment::Right));
+    }
+
+    #[test]
+    fn parse_alignment_end_returns_right() {
+        assert_eq!(parse_alignment("end"), Some(TextAlignment::Right));
+    }
+
+    #[test]
+    fn parse_alignment_center_returns_center() {
+        assert_eq!(parse_alignment("center"), Some(TextAlignment::Center));
+    }
+
+    #[test]
+    fn parse_alignment_both_returns_justify() {
+        assert_eq!(parse_alignment("both"), Some(TextAlignment::Justify));
+    }
+
+    #[test]
+    fn parse_alignment_distribute_returns_justify() {
+        assert_eq!(parse_alignment("distribute"), Some(TextAlignment::Justify));
+    }
+
+    #[test]
+    fn parse_alignment_unknown_returns_none() {
+        assert_eq!(parse_alignment("mediumKashida"), None);
+    }
+}

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -499,7 +499,7 @@ mod constructor {
 mod events {
     use std::io::Cursor;
 
-    use docspec_core::{Event, TextStyle};
+    use docspec_core::{Event, TextAlignment, TextStyle};
     use docspec_docx_reader::{DocxReader, EventSource as _};
 
     use crate::fixture;
@@ -534,10 +534,483 @@ mod events {
         }
     }
 
+    fn start_para_with_alignment(alignment: TextAlignment) -> Event {
+        Event::StartParagraph {
+            alignment: Some(alignment),
+            id: None,
+        }
+    }
+
     fn text(content: &str) -> Event {
         Event::Text {
             content: content.to_string(),
             style: TextStyle::default(),
+        }
+    }
+
+    mod rpr {
+        use super::*;
+
+        fn collect_events(content: &str) -> Vec<Event> {
+            let document_xml = format!(
+                r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{content}</w:body></w:document>"#,
+            );
+            let mut reader = make_reader(&document_xml);
+            drive(&mut reader)
+        }
+
+        fn styled_text(content: &str, style: TextStyle) -> Event {
+            Event::Text {
+                content: content.to_string(),
+                style,
+            }
+        }
+
+        fn expected_events(text_event: Event) -> Vec<Event> {
+            vec![
+                start_doc(),
+                start_para(),
+                text_event,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        }
+
+        #[test]
+        fn rpr_bold_applied_to_text() {
+            let events = collect_events("<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        bold: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_italic_applied_to_text() {
+            let events = collect_events("<w:p><w:r><w:rPr><w:i/></w:rPr><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        italic: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_strike_applied_to_text() {
+            let events =
+                collect_events("<w:p><w:r><w:rPr><w:strike/></w:rPr><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        strikethrough: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_dstrike_collapses_to_strikethrough() {
+            let events =
+                collect_events("<w:p><w:r><w:rPr><w:dstrike/></w:rPr><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        strikethrough: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_combined_bold_italic_strike() {
+            let events = collect_events(
+                "<w:p><w:r><w:rPr><w:b/><w:i/><w:strike/></w:rPr><w:t>x</w:t></w:r></w:p>",
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        bold: true,
+                        italic: true,
+                        strikethrough: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_bold_val_false_disables() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:b w:val="false"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_bold_val_zero_disables() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:b w:val="0"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_bold_val_on_enables() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:b w:val="on"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        bold: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_duplicate_last_wins() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:b/><w:b w:val="false"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_state_resets_between_runs() {
+            let events = collect_events(
+                "<w:p><w:r><w:rPr><w:b/></w:rPr><w:t>a</w:t></w:r><w:r><w:t>b</w:t></w:r></w:p>",
+            );
+            assert_eq!(
+                events,
+                vec![
+                    start_doc(),
+                    start_para(),
+                    styled_text(
+                        "a",
+                        TextStyle {
+                            bold: true,
+                            ..TextStyle::default()
+                        },
+                    ),
+                    text("b"),
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[test]
+        fn rpr_absent_uses_default_style() {
+            let events = collect_events("<w:p><w:r><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_underline_single_enables() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        underline: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_underline_double_enables() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:u w:val="double"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        underline: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_underline_dotted_enables() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:u w:val="dotted"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        underline: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_underline_val_none_disables() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:u w:val="none"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_underline_no_val_means_no_underline() {
+            let events = collect_events("<w:p><w:r><w:rPr><w:u/></w:rPr><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_vert_align_subscript() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:vertAlign w:val="subscript"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        subscript: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_vert_align_superscript() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:vertAlign w:val="superscript"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        superscript: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+
+        #[test]
+        fn rpr_vert_align_baseline_resets() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:vertAlign w:val="superscript"/><w:vertAlign w:val="baseline"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_vert_align_no_val_treated_lenient() {
+            let events =
+                collect_events("<w:p><w:r><w:rPr><w:vertAlign/></w:rPr><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(events, expected_events(text("x")));
+        }
+
+        #[test]
+        fn rpr_underline_bold_combined() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:b/><w:u w:val="single"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text(
+                    "x",
+                    TextStyle {
+                        bold: true,
+                        underline: true,
+                        ..TextStyle::default()
+                    },
+                ))
+            );
+        }
+    }
+
+    mod ppr {
+        use super::*;
+
+        fn collect_events(content: &str) -> Vec<Event> {
+            let document_xml = format!(
+                r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{content}</w:body></w:document>"#,
+            );
+            let mut reader = make_reader(&document_xml);
+            drive(&mut reader)
+        }
+
+        fn expected_paragraph_events(start: Event) -> Vec<Event> {
+            vec![start_doc(), start, Event::EndParagraph, Event::EndDocument]
+        }
+
+        #[test]
+        fn ppr_jc_center_sets_alignment() {
+            let events = collect_events(r#"<w:p><w:pPr><w:jc w:val="center"/></w:pPr></w:p>"#);
+            assert_eq!(
+                events,
+                expected_paragraph_events(start_para_with_alignment(TextAlignment::Center))
+            );
+        }
+
+        #[test]
+        fn ppr_jc_left_sets_left() {
+            let events = collect_events(r#"<w:p><w:pPr><w:jc w:val="left"/></w:pPr></w:p>"#);
+            assert_eq!(
+                events,
+                expected_paragraph_events(start_para_with_alignment(TextAlignment::Left))
+            );
+        }
+
+        #[test]
+        fn ppr_jc_start_maps_to_left() {
+            let events = collect_events(r#"<w:p><w:pPr><w:jc w:val="start"/></w:pPr></w:p>"#);
+            assert_eq!(
+                events,
+                expected_paragraph_events(start_para_with_alignment(TextAlignment::Left))
+            );
+        }
+
+        #[test]
+        fn ppr_jc_right_sets_right() {
+            let events = collect_events(r#"<w:p><w:pPr><w:jc w:val="right"/></w:pPr></w:p>"#);
+            assert_eq!(
+                events,
+                expected_paragraph_events(start_para_with_alignment(TextAlignment::Right))
+            );
+        }
+
+        #[test]
+        fn ppr_jc_end_maps_to_right() {
+            let events = collect_events(r#"<w:p><w:pPr><w:jc w:val="end"/></w:pPr></w:p>"#);
+            assert_eq!(
+                events,
+                expected_paragraph_events(start_para_with_alignment(TextAlignment::Right))
+            );
+        }
+
+        #[test]
+        fn ppr_jc_both_sets_justify() {
+            let events = collect_events(r#"<w:p><w:pPr><w:jc w:val="both"/></w:pPr></w:p>"#);
+            assert_eq!(
+                events,
+                expected_paragraph_events(start_para_with_alignment(TextAlignment::Justify))
+            );
+        }
+
+        #[test]
+        fn ppr_jc_distribute_sets_justify() {
+            let events = collect_events(r#"<w:p><w:pPr><w:jc w:val="distribute"/></w:pPr></w:p>"#);
+            assert_eq!(
+                events,
+                expected_paragraph_events(start_para_with_alignment(TextAlignment::Justify))
+            );
+        }
+
+        #[test]
+        fn ppr_jc_unmapped_leaves_alignment_none() {
+            let events =
+                collect_events(r#"<w:p><w:pPr><w:jc w:val="mediumKashida"/></w:pPr></w:p>"#);
+            assert_eq!(events, expected_paragraph_events(start_para()));
+        }
+
+        #[test]
+        fn ppr_jc_no_val_leaves_alignment_none() {
+            let events = collect_events("<w:p><w:pPr><w:jc/></w:pPr></w:p>");
+            assert_eq!(events, expected_paragraph_events(start_para()));
+        }
+
+        #[test]
+        fn ppr_absent_emits_start_paragraph_at_first_content() {
+            let events = collect_events("<w:p><w:r><w:t>x</w:t></w:r></w:p>");
+            assert_eq!(
+                events,
+                vec![
+                    start_doc(),
+                    start_para(),
+                    text("x"),
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[test]
+        fn ppr_empty_emits_default_alignment() {
+            let events = collect_events("<w:p><w:pPr/></w:p>");
+            assert_eq!(events, expected_paragraph_events(start_para()));
+        }
+
+        #[test]
+        fn empty_paragraph_still_emits_start_end() {
+            let events = collect_events("<w:p></w:p>");
+            assert_eq!(events, expected_paragraph_events(start_para()));
+        }
+
+        #[test]
+        fn ppr_jc_followed_by_run_emits_in_order() {
+            let events = collect_events(
+                r#"<w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                vec![
+                    start_doc(),
+                    start_para_with_alignment(TextAlignment::Right),
+                    text("x"),
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[test]
+        fn ppr_rpr_inside_ppr_is_ignored() {
+            let events = collect_events(
+                "<w:p><w:pPr><w:rPr><w:b/></w:rPr></w:pPr><w:r><w:t>x</w:t></w:r></w:p>",
+            );
+            assert_eq!(
+                events,
+                vec![
+                    start_doc(),
+                    start_para(),
+                    text("x"),
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
         }
     }
 
@@ -567,7 +1040,7 @@ mod events {
 
         assert_eq!(
             format!("{reader:?}"),
-            "DocxReader { buf: [], in_ignored_subtree: 0, in_paragraph: false, in_text: false, pending_text: \"\", phase: \"<phase>\", queue: [], xml: \"<quick_xml::Reader>\" }"
+            "DocxReader { buf: [], in_ignored_subtree: 0, in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, paragraph_started_emitted: false, in_rpr: false, pending_run_style: TextStyle { bold: false, code: false, italic: false, mark: None, strikethrough: false, subscript: false, superscript: false, underline: false }, pending_text: \"\", current_run_style: TextStyle { bold: false, code: false, italic: false, mark: None, strikethrough: false, subscript: false, superscript: false, underline: false }, phase: \"<phase>\", queue: [], run_content_emitted: false, xml: \"<quick_xml::Reader>\" }"
         );
     }
 
@@ -1763,6 +2236,245 @@ mod events {
                 start_doc(),
                 start_para(),
                 text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn rpr_after_text_in_same_run_is_ignored() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>foo</w:t><w:rPr><w:b/></w:rPr></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("foo"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn rpr_after_text_with_more_content_does_not_affect_subsequent_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:rPr><w:b/></w:rPr><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn ppr_after_run_in_same_paragraph_is_ignored() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>foo</w:t></w:r><w:pPr><w:jc w:val="center"/></w:pPr></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("foo"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn ppr_then_run_then_ppr_only_first_applies() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>x</w:t></w:r><w:pPr><w:jc w:val="left"/></w:pPr></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para_with_alignment(TextAlignment::Right),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn out_of_order_rpr_does_not_corrupt_next_run() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t><w:rPr><w:b/></w:rPr></w:r><w:r><w:rPr><w:i/></w:rPr><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::Text {
+                    content: "b".to_string(),
+                    style: TextStyle {
+                        italic: true,
+                        ..TextStyle::default()
+                    },
+                },
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_rpr_self_closed_emits_default_style() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr/><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_rpr_open_close_emits_default_style() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr></w:rPr><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_ppr_self_closed_emits_default_alignment() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:pPr/><w:r><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn rpr_with_unknown_child_is_no_op() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:color w:val="FF0000"/><w:b/></w:rPr><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::Text {
+                    content: "x".to_string(),
+                    style: TextStyle {
+                        bold: true,
+                        ..TextStyle::default()
+                    },
+                },
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn ppr_with_unknown_child_is_no_op() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:pPr><w:ind w:left="720"/><w:jc w:val="center"/></w:pPr><w:r><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para_with_alignment(TextAlignment::Center),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn rpr_after_line_break_in_same_run_is_ignored() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:br/><w:rPr><w:b/></w:rPr></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::LineBreak,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn multiple_paragraphs_state_resets_between() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>a</w:t></w:r></w:p><w:p><w:r><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para_with_alignment(TextAlignment::Right),
+                Event::Text {
+                    content: "a".to_string(),
+                    style: TextStyle {
+                        bold: true,
+                        ..TextStyle::default()
+                    },
+                },
+                Event::EndParagraph,
+                start_para(),
+                text("b"),
                 Event::EndParagraph,
                 Event::EndDocument,
             ]


### PR DESCRIPTION
Streaming w:rPr (bold / italic / underline / strikethrough / sub-superscript) and w:pPr (w:jc alignment). Out-of-order rPr/pPr silently ignored. No content buffering; queue invariant preserved.

174 tests pass (43 unit + 130 integration + 1 doctest).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for paragraph alignment in DOCX documents.
  * Added support for run properties including bold, italic, strikethrough, underline, and vertical alignment (subscript/superscript).

* **Documentation**
  * Updated documentation to explicitly list supported DOCX features and clarify handling of unsupported elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->