### PR TITLE
feat(docx-reader,blocknote-writer): text color and highlight support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "base64",
  "docspec-core",
  "docspec-json",
+ "paste",
  "serde_json",
 ]
 
@@ -1719,6 +1720,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2742,7 +2749,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/EVENTS.md
+++ b/EVENTS.md
@@ -8,7 +8,7 @@ DocSpec documents are streams of typed events. Readers emit events. Writers cons
 
 **Formatting as wrappers.** Inline formatting is expressed via `StartTextStyle { kind: TextStyleKind, id: Option<String> }` and `EndTextStyle` wrapper events around `Text` content. This matches the Start/End uniformity of every other inline and block container.
 
-**Semantic fidelity.** Events capture meaning, not appearance. Visual properties (font, color, size) are not represented — except mark color for highlighting.
+**Semantic fidelity.** Events capture meaning, not appearance. Visual properties (font, size) are not represented. Color is represented in two places: `TextStyleKind::Mark(Color)` for highlight/background, and `TextStyleKind::TextColor(Color)` for foreground text color.
 
 **Lazy asset references.** Images carry references, not bytes. Writers resolve via `AssetProvider`.
 
@@ -70,6 +70,7 @@ enum Color { Rgb { r: u8, g: u8, b: u8 } }
 enum TextStyleKind {
     Bold, Italic, Code, Strikethrough, Underline, Subscript, Superscript,
     Mark(Color),  // highlight color
+    TextColor(Color),  // foreground text color
 }
 
 enum ImageSource {
@@ -181,7 +182,7 @@ Every `Start*` has a matching `End*`. They nest but never overlap.
 
 **Link.** An inline container (uses Start/End because it carries `href`). Valid inside paragraphs, headings, list items, cells, definition details. Cannot nest.
 
-**StartTextStyle / EndTextStyle.** An inline-container pair carrying a single `TextStyleKind`. Valid inside paragraphs, headings, list items, cells, definition details. Style spans nest but never overlap (per Rule 1); readers MUST close-and-reopen to express overlapping source styles. `Subscript` and `Superscript` MAY both be active simultaneously by nesting; writers that cannot represent both prefer `Superscript`. The `Mark(Color)` variant carries the highlight color.
+**StartTextStyle / EndTextStyle.** An inline-container pair carrying a single `TextStyleKind`. Valid inside paragraphs, headings, list items, cells, definition details. Style spans nest but never overlap (per Rule 1); readers MUST close-and-reopen to express overlapping source styles. `Subscript` and `Superscript` MAY both be active simultaneously by nesting; writers that cannot represent both prefer `Superscript`. The `Mark(Color)` variant carries the highlight/background color; the `TextColor(Color)` variant carries the foreground text color.
 
 **Text.** Whitespace is significant. Outside preformatted blocks, newlines in content are collapsed to whitespace; readers emit `LineBreak` for explicit hard breaks (e.g., markdown two-space-newline, HTML `<br>`) and `SoftBreak` for soft breaks (e.g., source line wraps within a paragraph). Inline formatting is expressed via surrounding `StartTextStyle`/`EndTextStyle` wrapper events; the `Text` event itself carries content only.
 

--- a/crates/docspec-blocknote-writer/Cargo.toml
+++ b/crates/docspec-blocknote-writer/Cargo.toml
@@ -15,6 +15,7 @@ docspec-core = { workspace = true }
 docspec-json = { workspace = true }
 
 [dev-dependencies]
+paste = "1"
 serde_json = "1"
 
 [lints]

--- a/crates/docspec-blocknote-writer/README.md
+++ b/crates/docspec-blocknote-writer/README.md
@@ -17,10 +17,41 @@ Converts a DocSpec event stream into [BlockNote](https://www.blocknotejs.org/) J
 | Ordered list item                  | `numberedListItem`                                |
 | Inline link                        | `link` inline type with `href` (title is dropped) |
 
-Inline styles are consumed from `StartTextStyle`/`EndTextStyle` spans around `Text` events. Bold, italic, code, strikethrough, and underline render as BlockNote style flags. Subscript, superscript, and mark/highlight spans are accepted but omitted because BlockNote's default schema has no equivalent representation.
+Inline styles are consumed from `StartTextStyle`/`EndTextStyle` spans around `Text` events. Bold, italic, code, strikethrough, and underline render as BlockNote style flags. Subscript and superscript are accepted but omitted because BlockNote's default schema has no equivalent representation.
 Inline links (`StartLink`/`EndLink`) emit a `link` inline type with the `href`. The optional `title` field is dropped (BlockNote's default link schema has no title).
 
 List items support arbitrary nesting via BlockNote's native `children: Block[]` arrays. The `start` prop on `numberedListItem` is preserved when the first item in a sequence carries an explicit start number.
+
+### Color Styles
+
+Two color-bearing style kinds emit JSON keys in the inline `styles` object:
+
+- **`textColor`** — emitted when the reader sends `StartTextStyle { kind: TextColor(Color) }`. The RGB value is snapped to the nearest BlockNote palette color and written as a string, e.g. `"textColor":"red"`.
+- **`backgroundColor`** — emitted when the reader sends `StartTextStyle { kind: Mark(Color) }`. Same palette snap, written as e.g. `"backgroundColor":"blue"`.
+
+Pure black `(0, 0, 0)` is treated as BlockNote's default and produces no key for either style. Non-RGB colors are also omitted. Any other RGB color is snapped to one of the 9 named palette entries.
+
+#### Palette
+
+Each style type has its own 9-entry palette of named colors. The names are the same for both, but the RGB values differ because BlockNote uses distinct pastel shades for backgrounds versus richer tones for text:
+
+| Name     |
+| -------- |
+| `gray`   |
+| `brown`  |
+| `red`    |
+| `orange` |
+| `yellow` |
+| `green`  |
+| `blue`   |
+| `purple` |
+| `pink`   |
+
+#### Palette snap algorithm
+
+The palette snap uses squared Euclidean distance in 8-bit sRGB space. No perceptual weighting, no gamma correction. Ties are broken by iteration order. This mirrors the reference Elixir implementation.
+
+The two palettes use different RGB values, so the same input color can snap to different names depending on whether it's a text color or a background color. For instance, the saturated red `(224, 62, 62)` snaps to background palette `"orange"` (not `"red"`) because the background palette uses pastel colors and the Euclidean distance to pastel orange is shorter than to pastel red. This is intentional and matches the reference implementation.
 
 ## Not Yet Supported
 

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -142,6 +142,8 @@
 //!
 //! [`EventSink`]: docspec_core::EventSink
 
+pub mod palette;
+
 use std::io::Write;
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
@@ -838,6 +840,8 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         let mut code = false;
         let mut strike = false;
         let mut underline = false;
+        let mut text_color: Option<docspec_core::Color> = None;
+        let mut background_color: Option<docspec_core::Color> = None;
 
         for kind in &self.open_styles {
             match kind {
@@ -854,10 +858,8 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
                     // Intentionally not rendered: BlockNote's default schema has no superscript representation.
                     Self::omit_unsupported_text_style("superscript");
                 }
-                TextStyleKind::Mark(_) => {
-                    // Intentionally not rendered: BlockNote's default schema has no mark/highlight representation.
-                    Self::omit_unsupported_text_style("mark");
-                }
+                TextStyleKind::TextColor(color) => text_color = Some(color.clone()),
+                TextStyleKind::Mark(color) => background_color = Some(color.clone()),
                 future_kind => {
                     // Future text styles are accepted and omitted until BlockNote has a mapped representation.
                     Self::omit_future_text_style(future_kind);
@@ -878,6 +880,16 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
                 ] {
                     if enabled {
                         s.key(key).value(true)?;
+                    }
+                }
+                if let Some(c) = text_color {
+                    if let Some(name) = palette::nearest_text_color(&c) {
+                        s.key("textColor").value(name)?;
+                    }
+                }
+                if let Some(c) = background_color {
+                    if let Some(name) = palette::nearest_background_color(&c) {
+                        s.key("backgroundColor").value(name)?;
                     }
                 }
                 Ok(())

--- a/crates/docspec-blocknote-writer/src/palette.rs
+++ b/crates/docspec-blocknote-writer/src/palette.rs
@@ -1,0 +1,143 @@
+//! `BlockNote` default color palette and nearest-color snapping.
+//!
+//! Colors are snapped to the nearest named palette entry using squared Euclidean
+//! distance in 8-bit sRGB space. No perceptual weighting, no gamma correction.
+//! Pure black `(0, 0, 0)` returns `None` (`BlockNote` default — no key emitted).
+
+/// Snaps an RGB color to the nearest `BlockNote` text-color palette entry.
+///
+/// Returns `None` for pure black `(0, 0, 0)` (`BlockNote` default).
+#[inline]
+#[must_use]
+pub fn nearest_text_color(color: &docspec_core::Color) -> Option<&'static str> {
+    nearest(color, TEXT_PALETTE)
+}
+
+/// Snaps an RGB color to the nearest `BlockNote` background-color palette entry.
+///
+/// Returns `None` for pure black `(0, 0, 0)` (`BlockNote` default).
+#[inline]
+#[must_use]
+pub fn nearest_background_color(color: &docspec_core::Color) -> Option<&'static str> {
+    nearest(color, BACKGROUND_PALETTE)
+}
+
+fn nearest(
+    color: &docspec_core::Color,
+    palette: &[(&'static str, u8, u8, u8)],
+) -> Option<&'static str> {
+    let docspec_core::Color::Rgb { r, g, b } = color else {
+        return None;
+    };
+    if (*r, *g, *b) == (0, 0, 0) {
+        return None;
+    }
+    palette
+        .iter()
+        .min_by_key(|(_, pr, pg, pb)| {
+            let dr = u32::from(r.abs_diff(*pr));
+            let dg = u32::from(g.abs_diff(*pg));
+            let db = u32::from(b.abs_diff(*pb));
+            dr.wrapping_mul(dr)
+                .wrapping_add(dg.wrapping_mul(dg))
+                .wrapping_add(db.wrapping_mul(db))
+        })
+        .map(|(name, _, _, _)| *name)
+}
+
+const TEXT_PALETTE: &[(&str, u8, u8, u8)] = &[
+    ("gray", 155, 154, 151),
+    ("brown", 100, 71, 58),
+    ("red", 224, 62, 62),
+    ("orange", 217, 115, 13),
+    ("yellow", 223, 171, 1),
+    ("green", 77, 100, 97),
+    ("blue", 11, 110, 153),
+    ("purple", 105, 64, 165),
+    ("pink", 173, 26, 114),
+];
+
+const BACKGROUND_PALETTE: &[(&str, u8, u8, u8)] = &[
+    ("gray", 235, 236, 237),
+    ("brown", 233, 229, 227),
+    ("red", 251, 228, 228),
+    ("orange", 246, 233, 217),
+    ("yellow", 251, 243, 219),
+    ("green", 221, 237, 234),
+    ("blue", 221, 235, 241),
+    ("purple", 234, 228, 242),
+    ("pink", 244, 223, 235),
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use docspec_core::Color;
+
+    macro_rules! snap_cases {
+        ($snap_fn:ident; $(($r:literal, $g:literal, $b:literal) => $name:literal,)+) => {
+            $(
+                paste::paste! {
+                    #[test]
+                    fn [<r $r _g $g _b $b _matches_ $name>]() {
+                        assert_eq!(
+                            $snap_fn(&Color::Rgb { r: $r, g: $g, b: $b }),
+                            Some($name),
+                        );
+                    }
+                }
+            )+
+        };
+    }
+
+    snap_cases! {
+        nearest_text_color;
+        // Exact palette matches — one per palette entry
+        (155, 154, 151) => "gray",
+        (100,  71,  58) => "brown",
+        (224,  62,  62) => "red",
+        (217, 115,  13) => "orange",
+        (223, 171,   1) => "yellow",
+        ( 77, 100,  97) => "green",
+        ( 11, 110, 153) => "blue",
+        (105,  64, 165) => "purple",
+        (173,  26, 114) => "pink",
+        // Snap — pure red (255,0,0) is closest to text palette red (224,62,62)
+        (255,   0,   0) => "red",
+    }
+
+    snap_cases! {
+        nearest_background_color;
+        // Exact palette matches — one per palette entry
+        (235, 236, 237) => "gray",
+        (233, 229, 227) => "brown",
+        (251, 228, 228) => "red",
+        (246, 233, 217) => "orange",
+        (251, 243, 219) => "yellow",
+        (221, 237, 234) => "green",
+        (221, 235, 241) => "blue",
+        (234, 228, 242) => "purple",
+        (244, 223, 235) => "pink",
+        // AC9: saturated red (224,62,62) snaps to background "orange" NOT "red".
+        // Background red (251,228,228) is pastel; distance to pastel orange
+        // (246,233,217) is shorter than to pastel red.
+        (224,  62,  62) => "orange",
+        // Pure yellow (255,255,0):
+        //   distance to yellow (251,243,219) = 4² + 12² + 219² = 48121
+        //   distance to orange (246,233,217) = 9² + 22² + 217² = 47654 → orange wins
+        (255, 255,   0) => "orange",
+    }
+
+    #[test]
+    fn nearest_text_color_black_returns_none() {
+        assert_eq!(nearest_text_color(&Color::Rgb { r: 0, g: 0, b: 0 }), None);
+    }
+
+    #[test]
+    fn nearest_background_color_black_returns_none() {
+        assert_eq!(
+            nearest_background_color(&Color::Rgb { r: 0, g: 0, b: 0 }),
+            None
+        );
+    }
+}

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -1,6 +1,6 @@
 //! Integration tests for `BlockNoteWriter`.
 
-#![allow(clippy::expect_used)]
+#![allow(clippy::expect_used, clippy::redundant_test_prefix)]
 
 extern crate alloc;
 
@@ -2193,14 +2193,14 @@ mod tests {
     }
 
     #[test]
-    fn mark_dropped_style_text_preserves_content_without_flag() {
+    fn mark_style_emits_background_color_palette_snap() {
         let json = run_events(&[
             start_document(),
             start_paragraph(),
             start_text_style(TextStyleKind::Mark(Color::Rgb {
-                r: 255,
-                g: 255,
-                b: 0,
+                r: 251,
+                g: 243,
+                b: 219,
             })),
             text("x"),
             Event::EndTextStyle,
@@ -2209,7 +2209,154 @@ mod tests {
         ]);
         assert_eq!(
             json,
+            r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{"backgroundColor":"yellow"}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn test_blocknote_text_color_orange_exact_match() {
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            start_text_style(TextStyleKind::TextColor(Color::Rgb {
+                r: 217,
+                g: 115,
+                b: 13,
+            })),
+            text("x"),
+            Event::EndTextStyle,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{"textColor":"orange"}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn test_blocknote_saturated_red_snaps_to_background_orange() {
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            start_text_style(TextStyleKind::Mark(Color::Rgb {
+                r: 224,
+                g: 62,
+                b: 62,
+            })),
+            text("x"),
+            Event::EndTextStyle,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{"backgroundColor":"orange"}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn test_blocknote_pure_black_text_color_filtered() {
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            start_text_style(TextStyleKind::TextColor(Color::Rgb { r: 0, g: 0, b: 0 })),
+            text("x"),
+            Event::EndTextStyle,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
             r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn test_blocknote_pure_black_mark_filtered() {
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            start_text_style(TextStyleKind::Mark(Color::Rgb { r: 0, g: 0, b: 0 })),
+            text("x"),
+            Event::EndTextStyle,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn bold_plus_text_color_emits_both_keys() {
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            start_text_style(TextStyleKind::Bold),
+            start_text_style(TextStyleKind::TextColor(Color::Rgb {
+                r: 224,
+                g: 62,
+                b: 62,
+            })),
+            text("x"),
+            Event::EndTextStyle,
+            Event::EndTextStyle,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{"bold":true,"textColor":"red"}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn text_color_and_mark_combined_emits_both() {
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            start_text_style(TextStyleKind::TextColor(Color::Rgb {
+                r: 224,
+                g: 62,
+                b: 62,
+            })),
+            start_text_style(TextStyleKind::Mark(Color::Rgb {
+                r: 251,
+                g: 243,
+                b: 219,
+            })),
+            text("x"),
+            Event::EndTextStyle,
+            Event::EndTextStyle,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{"textColor":"red","backgroundColor":"yellow"}}],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn text_color_arbitrary_rgb_snaps_to_palette() {
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            start_text_style(TextStyleKind::TextColor(Color::Rgb {
+                r: 200,
+                g: 200,
+                b: 200,
+            })),
+            text("x"),
+            Event::EndTextStyle,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"paragraph","content":[{"type":"text","text":"x","styles":{"textColor":"gray"}}],"children":[]}]"#
         );
     }
 

--- a/crates/docspec-core/src/event.rs
+++ b/crates/docspec-core/src/event.rs
@@ -23,6 +23,8 @@ pub enum TextStyleKind {
     Superscript,
     /// Highlight/mark color formatting.
     Mark(crate::Color),
+    /// Foreground (text) color. Carries an explicit RGB color.
+    TextColor(crate::Color),
 }
 
 /// A streaming document event.

--- a/crates/docspec-core/tests/event.rs
+++ b/crates/docspec-core/tests/event.rs
@@ -682,6 +682,24 @@ mod tests {
     }
 
     #[test]
+    fn text_color_variant_round_trips() {
+        let color = Color::Rgb {
+            r: 17,
+            g: 34,
+            b: 51,
+        };
+        let kind = TextStyleKind::TextColor(color.clone());
+        let cloned = kind.clone();
+        assert_eq!(kind, cloned);
+        let event = Event::StartTextStyle {
+            kind: TextStyleKind::TextColor(color),
+            id: None,
+        };
+        let cloned_event = event.clone();
+        assert_eq!(event, cloned_event);
+    }
+
+    #[test]
     fn thematic_break() {
         let event = Event::ThematicBreak { id: None };
         let cloned = event.clone();

--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -12,17 +12,30 @@ architecture, and the event protocol.
 - Tabs (`<w:tab>` — emitted as a `Text` event containing the single character `"\t"`)
 - Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`) — emitted as structural events only; cell merging, header rows, and table styles are not represented
 - Run properties (`<w:rPr>`): `<w:b>` (bold), `<w:i>` (italic), `<w:u>` (underline — any `w:val` other than `none`), `<w:strike>` (strikethrough), `<w:dstrike>` (double-strike, collapses to strikethrough), `<w:vertAlign>` (`subscript` and `superscript` only; `baseline` resets to neither). These are emitted as deferred `StartTextStyle { kind, id: None }` / `EndTextStyle` wrapper events around the first run content, not as fields on `Text` events. Empty styled runs emit no style wrapper events; multiple `<w:t>` elements in one styled run share a single wrapper span.
+- Run color properties (`<w:rPr>`):
+  - `<w:color w:val="HEX">` — foreground (text) color. Emitted as `StartTextStyle { kind: TextColor(Color::Rgb { r, g, b }) }`. `w:val="auto"` and non-hex values are silently dropped. Black `(0,0,0)` is preserved by the reader; whether to treat it as "default color" is writer policy.
+  - `<w:highlight w:val="namedColor">` — highlight color using the 17-entry ECMA-376 named palette. Emitted as `StartTextStyle { kind: Mark(Color::Rgb { r, g, b }) }`. `w:val="none"` and unknown names are silently dropped.
+  - `<w:shd w:fill="HEX">` — background fill, used as a fallback highlight when `<w:highlight>` is absent. Emitted as `StartTextStyle { kind: Mark(Color::Rgb { r, g, b }) }`. `w:fill="auto"` and a missing `w:fill` attribute are silently dropped.
 - Paragraph properties (`<w:pPr>`): `<w:jc>` (alignment — `left`/`start` to Left, `right`/`end` to Right, `center` to Center, `both`/`distribute` to Justify)
 - Empty `<w:rPr/>` and `<w:pPr/>` are treated as no properties (default style / alignment None)
 - A `<w:rPr>` or `<w:pPr>` that appears after content in the same parent is silently ignored (per the OOXML spec, both must be the first child element)
 - Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`
 - Compression: `Stored` and `Deflated` only
 
+### Color and Highlight Precedence
+
+When both `<w:highlight>` and `<w:shd w:fill>` appear in the same `<w:rPr>`, `<w:highlight>` wins. The `<w:shd>` fill is ignored for that run.
+
+### No-Collapse Rule
+
+Adjacent runs with the same color emit separate `StartTextStyle`/`EndTextStyle` pairs. The reader maintains per-run discipline and does not merge consecutive runs, even when their style properties are identical.
+
 ## Out of Scope (silently dropped)
 
 - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
 - Style references (`<w:rStyle>`, `<w:pStyle>`)
-- Run formatting not listed above: `<w:color>`, `<w:sz>`, `<w:szCs>`, `<w:rFonts>`, `<w:shd>`, `<w:highlight>`, `<w:caps>`, `<w:smallCaps>`, `<w:position>`, `<w:spacing>`, `<w:kern>`, `<w:lang>`, `<w:noProof>`
+- Run formatting not listed above: `<w:sz>`, `<w:szCs>`, `<w:rFonts>`, `<w:caps>`, `<w:smallCaps>`, `<w:position>`, `<w:spacing>`, `<w:kern>`, `<w:lang>`, `<w:noProof>`
+- `themeColor` / `themeTint` / `themeShade` attributes on `<w:color>` and `<w:shd>` — silently dropped. The reader does not parse `styles.xml` or `theme1.xml`, so theme-referenced colors cannot be resolved. Future work.
 - Revision tracking (`<w:rPrChange>`, `<w:pPrChange>`)
 - Advanced paragraph layout beyond alignment: `<w:numPr>`, `<w:ind>`, `<w:tabs>`, `<w:framePr>`, `<w:sectPr>`
 - `<w:rPr>` nested inside `<w:pPr>` (paragraph mark / pilcrow run properties)

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -4,7 +4,7 @@ use alloc::collections::VecDeque;
 use core::fmt;
 use std::io::{BufReader, Read};
 
-use docspec_core::{Error, Event, Result, TextAlignment, TextStyleKind};
+use docspec_core::{Color, Error, Event, Result, TextAlignment, TextStyleKind};
 use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText};
 
 use crate::properties;
@@ -46,10 +46,20 @@ pub struct DocumentReader {
     in_rpr: bool,
     /// Run style kinds accumulated while inside `<w:rPr>`.
     pending_run_kinds: Vec<TextStyleKind>,
+    /// Text color accumulated while inside `<w:rPr>`.
+    pending_run_text_color: Option<Color>,
+    /// Highlight color accumulated while inside `<w:rPr>`.
+    pending_run_mark: Option<Color>,
+    /// Shading fill color accumulated while inside `<w:rPr>`.
+    pending_run_shade: Option<Color>,
     /// Text collected for the current `<w:t>` element.
     pending_text: String,
     /// Run style kinds frozen at `</w:rPr>`, applied to subsequent emissions in the same run.
     frozen_run_kinds: Vec<TextStyleKind>,
+    /// Text color frozen at `</w:rPr>`, applied to subsequent emissions in the same run.
+    frozen_run_text_color: Option<Color>,
+    /// Highlight/background color frozen at `</w:rPr>`, applied to subsequent emissions in the same run.
+    frozen_run_mark: Option<Color>,
     /// Style kinds currently opened for the active run.
     open_styles: Vec<TextStyleKind>,
     /// Document processing phase.
@@ -78,8 +88,13 @@ impl fmt::Debug for DocumentReader {
             .field("paragraph_started_emitted", &self.paragraph_started_emitted)
             .field("in_rpr", &self.in_rpr)
             .field("pending_run_kinds", &self.pending_run_kinds)
+            .field("pending_run_text_color", &self.pending_run_text_color)
+            .field("pending_run_mark", &self.pending_run_mark)
+            .field("pending_run_shade", &self.pending_run_shade)
             .field("pending_text", &self.pending_text)
             .field("frozen_run_kinds", &self.frozen_run_kinds)
+            .field("frozen_run_text_color", &self.frozen_run_text_color)
+            .field("frozen_run_mark", &self.frozen_run_mark)
             .field("open_styles", &self.open_styles)
             .field("phase", &"<phase>")
             .field("queue", &self.queue)
@@ -101,8 +116,13 @@ impl DocumentReader {
             paragraph_started_emitted: false,
             in_rpr: false,
             pending_run_kinds: Vec::new(),
+            pending_run_text_color: None,
+            pending_run_mark: None,
+            pending_run_shade: None,
             pending_text: String::new(),
             frozen_run_kinds: Vec::new(),
+            frozen_run_text_color: None,
+            frozen_run_mark: None,
             open_styles: Vec::new(),
             phase: Phase::NotStarted,
             queue: VecDeque::new(),
@@ -142,6 +162,11 @@ impl DocumentReader {
         }
         self.frozen_run_kinds.clear();
         self.pending_run_kinds.clear();
+        self.frozen_run_text_color = None;
+        self.frozen_run_mark = None;
+        self.pending_run_text_color = None;
+        self.pending_run_mark = None;
+        self.pending_run_shade = None;
         self.queue.push_back(Event::EndParagraph);
         self.in_paragraph = false;
         self.in_text = false;
@@ -168,6 +193,26 @@ impl DocumentReader {
                     id: None,
                 });
                 self.open_styles.push(kind.clone());
+            }
+        }
+        if let Some(color) = self.frozen_run_text_color.clone() {
+            let kind = TextStyleKind::TextColor(color);
+            if !self.open_styles.contains(&kind) {
+                self.queue.push_back(Event::StartTextStyle {
+                    kind: kind.clone(),
+                    id: None,
+                });
+                self.open_styles.push(kind);
+            }
+        }
+        if let Some(color) = self.frozen_run_mark.clone() {
+            let kind = TextStyleKind::Mark(color);
+            if !self.open_styles.contains(&kind) {
+                self.queue.push_back(Event::StartTextStyle {
+                    kind: kind.clone(),
+                    id: None,
+                });
+                self.open_styles.push(kind);
             }
         }
     }
@@ -242,6 +287,18 @@ impl DocumentReader {
                 let val = read_val_attribute(tag);
                 self.set_pending_vertical_alignment(properties::parse_vert_align(val.as_deref()));
             }
+            b"color" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                self.pending_run_text_color = properties::parse_color_val(val.as_deref());
+            }
+            b"highlight" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                self.pending_run_mark = properties::parse_highlight_val(val.as_deref());
+            }
+            b"shd" if self.in_rpr => {
+                let fill = read_attribute(tag, b"w:fill");
+                self.pending_run_shade = properties::parse_shd_fill(fill.as_deref());
+            }
             b"p" if !self.in_paragraph => {
                 self.queue.push_back(Event::StartParagraph {
                     alignment: None,
@@ -269,6 +326,12 @@ impl DocumentReader {
             }
             b"rPr" if self.in_rpr => {
                 self.frozen_run_kinds = core::mem::take(&mut self.pending_run_kinds);
+                self.frozen_run_text_color = self.pending_run_text_color.take();
+                self.frozen_run_mark = self
+                    .pending_run_mark
+                    .take()
+                    .or_else(|| self.pending_run_shade.take());
+                self.pending_run_shade = None;
                 self.in_rpr = false;
             }
             b"r" => {
@@ -277,6 +340,11 @@ impl DocumentReader {
                 }
                 self.frozen_run_kinds.clear();
                 self.pending_run_kinds.clear();
+                self.frozen_run_text_color = None;
+                self.frozen_run_mark = None;
+                self.pending_run_text_color = None;
+                self.pending_run_mark = None;
+                self.pending_run_shade = None;
                 self.run_content_emitted = false;
                 self.in_rpr = false;
             }
@@ -349,6 +417,9 @@ impl DocumentReader {
                 } else {
                     self.in_rpr = true;
                     self.pending_run_kinds.clear();
+                    self.pending_run_text_color = None;
+                    self.pending_run_mark = None;
+                    self.pending_run_shade = None;
                 }
             }
             b"b" if self.in_rpr => {
@@ -373,6 +444,18 @@ impl DocumentReader {
             b"vertAlign" if self.in_rpr => {
                 let val = read_val_attribute(tag);
                 self.set_pending_vertical_alignment(properties::parse_vert_align(val.as_deref()));
+            }
+            b"color" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                self.pending_run_text_color = properties::parse_color_val(val.as_deref());
+            }
+            b"highlight" if self.in_rpr => {
+                let val = read_val_attribute(tag);
+                self.pending_run_mark = properties::parse_highlight_val(val.as_deref());
+            }
+            b"shd" if self.in_rpr => {
+                let fill = read_attribute(tag, b"w:fill");
+                self.pending_run_shade = properties::parse_shd_fill(fill.as_deref());
             }
             b"p" if !self.in_paragraph => self.start_paragraph(),
             b"r" if self.in_paragraph => {
@@ -514,6 +597,13 @@ fn read_val_attribute(tag: &BytesStart<'_>) -> Option<String> {
         .map(str::to_owned)
 }
 
+fn read_attribute(tag: &BytesStart<'_>, name: &[u8]) -> Option<String> {
+    let a = tag.try_get_attribute(name).ok().flatten()?;
+    core::str::from_utf8(a.value.as_ref())
+        .ok()
+        .map(str::to_owned)
+}
+
 fn parse_on_off_attribute(tag: &BytesStart<'_>) -> bool {
     let val = read_val_attribute(tag);
     properties::parse_on_off(val.as_deref())
@@ -555,6 +645,35 @@ mod tests {
         let mut reader = make_reader(&doc);
         loop {
             if reader.queue.len() > 16 {
+                return Err(Box::new(Error::Other {
+                    message: format!("queue grew to {}", reader.queue.len()),
+                }));
+            }
+            if reader.next_event()?.is_none() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn queue_length_remains_bounded_with_colors(
+    ) -> core::result::Result<(), Box<dyn core::error::Error>> {
+        let doc = {
+            let mut content = String::from(
+                r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>"#,
+            );
+            for _ in 0..1000 {
+                content.push_str(
+                    r#"<w:p><w:r><w:rPr><w:b/><w:color w:val="FF0000"/><w:highlight w:val="yellow"/><w:shd w:val="clear" w:fill="0000FF"/></w:rPr><w:t>hello</w:t></w:r></w:p>"#,
+                );
+            }
+            content.push_str("</w:body></w:document>");
+            content
+        };
+        let mut reader = make_reader(&doc);
+        loop {
+            if reader.queue.len() > 32 {
                 return Err(Box::new(Error::Other {
                     message: format!("queue grew to {}", reader.queue.len()),
                 }));

--- a/crates/docspec-docx-reader/src/properties.rs
+++ b/crates/docspec-docx-reader/src/properties.rs
@@ -1,6 +1,6 @@
 //! OOXML value parsers for run and paragraph properties.
 
-use docspec_core::TextAlignment;
+use docspec_core::{Color, TextAlignment};
 
 /// Parses an `ST_OnOff` value (ECMA-376 §22.9.2.7).
 ///
@@ -47,6 +47,98 @@ pub fn parse_alignment(val: &str) -> Option<TextAlignment> {
         "both" | "distribute" => Some(TextAlignment::Justify),
         _ => None,
     }
+}
+
+/// Parses a hex color string (with or without leading `#`, 3 or 6 hex digits) into a `Color`.
+///
+/// Returns `None` for `"auto"`, empty strings, non-hex input, or lengths other than 3 or 6.
+pub fn parse_hex_color(val: &str) -> Option<Color> {
+    let s = val.strip_prefix('#').unwrap_or(val);
+    match s.len() {
+        3 => {
+            let mut chars = s.chars();
+            let r_char = chars.next()?;
+            let g_char = chars.next()?;
+            let b_char = chars.next()?;
+            let r_str = format!("{r_char}{r_char}");
+            let g_str = format!("{g_char}{g_char}");
+            let b_str = format!("{b_char}{b_char}");
+            let r = u8::from_str_radix(&r_str, 16).ok()?;
+            let g = u8::from_str_radix(&g_str, 16).ok()?;
+            let b = u8::from_str_radix(&b_str, 16).ok()?;
+            Some(Color::Rgb { r, g, b })
+        }
+        6 => {
+            let mut chars = s.chars();
+            let r1 = chars.next()?;
+            let r2 = chars.next()?;
+            let g1 = chars.next()?;
+            let g2 = chars.next()?;
+            let b1 = chars.next()?;
+            let b2 = chars.next()?;
+            let r_str = format!("{r1}{r2}");
+            let g_str = format!("{g1}{g2}");
+            let b_str = format!("{b1}{b2}");
+            let r = u8::from_str_radix(&r_str, 16).ok()?;
+            let g = u8::from_str_radix(&g_str, 16).ok()?;
+            let b = u8::from_str_radix(&b_str, 16).ok()?;
+            Some(Color::Rgb { r, g, b })
+        }
+        _ => None,
+    }
+}
+
+/// Parses the `w:val` attribute of a `<w:color>` element.
+///
+/// Returns `None` for absent attribute, `"auto"`, or non-hex values.
+pub fn parse_color_val(val: Option<&str>) -> Option<Color> {
+    parse_hex_color(val?)
+}
+
+/// Highlight color palette (OOXML standard 16 colors, excluding "none").
+const HIGHLIGHT_PALETTE: &[(&str, u8, u8, u8)] = &[
+    ("black", 0, 0, 0),
+    ("blue", 0, 0, 255),
+    ("cyan", 0, 255, 255),
+    ("green", 0, 255, 0),
+    ("magenta", 255, 0, 255),
+    ("red", 255, 0, 0),
+    ("yellow", 255, 255, 0),
+    ("white", 255, 255, 255),
+    ("darkBlue", 0, 0, 128),
+    ("darkCyan", 0, 128, 128),
+    ("darkGreen", 0, 128, 0),
+    ("darkMagenta", 128, 0, 128),
+    ("darkRed", 128, 0, 0),
+    ("darkYellow", 128, 128, 0),
+    ("darkGray", 128, 128, 128),
+    ("lightGray", 192, 192, 192),
+];
+
+/// Parses the `w:val` attribute of a `<w:highlight>` element.
+///
+/// Returns `None` for absent attribute, `"none"`, or unknown names.
+pub fn parse_highlight_val(val: Option<&str>) -> Option<Color> {
+    let s = val?;
+    if s == "none" {
+        return None;
+    }
+    HIGHLIGHT_PALETTE
+        .iter()
+        .find(|(name, _, _, _)| *name == s)
+        .map(|(_, r, g, b)| Color::Rgb {
+            r: *r,
+            g: *g,
+            b: *b,
+        })
+}
+
+/// Parses the `w:fill` attribute of a `<w:shd>` element.
+///
+/// Returns `None` for absent attribute, `"auto"`, or non-hex values.
+/// The `w:val` pattern attribute is intentionally ignored.
+pub fn parse_shd_fill(fill: Option<&str>) -> Option<Color> {
+    parse_hex_color(fill?)
 }
 
 #[cfg(test)]
@@ -195,5 +287,331 @@ mod tests {
     #[test]
     fn parse_alignment_unknown_returns_none() {
         assert_eq!(parse_alignment("mediumKashida"), None);
+    }
+
+    // ============================================================================
+    // parse_hex_color tests (11 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_hex_color_six_char_uppercase() {
+        assert_eq!(
+            parse_hex_color("FF0000"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+    }
+
+    #[test]
+    fn parse_hex_color_six_char_lowercase() {
+        assert_eq!(
+            parse_hex_color("ff0000"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+    }
+
+    #[test]
+    fn parse_hex_color_six_char_mixed_case() {
+        assert_eq!(
+            parse_hex_color("Ff00aA"),
+            Some(Color::Rgb {
+                r: 255,
+                g: 0,
+                b: 170
+            })
+        );
+    }
+
+    #[test]
+    fn parse_hex_color_three_char_expanded() {
+        assert_eq!(
+            parse_hex_color("f0f"),
+            Some(Color::Rgb {
+                r: 255,
+                g: 0,
+                b: 255
+            })
+        );
+    }
+
+    #[test]
+    fn parse_hex_color_three_char_uppercase() {
+        assert_eq!(
+            parse_hex_color("ABC"),
+            Some(Color::Rgb {
+                r: 170,
+                g: 187,
+                b: 204
+            })
+        );
+    }
+
+    #[test]
+    fn parse_hex_color_strips_leading_hash() {
+        assert_eq!(
+            parse_hex_color("#FF0000"),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+    }
+
+    #[test]
+    fn parse_hex_color_auto_returns_none() {
+        assert_eq!(parse_hex_color("auto"), None);
+    }
+
+    #[test]
+    fn parse_hex_color_empty_returns_none() {
+        assert_eq!(parse_hex_color(""), None);
+    }
+
+    #[test]
+    fn parse_hex_color_invalid_length_returns_none() {
+        assert_eq!(parse_hex_color("FFFF"), None);
+        assert_eq!(parse_hex_color("FFFFF"), None);
+        assert_eq!(parse_hex_color("FFFFFFF"), None);
+    }
+
+    #[test]
+    fn parse_hex_color_non_hex_returns_none() {
+        assert_eq!(parse_hex_color("GG0000"), None);
+    }
+
+    #[test]
+    fn parse_hex_color_black_returns_some() {
+        assert_eq!(
+            parse_hex_color("000000"),
+            Some(Color::Rgb { r: 0, g: 0, b: 0 })
+        );
+    }
+
+    // ============================================================================
+    // parse_color_val tests (6 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_color_val_none_input_returns_none() {
+        assert_eq!(parse_color_val(None), None);
+    }
+
+    #[test]
+    fn parse_color_val_auto_returns_none() {
+        assert_eq!(parse_color_val(Some("auto")), None);
+    }
+
+    #[test]
+    fn parse_color_val_valid_hex_returns_color() {
+        assert_eq!(
+            parse_color_val(Some("FF0000")),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+    }
+
+    #[test]
+    fn parse_color_val_invalid_hex_returns_none() {
+        assert_eq!(parse_color_val(Some("xyz")), None);
+    }
+
+    #[test]
+    fn parse_color_val_black_returns_some() {
+        assert_eq!(
+            parse_color_val(Some("000000")),
+            Some(Color::Rgb { r: 0, g: 0, b: 0 })
+        );
+    }
+
+    #[test]
+    fn parse_color_val_with_leading_hash() {
+        assert_eq!(
+            parse_color_val(Some("#FF0000")),
+            Some(Color::Rgb { r: 255, g: 0, b: 0 })
+        );
+    }
+
+    // ============================================================================
+    // parse_highlight_val tests (8 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_highlight_val_none_input_returns_none() {
+        assert_eq!(parse_highlight_val(None), None);
+    }
+
+    #[test]
+    fn parse_highlight_val_explicit_none_returns_none() {
+        assert_eq!(parse_highlight_val(Some("none")), None);
+    }
+
+    #[test]
+    fn parse_highlight_val_yellow_returns_yellow() {
+        assert_eq!(
+            parse_highlight_val(Some("yellow")),
+            Some(Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 0
+            })
+        );
+    }
+
+    #[test]
+    fn parse_highlight_val_dark_blue_returns_dark_blue() {
+        assert_eq!(
+            parse_highlight_val(Some("darkBlue")),
+            Some(Color::Rgb { r: 0, g: 0, b: 128 })
+        );
+    }
+
+    #[test]
+    fn parse_highlight_val_light_gray_returns_light_gray() {
+        assert_eq!(
+            parse_highlight_val(Some("lightGray")),
+            Some(Color::Rgb {
+                r: 192,
+                g: 192,
+                b: 192
+            })
+        );
+    }
+
+    #[test]
+    fn parse_highlight_val_unknown_returns_none() {
+        assert_eq!(parse_highlight_val(Some("orangeMaize")), None);
+    }
+
+    #[test]
+    fn parse_highlight_val_case_sensitive() {
+        assert_eq!(parse_highlight_val(Some("YELLOW")), None);
+    }
+
+    #[test]
+    fn parse_highlight_val_all_palette_entries() {
+        // Test all 16 named entries + "none"
+        let test_cases = vec![
+            ("black", Some(Color::Rgb { r: 0, g: 0, b: 0 })),
+            ("blue", Some(Color::Rgb { r: 0, g: 0, b: 255 })),
+            (
+                "cyan",
+                Some(Color::Rgb {
+                    r: 0,
+                    g: 255,
+                    b: 255,
+                }),
+            ),
+            ("green", Some(Color::Rgb { r: 0, g: 255, b: 0 })),
+            (
+                "magenta",
+                Some(Color::Rgb {
+                    r: 255,
+                    g: 0,
+                    b: 255,
+                }),
+            ),
+            ("red", Some(Color::Rgb { r: 255, g: 0, b: 0 })),
+            (
+                "yellow",
+                Some(Color::Rgb {
+                    r: 255,
+                    g: 255,
+                    b: 0,
+                }),
+            ),
+            (
+                "white",
+                Some(Color::Rgb {
+                    r: 255,
+                    g: 255,
+                    b: 255,
+                }),
+            ),
+            ("darkBlue", Some(Color::Rgb { r: 0, g: 0, b: 128 })),
+            (
+                "darkCyan",
+                Some(Color::Rgb {
+                    r: 0,
+                    g: 128,
+                    b: 128,
+                }),
+            ),
+            ("darkGreen", Some(Color::Rgb { r: 0, g: 128, b: 0 })),
+            (
+                "darkMagenta",
+                Some(Color::Rgb {
+                    r: 128,
+                    g: 0,
+                    b: 128,
+                }),
+            ),
+            ("darkRed", Some(Color::Rgb { r: 128, g: 0, b: 0 })),
+            (
+                "darkYellow",
+                Some(Color::Rgb {
+                    r: 128,
+                    g: 128,
+                    b: 0,
+                }),
+            ),
+            (
+                "darkGray",
+                Some(Color::Rgb {
+                    r: 128,
+                    g: 128,
+                    b: 128,
+                }),
+            ),
+            (
+                "lightGray",
+                Some(Color::Rgb {
+                    r: 192,
+                    g: 192,
+                    b: 192,
+                }),
+            ),
+            ("none", None),
+        ];
+        for (name, expected) in test_cases {
+            assert_eq!(
+                parse_highlight_val(Some(name)),
+                expected,
+                "Failed for: {name}"
+            );
+        }
+    }
+
+    // ============================================================================
+    // parse_shd_fill tests (5 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_shd_fill_none_input_returns_none() {
+        assert_eq!(parse_shd_fill(None), None);
+    }
+
+    #[test]
+    fn parse_shd_fill_auto_returns_none() {
+        assert_eq!(parse_shd_fill(Some("auto")), None);
+    }
+
+    #[test]
+    fn parse_shd_fill_valid_hex_returns_color() {
+        assert_eq!(
+            parse_shd_fill(Some("FFFF00")),
+            Some(Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 0
+            })
+        );
+    }
+
+    #[test]
+    fn parse_shd_fill_invalid_hex_returns_none() {
+        assert_eq!(parse_shd_fill(Some("xyz")), None);
+    }
+
+    #[test]
+    fn parse_shd_fill_black_returns_some() {
+        assert_eq!(
+            parse_shd_fill(Some("000000")),
+            Some(Color::Rgb { r: 0, g: 0, b: 0 })
+        );
     }
 }

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -4,6 +4,7 @@
     clippy::expect_used,
     clippy::indexing_slicing,
     clippy::panic,
+    clippy::redundant_test_prefix,
     clippy::std_instead_of_core,
     clippy::tests_outside_test_module,
     clippy::unwrap_used
@@ -499,7 +500,7 @@ mod constructor {
 mod events {
     use std::io::Cursor;
 
-    use docspec_core::{Event, TextAlignment, TextStyleKind};
+    use docspec_core::{Color, Event, TextAlignment, TextStyleKind};
     use docspec_docx_reader::{DocxReader, EventSource as _};
 
     use crate::fixture;
@@ -875,6 +876,227 @@ mod events {
                 ]
             );
         }
+
+        #[test]
+        fn text_color_red_emits_start_text_style_textcolor_red() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text_events(
+                    &[TextStyleKind::TextColor(Color::Rgb { r: 255, g: 0, b: 0 })],
+                    "x",
+                ))
+            );
+        }
+
+        #[test]
+        fn test_w_color_auto_emits_no_event() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:color w:val="auto"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(vec![text("x")]));
+        }
+
+        #[test]
+        fn test_w_color_black_emitted_unchanged() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:color w:val="000000"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text_events(
+                    &[TextStyleKind::TextColor(Color::Rgb { r: 0, g: 0, b: 0 })],
+                    "x",
+                ))
+            );
+        }
+
+        #[test]
+        fn highlight_yellow_emits_mark_yellow() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:highlight w:val="yellow"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text_events(
+                    &[TextStyleKind::Mark(Color::Rgb {
+                        r: 255,
+                        g: 255,
+                        b: 0
+                    })],
+                    "x",
+                ))
+            );
+        }
+
+        #[test]
+        fn test_w_highlight_none_emits_no_event() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:highlight w:val="none"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(vec![text("x")]));
+        }
+
+        #[test]
+        fn highlight_unknown_emits_no_event() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:highlight w:val="orangeMaize"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(vec![text("x")]));
+        }
+
+        #[test]
+        fn shd_fill_yellow_emits_mark_yellow() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:shd w:val="clear" w:fill="FFFF00"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text_events(
+                    &[TextStyleKind::Mark(Color::Rgb {
+                        r: 255,
+                        g: 255,
+                        b: 0
+                    })],
+                    "x",
+                ))
+            );
+        }
+
+        #[test]
+        fn test_w_shd_fill_auto_emits_no_event() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:shd w:val="clear" w:fill="auto"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(vec![text("x")]));
+        }
+
+        #[test]
+        fn shd_with_no_fill_attribute_emits_no_event() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:shd w:val="clear"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(events, expected_events(vec![text("x")]));
+        }
+
+        #[test]
+        fn test_highlight_wins_over_shd() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:highlight w:val="yellow"/><w:shd w:val="clear" w:fill="FF0000"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text_events(
+                    &[TextStyleKind::Mark(Color::Rgb {
+                        r: 255,
+                        g: 255,
+                        b: 0
+                    })],
+                    "x",
+                ))
+            );
+        }
+
+        #[test]
+        fn test_shd_used_when_highlight_none() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:highlight w:val="none"/><w:shd w:val="clear" w:fill="FF0000"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text_events(
+                    &[TextStyleKind::Mark(Color::Rgb { r: 255, g: 0, b: 0 })],
+                    "x",
+                ))
+            );
+        }
+
+        #[test]
+        fn test_consecutive_runs_different_text_color() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>a</w:t></w:r><w:r><w:rPr><w:color w:val="0000FF"/></w:rPr><w:t>b</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                vec![
+                    start_doc(),
+                    start_para(),
+                    Event::StartTextStyle {
+                        kind: TextStyleKind::TextColor(Color::Rgb { r: 255, g: 0, b: 0 }),
+                        id: None,
+                    },
+                    text("a"),
+                    Event::EndTextStyle,
+                    Event::StartTextStyle {
+                        kind: TextStyleKind::TextColor(Color::Rgb { r: 0, g: 0, b: 255 }),
+                        id: None,
+                    },
+                    text("b"),
+                    Event::EndTextStyle,
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[test]
+        fn bold_plus_text_color_plus_mark_combined() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:b/><w:color w:val="FF0000"/><w:highlight w:val="yellow"/></w:rPr><w:t>x</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                expected_events(styled_text_events(
+                    &[
+                        TextStyleKind::Bold,
+                        TextStyleKind::TextColor(Color::Rgb { r: 255, g: 0, b: 0 }),
+                        TextStyleKind::Mark(Color::Rgb {
+                            r: 255,
+                            g: 255,
+                            b: 0
+                        }),
+                    ],
+                    "x",
+                ))
+            );
+        }
+
+        #[test]
+        fn consecutive_runs_with_same_color_emit_close_and_reopen() {
+            let events = collect_events(
+                r#"<w:p><w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>a</w:t></w:r><w:r><w:rPr><w:color w:val="FF0000"/></w:rPr><w:t>b</w:t></w:r></w:p>"#,
+            );
+            assert_eq!(
+                events,
+                vec![
+                    start_doc(),
+                    start_para(),
+                    Event::StartTextStyle {
+                        kind: TextStyleKind::TextColor(Color::Rgb { r: 255, g: 0, b: 0 }),
+                        id: None,
+                    },
+                    text("a"),
+                    Event::EndTextStyle,
+                    Event::StartTextStyle {
+                        kind: TextStyleKind::TextColor(Color::Rgb { r: 255, g: 0, b: 0 }),
+                        id: None,
+                    },
+                    text("b"),
+                    Event::EndTextStyle,
+                    Event::EndParagraph,
+                    Event::EndDocument,
+                ]
+            );
+        }
+
+        #[test]
+        fn text_color_emits_no_event_when_in_rpr_is_false() {
+            let events =
+                collect_events(r#"<w:p><w:r><w:color w:val="FF0000"/><w:t>x</w:t></w:r></w:p>"#);
+            assert_eq!(events, expected_events(vec![text("x")]));
+        }
     }
 
     mod ppr {
@@ -1056,7 +1278,7 @@ mod events {
 
         assert_eq!(
             format!("{reader:?}"),
-            "DocxReader { inner: DocumentReader { buf: [], in_ignored_subtree: 0, in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_text: \"\", frozen_run_kinds: [], open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, xml: \"<quick_xml::Reader>\" } }"
+            "DocxReader { inner: DocumentReader { buf: [], in_ignored_subtree: 0, in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, xml: \"<quick_xml::Reader>\" } }"
         );
     }
 
@@ -2410,9 +2632,10 @@ mod events {
     }
 
     #[test]
+    // Uses <w:lang> as a known-but-unhandled rPr child to exercise the default-ignore path.
     fn rpr_with_unknown_child_is_no_op() {
         let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:color w:val="FF0000"/><w:b/></w:rPr><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:lang w:val="en-US"/><w:b/></w:rPr><w:t>x</w:t></w:r></w:p></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -38,7 +38,7 @@ writer.finish()?;
 | ---------- | ------------------------------------------------ | ------------------------- |
 | `markdown` | Markdown (CommonMark + GFM tables/strikethrough) | `docspec-markdown-reader` |
 | `html`     | HTML (paragraphs only)                           | `docspec-html-reader`     |
-| `docx`     | DOCX (paragraphs and text only)                  | `docspec-docx-reader`     |
+| `docx`     | DOCX (paragraphs, text, color, highlight, shading) | `docspec-docx-reader`   |
 
 `DocxReader` is dispatched through `AnyReader::from_reader` and `AnyReader::from_path`.
 Use `AnyReader::from_path(InputFormat::Docx, path)` to open a DOCX file, or

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -16,7 +16,7 @@
 //! |----------------|-----------------------------------------------------|-----------------------------|
 //! | `markdown`     | Markdown (`CommonMark` + GFM tables/strikethrough)  | [`readers::MarkdownReader`] |
 //! | `html`         | HTML (paragraphs only)                              | `readers::HtmlReader`       |
-//! | `docx`         | DOCX (paragraphs and text only)                     | `readers::DocxReader`       |
+//! | `docx`         | DOCX (paragraphs, text, color, highlight, shading)  | `readers::DocxReader`       |
 //!
 //! [`readers::DocxReader`] is dispatched through [`AnyReader::from_reader`] and
 //! [`AnyReader::from_path`]. Use `AnyReader::from_path(InputFormat::Docx, path)` to
@@ -118,9 +118,10 @@ pub mod readers {
 
     /// Streaming DOCX reader. Available when the `docx` feature is enabled.
     /// Dispatched through [`crate::AnyReader::from_reader`] and
-    /// [`crate::AnyReader::from_path`]. Emits only paragraphs and text; styles,
-    /// tables, lists, images, headers/footers, metadata, and tracked changes are
-    /// silently dropped.
+    /// [`crate::AnyReader::from_path`]. Emits paragraphs, text, and inline
+    /// formatting including text color, highlight color, and run/text shading
+    /// (via `TextColor` and `Mark` events). Tables, lists, images,
+    /// headers/footers, metadata, and tracked changes are silently dropped.
     #[cfg(feature = "docx")]
     #[cfg_attr(docsrs, doc(cfg(feature = "docx")))]
     pub use docspec_docx_reader::DocxReader;

--- a/crates/docspec/tests/docx_color_to_blocknote.rs
+++ b/crates/docspec/tests/docx_color_to_blocknote.rs
@@ -1,0 +1,114 @@
+//! End-to-end integration test: DOCX → `BlockNote` color pipeline.
+//!
+//! Verifies that the full DOCX → `BlockNote` conversion correctly maps:
+//! - `<w:color>` (text color) → `"textColor"` JSON key
+//! - `<w:highlight>` (highlight) → `"backgroundColor"` JSON key
+//! - `<w:shd>` (shading) → `"backgroundColor"` JSON key
+//! - Black `(0,0,0)` text color → filtered (no `"textColor"` key emitted)
+//! - Yellow highlight `(255,255,0)` → `"backgroundColor":"orange"` (counterintuitive palette snap)
+
+#![cfg(feature = "docx")]
+#![allow(
+    clippy::expect_used,
+    clippy::unwrap_used,
+    clippy::tests_outside_test_module,
+    clippy::unused_trait_names,
+    clippy::indexing_slicing,
+    clippy::doc_markdown,
+    clippy::doc_paragraphs_missing_punctuation
+)]
+
+use std::io::{Cursor, Write as _};
+
+use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+
+use docspec::writers::BlockNoteWriter;
+use docspec::{AnyReader, EventSink as _, EventSource as _, InputFormat, StackTrackingSink};
+
+const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let mut zip_writer = ZipWriter::new(buf);
+    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    zip_writer.start_file("_rels/.rels", opts).unwrap();
+    zip_writer.write_all(rels_xml.as_bytes()).unwrap();
+    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    zip_writer
+        .start_file("word/document.xml", opts_doc)
+        .unwrap();
+    zip_writer.write_all(document_xml.as_bytes()).unwrap();
+    zip_writer.finish().unwrap().into_inner()
+}
+
+/// End-to-end test: DOCX with color, highlight, and shading → BlockNote JSON.
+///
+/// Run 1: `<w:color w:val="D9730D"/>` (RGB 217,115,13) → text palette `"orange"`
+/// Run 2: `<w:highlight w:val="yellow"/>` (RGB 255,255,0) → background palette `"orange"`
+///        (counterintuitive: squared-Euclidean distance to bg-orange=47654 < bg-yellow=48121)
+/// Run 3: `<w:color w:val="000000"/>` (black, filtered) +
+///        `<w:shd w:fill="DDEDEA"/>` (RGB 221,237,234) → background palette `"green"`, no textColor
+#[test]
+fn docx_color_highlight_shading_round_trip_to_blocknote() {
+    let doc_xml = concat!(
+        r#"<?xml version="1.0"?>"#,
+        r#"<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">"#,
+        r#"<w:body><w:p>"#,
+        // Run 1: text color D9730D → textColor "orange"
+        r#"<w:r><w:rPr><w:color w:val="D9730D"/></w:rPr><w:t>orange-text</w:t></w:r>"#,
+        // Run 2: highlight yellow (255,255,0) → backgroundColor "orange" (counterintuitive!)
+        r#"<w:r><w:rPr><w:highlight w:val="yellow"/></w:rPr><w:t>highlighted</w:t></w:r>"#,
+        // Run 3: black text (filtered) + shading DDEDEA (221,237,234) → backgroundColor "green"
+        r#"<w:r><w:rPr><w:color w:val="000000"/><w:shd w:val="clear" w:fill="DDEDEA"/></w:rPr><w:t>green-bg</w:t></w:r>"#,
+        r#"</w:p></w:body></w:document>"#,
+    );
+
+    let bytes = synth_docx(SIMPLE_RELS, doc_xml);
+    let mut reader = AnyReader::from_reader(InputFormat::Docx, Cursor::new(bytes)).unwrap();
+
+    let mut buf = Vec::<u8>::new();
+    let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+
+    while let Some(event) = reader.next_event().unwrap() {
+        writer.handle_event(event).unwrap();
+    }
+    writer.finish().unwrap();
+
+    let actual: serde_json::Value =
+        serde_json::from_slice(&buf).expect("BlockNote output must be valid JSON");
+
+    let content = actual[0]["content"]
+        .as_array()
+        .expect("first block must have a content array");
+
+    // Run 1: D9730D (RGB 217,115,13) → text palette "orange" → textColor key
+    let expected_run1: serde_json::Value = serde_json::from_str(
+        r#"{"type":"text","text":"orange-text","styles":{"textColor":"orange"}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        content[0], expected_run1,
+        "run 1: D9730D text color must snap to palette \"orange\""
+    );
+
+    // Run 2: yellow highlight (255,255,0) → background palette "orange" (counterintuitive!)
+    // Squared-Euclidean distance: bg-orange=47654 < bg-yellow=48121
+    let expected_run2: serde_json::Value = serde_json::from_str(
+        r#"{"type":"text","text":"highlighted","styles":{"backgroundColor":"orange"}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        content[1], expected_run2,
+        "run 2: yellow highlight (255,255,0) must snap to background palette \"orange\", not \"yellow\""
+    );
+
+    // Run 3: black text filtered (no textColor) + shading DDEDEA (221,237,234) → bg palette "green"
+    let expected_run3: serde_json::Value = serde_json::from_str(
+        r#"{"type":"text","text":"green-bg","styles":{"backgroundColor":"green"}}"#,
+    )
+    .unwrap();
+    assert_eq!(
+        content[2], expected_run3,
+        "run 3: DDEDEA shading must snap to background palette \"green\", black text must be filtered (no textColor key)"
+    );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Foreground text color styling plus distinct background (highlight/shading) handling; DOCX reader emits run-level color/highlight/shading while preserving run boundaries
  * Automatic palette snapping maps input colors to BlockNote text/background palettes; pure black is filtered

* **Documentation**
  * READMEs and docs updated to describe supported inline styles, color semantics, palette snapping rules, and precedence

* **Tests**
  * New unit and integration tests for color parsing, palette snapping, and end-to-end DOCX→BlockNote conversion
<!-- end of auto-generated comment: release notes by coderabbit.ai -->