### PR TITLE
feat(pandoc-native-writer): HorizontalRule, LineBreak, SoftBreak

### DIFF
--- a/crates/docspec-pandoc-native-writer/README.md
+++ b/crates/docspec-pandoc-native-writer/README.md
@@ -11,6 +11,9 @@ Converts a DocSpec event stream into compact Pandoc native block-list syntax, su
 | `StartDocument` / `EndDocument` | `[` / `]` (block list framing) |
 | `StartParagraph` / `EndParagraph` | `Para [` / `]` |
 | `Text` (styles dropped) | `Str "..."` |
+| `ThematicBreak` (id dropped) | `HorizontalRule` |
+| `LineBreak` | `LineBreak` |
+| `SoftBreak` | `SoftBreak` |
 
 ## Not Supported
 
@@ -21,13 +24,11 @@ The following DocSpec events are silently ignored:
 - Preformatted / code blocks — `StartPreformatted` / `EndPreformatted`
 - Images — `Image`
 - Tables — `StartTable` / `EndTable` and related events
-- Thematic breaks — `ThematicBreak`
 - List items — `StartOrderedListItem` / `StartUnorderedListItem` and related events
 - Inline links — `StartLink` / `EndLink`
 - Footnotes — `StartFootnote` / `EndFootnote` / `FootnoteRef`
 - Definition lists — `StartDefinitionList` / `StartDefinitionTerm` / `StartDefinitionDetail`
 - Captions — `StartCaption` / `EndCaption`
-- Line breaks — `LineBreak` / `SoftBreak`
 - Text formatting styles — `StartTextStyle` / `EndTextStyle` are accepted but silently dropped
 
 ## Usage

--- a/crates/docspec-pandoc-native-writer/src/lib.rs
+++ b/crates/docspec-pandoc-native-writer/src/lib.rs
@@ -48,6 +48,30 @@ impl<W: Write> PandocNativeWriter<W> {
             writer,
         }
     }
+
+    #[inline]
+    fn write_block_literal(&mut self, token: &[u8]) -> Result<()> {
+        if self.started && !self.finished && !self.in_paragraph {
+            if !self.first_block {
+                self.writer.write_all(b",")?;
+            }
+            self.writer.write_all(token)?;
+            self.first_block = false;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn write_inline_literal(&mut self, token: &[u8]) -> Result<()> {
+        if self.in_paragraph {
+            if self.paragraph_has_inline {
+                self.writer.write_all(b",")?;
+            }
+            self.writer.write_all(token)?;
+            self.paragraph_has_inline = true;
+        }
+        Ok(())
+    }
 }
 
 impl<W: Write> EventSink for PandocNativeWriter<W> {
@@ -70,8 +94,15 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
 
     /// Handles a single `DocSpec` event.
     ///
-    /// Only `StartDocument`, `EndDocument`, `StartParagraph`, `EndParagraph`,
-    /// and `Text` events produce output. All other events are silently ignored.
+    /// The following events produce output:
+    /// - `StartDocument` / `EndDocument` — block-list framing
+    /// - `StartParagraph` / `EndParagraph` — `Para [...]`
+    /// - `Text` — `Str "..."`
+    /// - `ThematicBreak` — `HorizontalRule`
+    /// - `LineBreak` — `LineBreak`
+    /// - `SoftBreak` — `SoftBreak`
+    ///
+    /// All other events are silently ignored.
     #[inline]
     fn handle_event(&mut self, event: Event) -> Result<()> {
         match event {
@@ -116,6 +147,9 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
                 escape::write_haskell_string(&mut self.writer, &content)?;
                 self.paragraph_has_inline = true;
             }
+            Event::ThematicBreak { .. } => self.write_block_literal(b"HorizontalRule")?,
+            Event::LineBreak => self.write_inline_literal(b"LineBreak")?,
+            Event::SoftBreak => self.write_inline_literal(b"SoftBreak")?,
             _ => {}
         }
         Ok(())

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -244,10 +244,179 @@ mod tests {
                 start_para(),
                 text("x"),
                 Event::EndParagraph,
-                Event::ThematicBreak { id: None },
+                Event::StartBlockQuote { id: None },
+                Event::EndBlockQuote,
                 Event::EndDocument
             ]),
             "[Para [Str \"x\"]]"
+        );
+    }
+
+    #[test]
+    fn thematic_break_standalone() {
+        assert_eq!(
+            run([
+                start_doc(),
+                Event::ThematicBreak { id: None },
+                Event::EndDocument
+            ]),
+            "[HorizontalRule]"
+        );
+    }
+
+    #[test]
+    fn thematic_break_between_paragraphs() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::EndParagraph,
+                Event::ThematicBreak { id: None },
+                start_para(),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\"],HorizontalRule,Para [Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn thematic_break_with_id_ignored() {
+        assert_eq!(
+            run([
+                start_doc(),
+                Event::ThematicBreak {
+                    id: Some("hr1".to_string()),
+                },
+                Event::EndDocument
+            ]),
+            "[HorizontalRule]"
+        );
+    }
+
+    #[test]
+    fn thematic_break_outside_document_ignored() {
+        assert_eq!(
+            run([
+                Event::ThematicBreak { id: None },
+                start_doc(),
+                Event::EndDocument
+            ]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn thematic_break_inside_paragraph_ignored() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::ThematicBreak { id: None },
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\",Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn line_break_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::LineBreak,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\",LineBreak,Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn line_break_at_start_of_paragraph_no_leading_comma() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                Event::LineBreak,
+                text("a"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [LineBreak,Str \"a\"]]"
+        );
+    }
+
+    #[test]
+    fn line_break_outside_paragraph_ignored() {
+        assert_eq!(
+            run([start_doc(), Event::LineBreak, Event::EndDocument]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn soft_break_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::SoftBreak,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\",SoftBreak,Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn soft_break_at_start_of_paragraph_no_leading_comma() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                Event::SoftBreak,
+                text("a"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [SoftBreak,Str \"a\"]]"
+        );
+    }
+
+    #[test]
+    fn soft_break_outside_paragraph_ignored() {
+        assert_eq!(
+            run([start_doc(), Event::SoftBreak, Event::EndDocument]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn mixed_breaks_and_text_in_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::SoftBreak,
+                text("b"),
+                Event::LineBreak,
+                text("c"),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]),
+            "[Para [Str \"a\",SoftBreak,Str \"b\",LineBreak,Str \"c\"]]"
         );
     }
 


### PR DESCRIPTION
Emit `HorizontalRule`, `LineBreak`, and `SoftBreak` via two shared private helpers (`write_block_literal`, `write_inline_literal`).