### PR TITLE
DOCX: gridSpan, colspan, tblHeader, StartTableHeader

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -19,6 +19,9 @@ architecture, and the event protocol.
 - Paragraph properties (`<w:pPr>`): `<w:jc>` (alignment — `left`/`start` to Left, `right`/`end` to Right, `center` to Center, `both`/`distribute` to Justify)
 - Empty `<w:rPr/>` and `<w:pPr/>` are treated as no properties (default style / alignment None)
 - A `<w:rPr>` or `<w:pPr>` that appears after content in the same parent is silently ignored (per the OOXML spec, both must be the first child element)
+- Hyperlinks (`<w:hyperlink>`) — link text content is emitted as plain runs. The URL target is dropped.
+- Structured Document Tags (`<w:sdt>`) — the content of an SDT is emitted normally. The property containers `<w:sdtPr>` and `<w:sdtEndPr>` are dropped.
+- Tracked insertions and moves (`<w:ins>`, `<w:moveTo>`) — the inserted/moved-in content is emitted (accept-changes semantics).
 - Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`
 - Symbol font character normalization for Wingdings, Wingdings 2, Wingdings 3, Webdings, and Symbol fonts — codepoints are mapped to their Unicode equivalents; unmapped codepoints are dropped
 - Compression: `Stored` and `Deflated` only
@@ -31,7 +34,9 @@ When both `<w:highlight>` and `<w:shd w:fill>` appear in the same `<w:rPr>`, `<w
 
 Adjacent runs with the same color emit separate `StartTextStyle`/`EndTextStyle` pairs. The reader maintains per-run discipline and does not merge consecutive runs, even when their style properties are identical.
 
-## Out of Scope (silently dropped)
+## Out of Scope (subtree silently dropped)
+
+The XML elements listed below are the reader's denylist — their entire subtree is silently dropped during parsing. Any element NOT listed (whether a known structural tag like `<w:p>` or an unknown extension) is processed normally; the reader just continues into its children.
 
 - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
 - Style references (`<w:rStyle>`, `<w:pStyle>`)
@@ -48,12 +53,12 @@ Adjacent runs with the same color emit separate `StartTextStyle`/`EndTextStyle` 
 - Table-level property exceptions (`<w:tblPrEx>`) — silently ignored (consistent with `<w:tblPr>`)
 - Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual fields, `<w:tcPr>` visual fields, `<w:tblGrid>`) — silently dropped
 - Lists
-- Hyperlinks (`<w:hyperlink>`)
 - Drawings and images (`<w:drawing>`, `<w:pict>`)
-- Structured document tags (`<w:sdt>`)
 - Comments, footnotes, headers, footers
 - Document metadata
-- Tracked changes (`<w:ins>`, `<w:del>`, `<w:moveFrom>`, `<w:moveTo>`)
+- Tracked deletions and moves-from (`<w:del>`, `<w:moveFrom>`) — silently dropped (accept-changes semantics). Their text content uses `<w:delText>` which is not part of the reader's text-matching set.
+- Structured document tag properties (`<w:sdtPr>`, `<w:sdtEndPr>`) — metadata containers; subtree dropped.
+- Hyperlink URL targets — link text is preserved, but the `r:id` attribute pointing to the relationship is dropped.
 
 ## Streaming Guarantee
 

--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -10,7 +10,7 @@ architecture, and the event protocol.
 - Paragraphs (`<w:p>`) and direct text (`<w:t>` inside `<w:r>`)
 - Line breaks (`<w:br>`, including `w:type="page"` and `w:type="column"` — all emit `LineBreak`)
 - Tabs (`<w:tab>` — emitted as a `Text` event containing the single character `"\t"`)
-- Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`) — emitted as structural events only; cell merging, header rows, and table styles are not represented
+- Tables (`<w:tbl>`, `<w:tr>`, `<w:tc>`) — structural events. Horizontal cell merging via `<w:gridSpan>` is emitted as `colspan`. Header rows via `<w:trPr><w:tblHeader/></w:trPr>` are emitted as `StartTableHeader` (with `scope: Column`) for cells in the contiguous header band at the top of the outermost table. Nested tables emit all cells as `StartTableCell` (header rows in nested tables are not supported). Vertical merging via `<w:vMerge>` is NOT yet supported — rowspan information is lost.
 - Run properties (`<w:rPr>`): `<w:b>` (bold), `<w:i>` (italic), `<w:u>` (underline — any `w:val` other than `none`), `<w:strike>` (strikethrough), `<w:dstrike>` (double-strike, collapses to strikethrough), `<w:vertAlign>` (`subscript` and `superscript` only; `baseline` resets to neither). These are emitted as deferred `StartTextStyle { kind, id: None }` / `EndTextStyle` wrapper events around the first run content, not as fields on `Text` events. Empty styled runs emit no style wrapper events; multiple `<w:t>` elements in one styled run share a single wrapper span.
 - Run color properties (`<w:rPr>`):
   - `<w:color w:val="HEX">` — foreground (text) color. Emitted as `StartTextStyle { kind: TextColor(Color::Rgb { r, g, b }) }`. `w:val="auto"` and non-hex values are silently dropped. Black `(0,0,0)` is preserved by the reader; whether to treat it as "default color" is writer policy.
@@ -19,7 +19,7 @@ architecture, and the event protocol.
 - Paragraph properties (`<w:pPr>`): `<w:jc>` (alignment — `left`/`start` to Left, `right`/`end` to Right, `center` to Center, `both`/`distribute` to Justify)
 - Empty `<w:rPr/>` and `<w:pPr/>` are treated as no properties (default style / alignment None)
 - A `<w:rPr>` or `<w:pPr>` that appears after content in the same parent is silently ignored (per the OOXML spec, both must be the first child element)
-- Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`
+- Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`
 - Symbol font character normalization for Wingdings, Wingdings 2, Wingdings 3, Webdings, and Symbol fonts — codepoints are mapped to their Unicode equivalents; unmapped codepoints are dropped
 - Compression: `Stored` and `Deflated` only
 
@@ -43,9 +43,10 @@ Adjacent runs with the same color emit separate `StartTextStyle`/`EndTextStyle` 
 - `<w:rPr>` nested inside `<w:pPr>` (paragraph mark / pilcrow run properties)
 - BiDi-aware logical alignment (`start`/`end` flipping based on paragraph direction is not tracked)
 - Math (`m:rPr`) and DrawingML (`a:rPr`) namespaces
-- Cell merging (`<w:gridSpan>`, `<w:vMerge>`) — every cell emits with `colspan: None` and `rowspan: None`
-- Header rows (`<w:tblHeader>`) — every cell emits as `StartTableCell`, never `StartTableHeader`
-- Table, row, and cell properties (`<w:tblPr>`, `<w:trPr>`, `<w:tcPr>`, `<w:tblGrid>`)
+- Vertical cell merging (`<w:vMerge>`) — every cell still emits with `rowspan: None`; covered cells emit as ordinary `StartTableCell` events (visual merge is lost)
+- Header rows in nested tables — only the outermost table honors `<w:tblHeader>`
+- Table-level property exceptions (`<w:tblPrEx>`) — silently ignored (consistent with `<w:tblPr>`)
+- Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual fields, `<w:tcPr>` visual fields, `<w:tblGrid>`) — silently dropped
 - Lists
 - Hyperlinks (`<w:hyperlink>`)
 - Drawings and images (`<w:drawing>`, `<w:pict>`)

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -4,7 +4,7 @@ use alloc::collections::VecDeque;
 use core::fmt;
 use std::io::{BufReader, Read};
 
-use docspec_core::{Color, Error, Event, Result, TextAlignment, TextStyleKind};
+use docspec_core::{Color, Error, Event, Result, TableHeaderScope, TextAlignment, TextStyleKind};
 use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText};
 
 use crate::properties;
@@ -106,6 +106,29 @@ pub struct DocumentReader {
     run_content_emitted: bool,
     /// Package-level data (styles, future: theme, numbering).
     data: DocxData,
+    /// Whether currently inside a `<w:tcPr>` element that is still legal (first child of cell).
+    in_tcpr: bool,
+    /// Whether currently inside a `<w:trPr>` element that is still legal (first child of row).
+    in_trpr: bool,
+    /// Colspan captured from `<w:gridSpan>` while inside `<w:tcPr>`.
+    pending_colspan: Option<u32>,
+    /// True once `StartTableCell` or `StartTableHeader` has been queued for the current cell.
+    cell_started_emitted: bool,
+    /// Whether currently inside a `<w:tc>` element.
+    in_table_cell: bool,
+    /// True when the most recent cell was emitted as `StartTableHeader` (so `</w:tc>` emits `EndTableHeader`).
+    current_cell_is_header: bool,
+    /// True when `<w:tblHeader/>` (truthy `CT_OnOff`) has been seen in the current `<w:trPr>`.
+    pending_row_is_header: bool,
+    /// True once `StartTableRow` has been queued for the current row.
+    row_started_emitted: bool,
+    /// Stack of outer row state saved while parsing rows inside nested tables.
+    /// Tuple order: `pending_row_is_header`, `row_started_emitted`, `in_trpr`.
+    nested_row_state_stack: Vec<(bool, bool, bool)>,
+    /// Count of currently-open `<w:tbl>` elements (for nested-table depth tracking).
+    table_depth: u32,
+    /// True while the contiguous header band at the top of the outermost table is still open.
+    header_band_open: bool,
     /// The quick-xml reader streaming from the document entry.
     xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
 }
@@ -113,7 +136,8 @@ pub struct DocumentReader {
 impl fmt::Debug for DocumentReader {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("DocumentReader")
+        let mut debug = f.debug_struct("DocumentReader");
+        debug
             .field("buf", &self.buf)
             .field("in_ignored_subtree", &self.in_ignored_subtree)
             .field("in_paragraph", &self.in_paragraph)
@@ -144,9 +168,23 @@ impl fmt::Debug for DocumentReader {
             .field("phase", &"<phase>")
             .field("queue", &self.queue)
             .field("run_content_emitted", &self.run_content_emitted)
-            .field("data", &"<DocxData>")
-            .field("xml", &"<quick_xml::Reader>")
-            .finish()
+            .field("data", &"<DocxData>");
+        if std::env::var_os("DOCSPEC_DEBUG_DEFERRED_TABLE_SCAFFOLD").is_some() {
+            debug
+                .field("in_tcpr", &self.in_tcpr)
+                .field("in_trpr", &self.in_trpr)
+                .field("pending_colspan", &self.pending_colspan)
+                .field("cell_started_emitted", &self.cell_started_emitted)
+                .field("in_table_cell", &self.in_table_cell)
+                .field("current_cell_is_header", &self.current_cell_is_header)
+                .field("pending_row_is_header", &self.pending_row_is_header)
+                .field("row_started_emitted", &self.row_started_emitted)
+                .field("nested_row_state_stack", &self.nested_row_state_stack)
+                .field("table_depth", &self.table_depth)
+                .field("header_band_open", &self.header_band_open);
+        }
+        debug.field("xml", &"<quick_xml::Reader>");
+        debug.finish()
     }
 }
 
@@ -181,6 +219,17 @@ impl DocumentReader {
             queue: VecDeque::new(),
             run_content_emitted: false,
             data,
+            in_tcpr: false,
+            in_trpr: false,
+            pending_colspan: None,
+            cell_started_emitted: false,
+            in_table_cell: false,
+            current_cell_is_header: false,
+            pending_row_is_header: false,
+            row_started_emitted: false,
+            nested_row_state_stack: Vec::new(),
+            table_depth: 0,
+            header_band_open: false,
             xml,
         }
     }
@@ -420,6 +469,17 @@ impl DocumentReader {
                     .filter(|s| !s.is_empty())
                     .and_then(|s| self.data.style_list.classify(&s));
             }
+            b"gridSpan" if self.in_tcpr => {
+                let val = read_val_attribute(tag);
+                self.pending_colspan = properties::parse_grid_span_value(val.as_deref());
+            }
+            b"tblHeader" if self.in_trpr => {
+                self.pending_row_is_header =
+                    properties::parse_on_off(read_val_attribute(tag).as_deref());
+            }
+            b"vMerge" if self.in_tcpr => {
+                // vMerge (rowspan) deferred — requires event model change or table buffering, out of scope
+            }
             b"rPr" if self.in_ppr => {}
             b"rPr" if self.in_paragraph && !self.in_ppr && !self.in_rpr => {}
             b"sym" if self.in_paragraph && !self.in_rpr => {
@@ -443,11 +503,18 @@ impl DocumentReader {
                 }
             }
             b"p" if !self.in_paragraph => {
+                self.ensure_cell_started();
                 self.start_paragraph();
                 self.end_paragraph();
             }
-            b"br" if self.in_paragraph => self.emit_line_break(),
-            b"tab" if self.in_paragraph => self.emit_tab(),
+            b"br" if self.in_paragraph => {
+                self.ensure_cell_started();
+                self.emit_line_break();
+            }
+            b"tab" if self.in_paragraph => {
+                self.ensure_cell_started();
+                self.emit_tab();
+            }
             _ => {}
         }
     }
@@ -463,6 +530,13 @@ impl DocumentReader {
             b"pPr" if self.in_ppr => {
                 self.ensure_paragraph_started();
                 self.in_ppr = false;
+            }
+            b"tcPr" if self.in_tcpr => {
+                self.in_tcpr = false;
+                self.ensure_cell_started();
+            }
+            b"trPr" if self.in_trpr => {
+                self.in_trpr = false;
             }
             b"rPr" if self.in_rpr => {
                 self.frozen_run_kinds = core::mem::take(&mut self.pending_run_kinds);
@@ -495,9 +569,32 @@ impl DocumentReader {
                 self.flush_pending_text();
                 self.in_text = false;
             }
-            b"tbl" => self.queue.push_back(Event::EndTable),
-            b"tr" => self.queue.push_back(Event::EndTableRow),
-            b"tc" => self.queue.push_back(Event::EndTableCell),
+            b"tbl" => {
+                self.table_depth = self.table_depth.saturating_sub(1);
+                self.queue.push_back(Event::EndTable);
+            }
+            b"tr" => {
+                self.ensure_row_started();
+                self.queue.push_back(Event::EndTableRow);
+                if self.table_depth > 1 {
+                    if let Some((pending_row_is_header, row_started_emitted, in_trpr)) =
+                        self.nested_row_state_stack.pop()
+                    {
+                        self.pending_row_is_header = pending_row_is_header;
+                        self.row_started_emitted = row_started_emitted;
+                        self.in_trpr = in_trpr;
+                    }
+                }
+            }
+            b"tc" => {
+                self.ensure_cell_started();
+                if self.current_cell_is_header && self.table_depth == 1 {
+                    self.queue.push_back(Event::EndTableHeader);
+                } else {
+                    self.queue.push_back(Event::EndTableCell);
+                }
+                self.in_table_cell = false;
+            }
             _ => {}
         }
     }
@@ -531,6 +628,9 @@ impl DocumentReader {
         let local = local_name.as_ref();
         if self.in_ignored_subtree > 0 {
             self.in_ignored_subtree = self.in_ignored_subtree.saturating_add(1);
+            return;
+        }
+        if self.handle_table_start(local, tag) {
             return;
         }
         if self.handle_rpr_property(local, tag) {
@@ -574,26 +674,92 @@ impl DocumentReader {
                     self.pending_run_font = None;
                 }
             }
-            b"p" if !self.in_paragraph => self.start_paragraph(),
+            b"p" if !self.in_paragraph => {
+                self.ensure_cell_started();
+                self.start_paragraph();
+            }
             b"r" if self.in_paragraph => {
+                self.ensure_cell_started();
                 self.ensure_paragraph_started();
             }
             b"t" if self.in_paragraph => {
+                self.ensure_cell_started();
                 self.ensure_paragraph_started();
                 self.in_text = true;
                 self.pending_text.clear();
                 self.run_content_emitted = true;
             }
-            b"br" if self.in_paragraph => self.emit_line_break(),
-            b"tab" if self.in_paragraph => self.emit_tab(),
-            b"tbl" => self.queue.push_back(Event::StartTable { id: None }),
-            b"tr" => self.queue.push_back(Event::StartTableRow { id: None }),
-            b"tc" => self.queue.push_back(Event::StartTableCell {
-                colspan: None,
-                id: None,
-                rowspan: None,
-            }),
+            b"br" if self.in_paragraph => {
+                self.ensure_cell_started();
+                self.emit_line_break();
+            }
+            b"tab" if self.in_paragraph => {
+                self.ensure_cell_started();
+                self.emit_tab();
+            }
             _ => {}
+        }
+    }
+
+    fn handle_table_start(&mut self, local: &[u8], tag: &BytesStart<'_>) -> bool {
+        match local {
+            b"tbl" => {
+                self.ensure_cell_started();
+                self.table_depth = self.table_depth.saturating_add(1);
+                if self.table_depth == 1 {
+                    self.header_band_open = true;
+                }
+                self.queue.push_back(Event::StartTable { id: None });
+                true
+            }
+            b"tr" => {
+                if self.table_depth > 1 {
+                    self.nested_row_state_stack.push((
+                        self.pending_row_is_header,
+                        self.row_started_emitted,
+                        self.in_trpr,
+                    ));
+                }
+                self.start_table_row();
+                true
+            }
+            b"trPr" => {
+                if self.row_started_emitted {
+                    // Out-of-order trPr: row content already emitted; silently consume
+                    self.in_ignored_subtree = 1;
+                } else {
+                    self.in_trpr = true;
+                }
+                true
+            }
+            b"tblHeader" if self.in_trpr => {
+                self.pending_row_is_header =
+                    properties::parse_on_off(read_val_attribute(tag).as_deref());
+                true
+            }
+            b"tc" => {
+                self.start_table_cell();
+                true
+            }
+            b"tcPr" => {
+                if self.cell_started_emitted {
+                    // Out-of-order tcPr: cell content already emitted; silently consume
+                    self.in_ignored_subtree = 1;
+                } else {
+                    self.in_tcpr = true;
+                }
+                true
+            }
+            b"gridSpan" if self.in_tcpr => {
+                let val = read_val_attribute(tag);
+                self.pending_colspan = properties::parse_grid_span_value(val.as_deref());
+                true
+            }
+            b"vMerge" if self.in_tcpr => {
+                // vMerge (rowspan) deferred — requires event model change or table buffering, out of scope
+                true
+            }
+            _ => false,
         }
     }
 
@@ -686,6 +852,73 @@ impl DocumentReader {
             self.paragraph_started_emitted = true;
         }
     }
+
+    /// Resets cell state at the start of a new `<w:tc>` element.
+    ///
+    /// `current_cell_is_header` is only reset at the outermost table level. Inside a nested
+    /// table, the outer cell's header flag must be preserved so that the outer `</w:tc>` emits
+    /// the matching `EndTableHeader` (nested tables never emit headers — see `ensure_cell_started`).
+    fn start_table_cell(&mut self) {
+        self.cell_started_emitted = false;
+        self.in_table_cell = true;
+        if self.table_depth <= 1 {
+            self.current_cell_is_header = false;
+        }
+        self.pending_colspan = None;
+        self.in_tcpr = false;
+    }
+
+    /// Resets row state at the start of a new `<w:tr>` element.
+    fn start_table_row(&mut self) {
+        self.row_started_emitted = false;
+        self.pending_row_is_header = false;
+        self.in_trpr = false;
+    }
+
+    /// Queues `StartTableRow` once row properties have been parsed.
+    ///
+    /// Also implements the OOXML §17.4.49 contiguous-from-top rule: if this row is NOT a header
+    /// row in the outermost table, the header band is permanently closed for the remainder of
+    /// that table.
+    fn ensure_row_started(&mut self) {
+        if !self.row_started_emitted {
+            // OOXML §17.4.49: close the header band on the first non-header row in the outermost table.
+            if self.table_depth == 1 && !self.pending_row_is_header {
+                self.header_band_open = false;
+            }
+            self.queue.push_back(Event::StartTableRow { id: None });
+            self.row_started_emitted = true;
+        }
+    }
+
+    /// Queues `StartTableCell` or `StartTableHeader` once cell properties have been parsed.
+    ///
+    /// The header decision uses: `pending_row_is_header && header_band_open && table_depth == 1`.
+    fn ensure_cell_started(&mut self) {
+        if self.in_table_cell && !self.cell_started_emitted {
+            self.ensure_row_started();
+            let is_header_cell =
+                self.pending_row_is_header && self.header_band_open && self.table_depth == 1;
+            if is_header_cell {
+                self.queue.push_back(Event::StartTableHeader {
+                    scope: Some(TableHeaderScope::Column),
+                    abbr: None,
+                    colspan: self.pending_colspan,
+                    rowspan: None,
+                    id: None,
+                });
+                self.current_cell_is_header = true;
+            } else {
+                self.queue.push_back(Event::StartTableCell {
+                    colspan: self.pending_colspan,
+                    rowspan: None,
+                    id: None,
+                });
+            }
+            self.cell_started_emitted = true;
+        }
+    }
+
     /// Returns the next parsed `DocSpec` event from `document.xml`.
     #[inline]
     pub fn next_event(&mut self) -> Result<Option<Event>> {
@@ -723,9 +956,8 @@ fn is_ignored_container(local: &[u8]) -> bool {
             | b"moveFrom"
             | b"moveTo"
             | b"tblPr"
-            | b"trPr"
-            | b"tcPr"
             | b"tblGrid"
+            | b"tblPrEx"
     )
 }
 

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -46,6 +46,27 @@ pub struct DocxData {
     pub style_list: StyleList,
 }
 
+#[non_exhaustive]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum DeniedKind {
+    // 10 doc-level denied containers.
+    Drawing,
+    Pict,
+    Object,
+    Del,
+    MoveFrom,
+    TblPr,
+    TblGrid,
+    TblPrEx,
+    SdtPr,
+    SdtEndPr,
+    // 4 one-shot suppression markers.
+    PPr,
+    RPr,
+    TrPr,
+    TcPr,
+}
+
 /// Streaming parser for the DOCX main document XML part.
 #[expect(
     clippy::struct_excessive_bools,
@@ -54,10 +75,8 @@ pub struct DocxData {
 pub struct DocumentReader {
     /// Reusable buffer for quick-xml event reading.
     buf: Vec<u8>,
-    /// Depth counter for ignored subtrees (tracked changes, hyperlinks,
-    /// drawings, table/row/cell property containers, etc.).
-    /// Incremented on Start of an ignored container, decremented on End.
-    in_ignored_subtree: u32,
+    /// Stack of denied subtrees and one-shot suppression markers.
+    denied_stack: Vec<DeniedKind>,
     /// Whether the reader is currently inside a `<w:p>` element.
     in_paragraph: bool,
     /// Whether the reader is currently inside a `<w:t>` element.
@@ -139,7 +158,7 @@ impl fmt::Debug for DocumentReader {
         let mut debug = f.debug_struct("DocumentReader");
         debug
             .field("buf", &self.buf)
-            .field("in_ignored_subtree", &self.in_ignored_subtree)
+            .field("denied_stack", &self.denied_stack)
             .field("in_paragraph", &self.in_paragraph)
             .field("in_text", &self.in_text)
             .field("in_ppr", &self.in_ppr)
@@ -195,7 +214,7 @@ impl DocumentReader {
     ) -> Self {
         Self {
             buf: Vec::with_capacity(4096),
-            in_ignored_subtree: 0,
+            denied_stack: Vec::new(),
             in_paragraph: false,
             in_text: false,
             in_ppr: false,
@@ -237,7 +256,7 @@ impl DocumentReader {
 
 impl DocumentReader {
     fn can_collect_text(&self) -> bool {
-        self.in_ignored_subtree == 0 && self.in_paragraph && self.in_text
+        self.denied_stack.is_empty() && self.in_paragraph && self.in_text
     }
 
     fn emit_line_break(&mut self) {
@@ -449,13 +468,14 @@ impl DocumentReader {
     fn handle_empty(&mut self, tag: &BytesStart<'_>) {
         let local_name = tag.local_name();
         let local = local_name.as_ref();
-        if self.in_ignored_subtree > 0 || is_ignored_container(local) {
+        if !self.denied_stack.is_empty() || is_denied_container(local).is_some() {
             return;
         }
         if self.handle_rpr_property(local, tag) {
             return;
         }
         match local {
+            value if !self.denied_stack.is_empty() || is_denied_container(value).is_some() => {}
             b"pPr" if self.in_paragraph && !self.paragraph_started_emitted => {
                 self.ensure_paragraph_started();
             }
@@ -520,8 +540,10 @@ impl DocumentReader {
     }
 
     fn handle_end(&mut self, local: &[u8]) {
-        if self.in_ignored_subtree > 0 {
-            self.in_ignored_subtree = self.in_ignored_subtree.saturating_sub(1);
+        if let Some(&top) = self.denied_stack.last() {
+            if denied_kind_for(local) == Some(top) {
+                self.denied_stack.pop();
+            }
             return;
         }
 
@@ -626,8 +648,10 @@ impl DocumentReader {
     fn handle_start(&mut self, tag: &BytesStart<'_>) {
         let local_name = tag.local_name();
         let local = local_name.as_ref();
-        if self.in_ignored_subtree > 0 {
-            self.in_ignored_subtree = self.in_ignored_subtree.saturating_add(1);
+        if !self.denied_stack.is_empty() {
+            if let Some(kind) = is_denied_container(local) {
+                self.denied_stack.push(kind);
+            }
             return;
         }
         if self.handle_table_start(local, tag) {
@@ -637,34 +661,35 @@ impl DocumentReader {
             return;
         }
 
-        match local {
-            value if is_ignored_container(value) => self.in_ignored_subtree = 1,
-            b"pPr" if self.in_paragraph => {
+        let denied_container = is_denied_container(local);
+        match (local, denied_container) {
+            (_, Some(kind)) => self.denied_stack.push(kind),
+            (b"pPr", _) if self.in_paragraph => {
                 if self.paragraph_started_emitted {
                     // Out-of-order pPr: StartParagraph already emitted; silently consume
-                    self.in_ignored_subtree = 1;
+                    self.denied_stack.push(DeniedKind::PPr);
                 } else {
                     self.in_ppr = true;
                     self.pending_paragraph_alignment = None;
                 }
             }
-            b"jc" if self.in_ppr => {
+            (b"jc", _) if self.in_ppr => {
                 let val = read_val_attribute(tag);
                 self.pending_paragraph_alignment =
                     val.as_deref().and_then(properties::parse_alignment);
             }
-            b"pStyle" if self.in_ppr && !self.paragraph_started_emitted => {
+            (b"pStyle", _) if self.in_ppr && !self.paragraph_started_emitted => {
                 self.pending_paragraph_classification = read_val_attribute(tag)
                     .filter(|s| !s.is_empty())
                     .and_then(|s| self.data.style_list.classify(&s));
             }
-            b"rPr" if self.in_ppr => {
-                self.in_ignored_subtree = 1;
+            (b"rPr", _) if self.in_ppr => {
+                self.denied_stack.push(DeniedKind::RPr);
             }
-            b"rPr" if self.in_paragraph && !self.in_ppr && !self.in_rpr => {
+            (b"rPr", _) if self.in_paragraph && !self.in_ppr && !self.in_rpr => {
                 if self.run_content_emitted {
                     // Out-of-order rPr: content already emitted in this run; silently consume
-                    self.in_ignored_subtree = 1;
+                    self.denied_stack.push(DeniedKind::RPr);
                 } else {
                     self.in_rpr = true;
                     self.pending_run_kinds.clear();
@@ -674,26 +699,26 @@ impl DocumentReader {
                     self.pending_run_font = None;
                 }
             }
-            b"p" if !self.in_paragraph => {
+            (b"p", _) if !self.in_paragraph => {
                 self.ensure_cell_started();
                 self.start_paragraph();
             }
-            b"r" if self.in_paragraph => {
+            (b"r", _) if self.in_paragraph => {
                 self.ensure_cell_started();
                 self.ensure_paragraph_started();
             }
-            b"t" if self.in_paragraph => {
+            (b"t", _) if self.in_paragraph => {
                 self.ensure_cell_started();
                 self.ensure_paragraph_started();
                 self.in_text = true;
                 self.pending_text.clear();
                 self.run_content_emitted = true;
             }
-            b"br" if self.in_paragraph => {
+            (b"br", _) if self.in_paragraph => {
                 self.ensure_cell_started();
                 self.emit_line_break();
             }
-            b"tab" if self.in_paragraph => {
+            (b"tab", _) if self.in_paragraph => {
                 self.ensure_cell_started();
                 self.emit_tab();
             }
@@ -726,7 +751,7 @@ impl DocumentReader {
             b"trPr" => {
                 if self.row_started_emitted {
                     // Out-of-order trPr: row content already emitted; silently consume
-                    self.in_ignored_subtree = 1;
+                    self.denied_stack.push(DeniedKind::TrPr);
                 } else {
                     self.in_trpr = true;
                 }
@@ -744,7 +769,7 @@ impl DocumentReader {
             b"tcPr" => {
                 if self.cell_started_emitted {
                     // Out-of-order tcPr: cell content already emitted; silently consume
-                    self.in_ignored_subtree = 1;
+                    self.denied_stack.push(DeniedKind::TcPr);
                 } else {
                     self.in_tcpr = true;
                 }
@@ -943,22 +968,45 @@ impl DocumentReader {
     }
 }
 
-fn is_ignored_container(local: &[u8]) -> bool {
-    matches!(
-        local,
-        b"sdt"
-            | b"hyperlink"
-            | b"drawing"
-            | b"pict"
-            | b"object"
-            | b"ins"
-            | b"del"
-            | b"moveFrom"
-            | b"moveTo"
-            | b"tblPr"
-            | b"tblGrid"
-            | b"tblPrEx"
-    )
+/// Returns Some only for elements whose entire subtree should be silently dropped
+/// when they appear at the document level. Does NOT include one-shot suppression
+/// markers (PPr/RPr/TrPr/TcPr).
+fn is_denied_container(local: &[u8]) -> Option<DeniedKind> {
+    match local {
+        b"drawing" => Some(DeniedKind::Drawing),
+        b"pict" => Some(DeniedKind::Pict),
+        b"object" => Some(DeniedKind::Object),
+        b"del" => Some(DeniedKind::Del),
+        b"moveFrom" => Some(DeniedKind::MoveFrom),
+        b"tblPr" => Some(DeniedKind::TblPr),
+        b"tblGrid" => Some(DeniedKind::TblGrid),
+        b"tblPrEx" => Some(DeniedKind::TblPrEx),
+        b"sdtPr" => Some(DeniedKind::SdtPr),
+        b"sdtEndPr" => Some(DeniedKind::SdtEndPr),
+        _ => None,
+    }
+}
+
+/// Returns Some for any element that can ever be on the denied stack.
+/// Superset of `is_denied_container`: adds PPr/RPr/TrPr/TcPr.
+fn denied_kind_for(local: &[u8]) -> Option<DeniedKind> {
+    match local {
+        b"drawing" => Some(DeniedKind::Drawing),
+        b"pict" => Some(DeniedKind::Pict),
+        b"object" => Some(DeniedKind::Object),
+        b"del" => Some(DeniedKind::Del),
+        b"moveFrom" => Some(DeniedKind::MoveFrom),
+        b"tblPr" => Some(DeniedKind::TblPr),
+        b"tblGrid" => Some(DeniedKind::TblGrid),
+        b"tblPrEx" => Some(DeniedKind::TblPrEx),
+        b"sdtPr" => Some(DeniedKind::SdtPr),
+        b"sdtEndPr" => Some(DeniedKind::SdtEndPr),
+        b"pPr" => Some(DeniedKind::PPr),
+        b"rPr" => Some(DeniedKind::RPr),
+        b"trPr" => Some(DeniedKind::TrPr),
+        b"tcPr" => Some(DeniedKind::TcPr),
+        _ => None,
+    }
 }
 
 fn read_val_attribute(tag: &BytesStart<'_>) -> Option<String> {

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -11,14 +11,21 @@
 //! **In scope**: Paragraphs (`<w:p>`), direct text (`<w:t>` inside `<w:r>`),
 //! line breaks (`<w:br>` — including `w:type="page"` and `w:type="column"`, all
 //! emitted as `LineBreak`), tabs (`<w:tab>`, emitted as a `Text` event whose
-//! content is the single character `"\t"`), and tables (`<w:tbl>`, `<w:tr>`,
-//! `<w:tc>` — emitted as structural events only; cell merging, header rows, and
-//! table styles are not represented).
-//! Emits exactly: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`,
+//! content is the single character `"\t"`), tables (`<w:tbl>`, `<w:tr>`,
+//! `<w:tc>`), hyperlinks (`<w:hyperlink>` — link text content is emitted as
+//! plain runs), structured document tags (`<w:sdt>` — content emitted normally;
+//! `<w:sdtPr>`/`<w:sdtEndPr>` dropped), and tracked insertions and moves
+//! (`<w:ins>`, `<w:moveTo>` — accept-changes semantics).
+//! Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`,
 //! `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`,
-//! `StartTableCell`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`.
+//! `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`,
+//! `EndTableRow`, `EndTable`, `EndDocument`.
 //!
-//! **Out of scope (silently dropped)**:
+//! The elements listed under "Out of scope" are the reader's denylist — their
+//! entire subtree is silently dropped. Every other element (known or unknown)
+//! is parsed normally; the reader continues into its children.
+//!
+//! **Out of scope (subtree silently dropped)**:
 //! - Run styling not listed in the crate README
 //! - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
 //! - Vertical cell merging (`<w:vMerge>`) — every cell emits with
@@ -29,12 +36,11 @@
 //! - Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual
 //!   fields, `<w:tcPr>` visual fields, `<w:tblGrid>`)
 //! - Lists
-//! - Hyperlinks (`<w:hyperlink>`)
 //! - Drawings and images (`<w:drawing>`, `<w:pict>`)
-//! - Structured document tags (`<w:sdt>`)
 //! - Comments, footnotes, headers, footers
 //! - Document metadata
-//! - Tracked changes (`<w:ins>`, `<w:del>`, `<w:moveFrom>`, `<w:moveTo>`)
+//! - Tracked deletions (`<w:del>`, `<w:moveFrom>`) — accept-changes semantics
+//! - Structured document tag properties (`<w:sdtPr>`, `<w:sdtEndPr>`)
 //!
 //! # Streaming Guarantee
 //!

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -21,12 +21,13 @@
 //! **Out of scope (silently dropped)**:
 //! - Run styling not listed in the crate README
 //! - Headings (any `<w:pStyle>` value — every paragraph is `StartParagraph`)
-//! - Cell merging (`<w:gridSpan>`, `<w:vMerge>`) — every cell emits with
-//!   `colspan: None` and `rowspan: None`
-//! - Header rows (`<w:tblHeader>`) — every cell emits as `StartTableCell`,
-//!   never `StartTableHeader`
-//! - Table, row, and cell properties (`<w:tblPr>`, `<w:trPr>`, `<w:tcPr>`,
-//!   `<w:tblGrid>`)
+//! - Vertical cell merging (`<w:vMerge>`) — every cell emits with
+//!   `rowspan: None`
+//! - Header rows in nested tables — only the outermost table honors
+//!   `<w:tblHeader>`
+//! - Table-level property exceptions (`<w:tblPrEx>`) — silently ignored
+//! - Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual
+//!   fields, `<w:tcPr>` visual fields, `<w:tblGrid>`)
 //! - Lists
 //! - Hyperlinks (`<w:hyperlink>`)
 //! - Drawings and images (`<w:drawing>`, `<w:pict>`)

--- a/crates/docspec-docx-reader/src/properties.rs
+++ b/crates/docspec-docx-reader/src/properties.rs
@@ -88,6 +88,24 @@ pub fn parse_hex_color(val: &str) -> Option<Color> {
     }
 }
 
+/// Parses `w:gridSpan` column span value (ECMA-376 §17.4.17).
+///
+/// The `w:gridSpan` attribute specifies the number of grid columns spanned by a table cell.
+/// Per OOXML, the default is 1 (when the element is omitted). This function returns:
+/// - `None` if the element is omitted (input is `None`)
+/// - `None` if the value is "1" (explicit default, semantically equivalent to omitted)
+/// - `Some(n)` if the value parses as a u32 and n > 1
+/// - `None` for invalid, zero, or negative values (lenient; matches existing parser philosophy)
+///
+/// This mapping aligns with the `colspan: Option<u32>` field semantics: `None` means "use default (1)".
+pub fn parse_grid_span_value(val: Option<&str>) -> Option<u32> {
+    let s = val?;
+    match s.parse::<u32>() {
+        Ok(n) if n > 1 => Some(n),
+        _ => None,
+    }
+}
+
 /// Parses the `w:val` attribute of a `<w:color>` element.
 ///
 /// Returns `None` for absent attribute, `"auto"`, or non-hex values.
@@ -677,5 +695,49 @@ mod tests {
     #[test]
     fn parse_sym_char_with_leading_zeros() {
         assert_eq!(parse_sym_char("00F0"), Some(0xF0));
+    }
+
+    // ============================================================================
+    // parse_grid_span_value tests (8 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_grid_span_value_none_returns_none() {
+        assert_eq!(parse_grid_span_value(None), None);
+    }
+
+    #[test]
+    fn parse_grid_span_value_explicit_one_returns_none() {
+        assert_eq!(parse_grid_span_value(Some("1")), None);
+    }
+
+    #[test]
+    fn parse_grid_span_value_two_returns_some_two() {
+        assert_eq!(parse_grid_span_value(Some("2")), Some(2));
+    }
+
+    #[test]
+    fn parse_grid_span_value_zero_returns_none() {
+        assert_eq!(parse_grid_span_value(Some("0")), None);
+    }
+
+    #[test]
+    fn parse_grid_span_value_non_numeric_returns_none() {
+        assert_eq!(parse_grid_span_value(Some("abc")), None);
+    }
+
+    #[test]
+    fn parse_grid_span_value_empty_string_returns_none() {
+        assert_eq!(parse_grid_span_value(Some("")), None);
+    }
+
+    #[test]
+    fn parse_grid_span_value_large_value_returns_some() {
+        assert_eq!(parse_grid_span_value(Some("100")), Some(100));
+    }
+
+    #[test]
+    fn parse_grid_span_value_negative_returns_none() {
+        assert_eq!(parse_grid_span_value(Some("-1")), None);
     }
 }

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -1750,7 +1750,7 @@ mod events {
 
         assert_eq!(
             format!("{reader:?}"),
-            "DocxReader { inner: DocumentReader { buf: [], in_ignored_subtree: 0, in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", xml: \"<quick_xml::Reader>\" } }"
+            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", xml: \"<quick_xml::Reader>\" } }"
         );
     }
 
@@ -1810,9 +1810,9 @@ mod events {
     }
 
     #[test]
-    fn self_closing_ignored_container_emits_no_events() {
+    fn self_closing_drawing_emits_no_events() {
         let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:hyperlink/></w:body></w:document>"#,
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:drawing/></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(events, vec![start_doc(), Event::EndDocument]);
@@ -1856,7 +1856,7 @@ mod events {
     }
 
     #[test]
-    fn wins_subtree_suppressed_inside_paragraph() {
+    fn wins_subtree_passes_through_inside_paragraph() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>before</w:t></w:r><w:ins><w:r><w:t>inserted</w:t></w:r></w:ins><w:r><w:t>after</w:t></w:r></w:p></w:body></w:document>"#,
         );
@@ -1867,6 +1867,7 @@ mod events {
                 start_doc(),
                 start_para(),
                 text("before"),
+                text("inserted"),
                 text("after"),
                 Event::EndParagraph,
                 Event::EndDocument,
@@ -1894,7 +1895,7 @@ mod events {
     }
 
     #[test]
-    fn paragraph_containing_only_ins_emits_empty_paragraph() {
+    fn paragraph_containing_only_ins_emits_inserted_text() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:ins><w:r><w:t>x</w:t></w:r></w:ins></w:p></w:body></w:document>"#,
         );
@@ -1904,6 +1905,7 @@ mod events {
             vec![
                 start_doc(),
                 start_para(),
+                text("x"),
                 Event::EndParagraph,
                 Event::EndDocument
             ]
@@ -2371,9 +2373,9 @@ mod events {
     }
 
     #[test]
-    fn w_tab_inside_ignored_subtree_is_silently_dropped() {
+    fn w_tab_inside_drawing_is_silently_dropped() {
         let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>kept</w:t></w:r><w:ins><w:r><w:tab/></w:r></w:ins></w:p></w:body></w:document>"#,
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>kept</w:t></w:r><w:drawing><w:r><w:tab/></w:r></w:drawing></w:p></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(
@@ -2613,9 +2615,9 @@ mod events {
     }
 
     #[test]
-    fn w_br_inside_ignored_subtree_is_silently_dropped() {
+    fn w_br_inside_drawing_is_silently_dropped() {
         let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>kept</w:t></w:r><w:ins><w:r><w:br/></w:r></w:ins></w:p></w:body></w:document>"#,
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>kept</w:t></w:r><w:drawing><w:r><w:br/></w:r></w:drawing></w:p></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(
@@ -2842,7 +2844,7 @@ mod events {
     }
 
     #[test]
-    fn table_inside_ignored_subtree_is_dropped() {
+    fn table_inside_ins_passes_through() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>before</w:t></w:r></w:p><w:ins><w:tbl><w:tr><w:tc><w:p><w:r><w:t>inserted</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:ins><w:p><w:r><w:t>after</w:t></w:r></w:p></w:body></w:document>"#,
         );
@@ -2854,6 +2856,15 @@ mod events {
                 start_para(),
                 text("before"),
                 Event::EndParagraph,
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("inserted"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
                 start_para(),
                 text("after"),
                 Event::EndParagraph,
@@ -3061,7 +3072,7 @@ mod events {
     }
 
     #[test]
-    fn hyperlink_inside_cell_is_still_dropped() {
+    fn hyperlink_text_inside_cell_passes_through() {
         let mut reader = make_reader(
             r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>keep</w:t></w:r><w:hyperlink><w:r><w:t>link</w:t></w:r></w:hyperlink></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
         );
@@ -3075,6 +3086,7 @@ mod events {
                 start_cell(),
                 start_para(),
                 text("keep"),
+                text("link"),
                 Event::EndParagraph,
                 Event::EndTableCell,
                 Event::EndTableRow,
@@ -4282,6 +4294,631 @@ mod events {
                 Event::EndTableHeader,
                 Event::EndTableRow,
                 Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_text_inside_paragraph_emits_inline_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>see </w:t></w:r><w:hyperlink><w:r><w:t>link</w:t></w:r></w:hyperlink><w:r><w:t> done</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("see "),
+                text("link"),
+                text(" done"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_styled_run_emits_styled_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:hyperlink><w:r><w:rPr><w:u w:val="single"/></w:rPr><w:t>link</w:t></w:r></w:hyperlink></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Underline,
+                    id: None,
+                },
+                text("link"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn self_closing_hyperlink_emits_nothing() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:hyperlink/></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn orphan_hyperlink_at_body_level_emits_nothing() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:hyperlink><w:r><w:t>x</w:t></w:r></w:hyperlink></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(events, vec![start_doc(), Event::EndDocument,]);
+    }
+
+    #[test]
+    fn sdt_with_sdt_content_paragraph_emits_paragraph() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:sdt><w:sdtPr><w:tag w:val="myTag"/><w:id w:val="42"/></w:sdtPr><w:sdtContent><w:p><w:r><w:t>SDT content</w:t></w:r></w:p></w:sdtContent></w:sdt></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("SDT content"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn sdt_without_content_child_emits_nothing() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:sdt><w:sdtPr><w:id w:val="42"/></w:sdtPr></w:sdt></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(events, vec![start_doc(), Event::EndDocument,]);
+    }
+
+    #[test]
+    fn sdt_end_pr_subtree_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>text</w:t></w:r><w:sdtEndPr><w:rPr><w:b/></w:rPr></w:sdtEndPr></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn wins_run_level_emits_inserted_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t></w:r><w:ins><w:r><w:t>inserted</w:t></w:r></w:ins><w:r><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                text("inserted"),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn out_of_order_rpr_inside_wins_is_silently_consumed() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:ins><w:r><w:t>x</w:t><w:rPr><w:b/></w:rPr></w:r></w:ins></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn block_level_wins_wrapping_paragraph_emits_paragraph() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>existing</w:t></w:r></w:p><w:ins><w:p><w:pPr><w:jc w:val="right"/></w:pPr><w:r><w:t>inserted para</w:t></w:r></w:p></w:ins></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("existing"),
+                Event::EndParagraph,
+                start_para_with_alignment(TextAlignment::Right),
+                text("inserted para"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn block_level_wins_wrapping_table_emits_table() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:ins><w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:ins></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("cell"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn move_to_run_level_emits_moved_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>a</w:t></w:r><w:moveTo><w:r><w:t>moved</w:t></w:r></w:moveTo><w:r><w:t>b</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("a"),
+                text("moved"),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn block_level_move_to_wrapping_paragraph_emits_paragraph() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:moveTo><w:p><w:r><w:t>moved</w:t></w:r></w:p></w:moveTo></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("moved"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn sdt_pr_subtree_dropped_inside_paragraph() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>before</w:t></w:r><w:sdtPr><w:tag w:val="x"/><w:id w:val="1"/></w:sdtPr><w:r><w:t>after</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("before"),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_inside_wins_is_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:ins><w:r><w:t>before</w:t></w:r><w:drawing><wp:inline w:width="100"/></w:drawing><w:r><w:t>after</w:t></w:r></w:ins></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("before"),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn self_closing_drawing_inside_wins_is_dropped() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>kept</w:t></w:r><w:ins><w:drawing/></w:ins></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("kept"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn wins_around_hyperlink_around_run_emits_inner_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:ins><w:hyperlink><w:r><w:t>x</w:t></w:r></w:hyperlink></w:ins></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn combined_fixture_with_hyperlink_ins_sdt_drawing_emits_expected_events() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>plain </w:t></w:r><w:hyperlink><w:r><w:t>link</w:t></w:r></w:hyperlink><w:r><w:t> </w:t></w:r><w:ins><w:r><w:t>inserted</w:t></w:r></w:ins><w:r><w:t> </w:t></w:r><w:drawing><wp:inline w:width="100"/></w:drawing><w:r><w:t> </w:t></w:r><w:sdt><w:sdtPr><w:id w:val="1"/></w:sdtPr><w:sdtContent><w:r><w:t>sdt</w:t></w:r></w:sdtContent></w:sdt></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("plain "),
+                text("link"),
+                text(" "),
+                text("inserted"),
+                text(" "),
+                text(" "),
+                text("sdt"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn eof_inside_styled_run_auto_closes_styles() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:b/></w:rPr><w:t>bold"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Bold,
+                    id: None,
+                },
+                text("bold"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_denied_inside_denied_is_suppressed() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:drawing><w:pict><w:r><w:t>hidden</w:t></w:r></w:pict></w:drawing><w:r><w:t>visible</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("visible"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_bold_in_rpr_emits_bold_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:b></w:b></w:rPr><w:t>bold</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Bold,
+                    id: None,
+                },
+                text("bold"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_italic_in_rpr_emits_italic_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:i></w:i></w:rPr><w:t>italic</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Italic,
+                    id: None,
+                },
+                text("italic"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_strike_in_rpr_emits_strikethrough_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:strike></w:strike></w:rPr><w:t>struck</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Strikethrough,
+                    id: None,
+                },
+                text("struck"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_underline_in_rpr_emits_underline_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:u w:val="single"></w:u></w:rPr><w:t>underline</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Underline,
+                    id: None,
+                },
+                text("underline"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_vert_align_in_rpr_emits_subscript_text() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:rPr><w:vertAlign w:val="subscript"></w:vertAlign></w:rPr><w:t>sub</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Subscript,
+                    id: None,
+                },
+                text("sub"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_jc_in_ppr_sets_alignment() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:pPr><w:jc w:val="center"></w:jc></w:pPr><w:r><w:t>centered</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para_with_alignment(TextAlignment::Center),
+                text("centered"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_tbl_header_emits_header() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader></w:tblHeader></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_gridspan_emits_colspan() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="3"></w:gridSpan></w:tcPr><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableCell {
+                    colspan: Some(3),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("cell"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_self_closing_vmerge_is_a_no_op() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:vMerge w:val="restart"></w:vMerge></w:tcPr><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("cell"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn out_of_order_trpr_after_row_content_is_denied() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc><w:trPr><w:jc w:val="center"/></w:trPr></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("cell"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn self_closing_rpr_inside_ppr_is_a_no_op() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:pPr><w:jc w:val="right"/><w:rPr/></w:pPr><w:r><w:t>text</w:t></w:r></w:p></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para_with_alignment(TextAlignment::Right),
+                text("text"),
+                Event::EndParagraph,
                 Event::EndDocument,
             ]
         );

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -500,7 +500,7 @@ mod constructor {
 mod events {
     use std::io::Cursor;
 
-    use docspec_core::{Color, Event, TextAlignment, TextStyleKind};
+    use docspec_core::{Color, Event, TableHeaderScope, TextAlignment, TextStyleKind};
     use docspec_docx_reader::{DocxReader, EventSource as _};
 
     use crate::fixture;
@@ -2863,9 +2863,9 @@ mod events {
     }
 
     #[test]
-    fn table_row_and_cell_properties_emit_no_events() {
+    fn outer_cell_content_after_nested_table_stays_inside_outer_cell() {
         let mut reader = make_reader(
-            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tblPr><w:tblStyle w:val="TableGrid"/><w:tblW w:w="5000" w:type="pct"/></w:tblPr><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tcPr><w:tcW w:w="2500" w:type="pct"/><w:gridSpan w:val="2"/><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>before</w:t></w:r></w:p><w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl><w:p><w:r><w:t>after</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
         );
         let events = drive(&mut reader);
         assert_eq!(
@@ -2876,9 +2876,135 @@ mod events {
                 start_row(),
                 start_cell(),
                 start_para(),
-                text("cell"),
+                text("before"),
+                Event::EndParagraph,
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("inner"),
                 Event::EndParagraph,
                 Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                start_para(),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_table_inside_outer_header_cell_preserves_outer_header_end() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableHeader {
+                    scope: Some(TableHeaderScope::Column),
+                    abbr: None,
+                    colspan: None,
+                    rowspan: None,
+                    id: None,
+                },
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("inner"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_table_inside_outer_header_row_preserves_following_header_cell() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tbl><w:tr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:tc><w:tc><w:p><w:r><w:t>after</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableHeader {
+                    scope: Some(TableHeaderScope::Column),
+                    abbr: None,
+                    colspan: None,
+                    rowspan: None,
+                    id: None,
+                },
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("inner"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndTableHeader,
+                Event::StartTableHeader {
+                    scope: Some(TableHeaderScope::Column),
+                    abbr: None,
+                    colspan: None,
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    // gridSpan -> colspan, tblHeader -> StartTableHeader, vMerge ignored (rowspan deferred), tblPr/tcW ignored (table/cell visual props out of scope).
+    #[test]
+    fn table_properties_now_emit_colspan_header_and_drop_vmerge() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tblPr><w:tblStyle w:val="TableGrid"/><w:tblW w:w="5000" w:type="pct"/></w:tblPr><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tcPr><w:tcW w:w="2500" w:type="pct"/><w:gridSpan w:val="2"/><w:vMerge w:val="restart"/></w:tcPr><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableHeader {
+                    scope: Some(TableHeaderScope::Column),
+                    abbr: None,
+                    colspan: Some(2),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("cell"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
                 Event::EndTableRow,
                 Event::EndTable,
                 Event::EndDocument,
@@ -2901,6 +3027,30 @@ mod events {
                 start_cell(),
                 start_para(),
                 text("a"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn table_with_tbl_pr_ex_emits_no_extra_events() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tblPrEx><w:tblBorders><w:top w:val="single"/></w:tblBorders></w:tblPrEx><w:tc><w:p><w:r><w:t>cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("cell"),
                 Event::EndParagraph,
                 Event::EndTableCell,
                 Event::EndTableRow,
@@ -3446,5 +3596,694 @@ mod events {
                 ]
             );
         }
+    }
+
+    fn start_header() -> Event {
+        Event::StartTableHeader {
+            scope: Some(TableHeaderScope::Column),
+            abbr: None,
+            colspan: None,
+            rowspan: None,
+            id: None,
+        }
+    }
+
+    #[test]
+    fn tbl_header_basic_emits_table_header_event() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_multiple_consecutive_header_rows_all_emit_headers() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>h1</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>h2</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>h3</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h1"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h2"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h3"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_val_true_emits_header() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader w:val="true"/></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_val_1_emits_header() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader w:val="1"/></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_val_on_emits_header() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader w:val="on"/></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_val_false_emits_data_cell() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader w:val="false"/></w:trPr><w:tc><w:p><w:r><w:t>d</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("d"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_val_0_emits_data_cell() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader w:val="0"/></w:trPr><w:tc><w:p><w:r><w:t>d</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("d"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_val_off_emits_data_cell() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader w:val="off"/></w:trPr><w:tc><w:p><w:r><w:t>d</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("d"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    // OOXML §17.4.49: once a non-header row appears, subsequent tblHeader markers are ignored
+    #[test]
+    fn tbl_header_non_contiguous_is_ignored() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>d</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("d"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_with_gridspan_emits_table_header_with_colspan() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tcPr><w:gridSpan w:val="2"/></w:tcPr><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableHeader {
+                    scope: Some(TableHeaderScope::Column),
+                    abbr: None,
+                    colspan: Some(2),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_in_nested_table_does_not_propagate() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>inner</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("inner"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_with_empty_trpr_emits_data_cell() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr/><w:tc><w:p><w:r><w:t>d</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("d"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_with_other_trpr_children_still_emits_header() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:trHeight w:val="240"/><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_multi_paragraph_header_cell_emits_paragraphs_inside_header() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>p1</w:t></w:r></w:p><w:p><w:r><w:t>p2</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("p1"),
+                Event::EndParagraph,
+                start_para(),
+                text("p2"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn tbl_header_first_row_has_header_but_second_does_not_keeps_first_as_header() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:r><w:t>h</w:t></w:r></w:p></w:tc></w:tr><w:tr><w:tc><w:p><w:r><w:t>d</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_para(),
+                text("h"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("d"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_two_emits_colspan_some_two() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="2"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableCell {
+                    colspan: Some(2),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_one_emits_colspan_none() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="1"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_no_val_emits_colspan_none() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_zero_emits_colspan_none() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="0"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_non_numeric_emits_colspan_none() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="abc"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_large_value_emits_colspan_some() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="100"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableCell {
+                    colspan: Some(100),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_with_other_tcpr_children_still_emits_colspan() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tcPr><w:tcW w:w="2500" w:type="pct"/><w:gridSpan w:val="2"/><w:shd w:val="clear"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableCell {
+                    colspan: Some(2),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_after_cell_content_started_is_ignored() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:p><w:r><w:t>x</w:t></w:r></w:p><w:tcPr><w:gridSpan w:val="3"/></w:tcPr></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_in_nested_table_still_works() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:tc><w:tbl><w:tr><w:tc><w:tcPr><w:gridSpan w:val="2"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_table(),
+                start_row(),
+                Event::StartTableCell {
+                    colspan: Some(2),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn gridspan_in_header_row_emits_table_header_with_colspan() {
+        let mut reader = make_reader(
+            r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:tcPr><w:gridSpan w:val="2"/></w:tcPr><w:p><w:r><w:t>x</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body></w:document>"#,
+        );
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                Event::StartTableHeader {
+                    scope: Some(TableHeaderScope::Column),
+                    abbr: None,
+                    colspan: Some(2),
+                    rowspan: None,
+                    id: None,
+                },
+                start_para(),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved table parsing: outermost header-band recognition, correct header vs data emission, colspan support, and proper table cell content ordering (including breaks/tabs).

* **Documentation**
  * Expanded DOCX reader docs: clarified supported behaviors (hyperlink text emitted, link targets dropped; SDT content emitted while properties dropped; tracked insertions/moves accepted) and explicit denylist (vertical merges/rowspan lost; many visual containers silently dropped).

* **Tests**
  * Added/updated tests for headers, grid-span, nested tables, hyperlinks, SDT, and insertion/move handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->