### PR TITLE
feat(pandoc-native-writer): Headings

### DIFF
--- a/crates/docspec-pandoc-native-writer/README.md
+++ b/crates/docspec-pandoc-native-writer/README.md
@@ -10,6 +10,7 @@ Converts a DocSpec event stream into compact Pandoc native block-list syntax, su
 | --- | --- |
 | `StartDocument` / `EndDocument` | `[` / `]` (block list framing) |
 | `StartParagraph` / `EndParagraph` | `Para [` / `]` |
+| `StartHeading { level, id }` / `EndHeading` | `Header N ("id",[],[]) [` / `]` (level passed through raw; classes and key-value attrs always empty) |
 | `Text` (styles dropped) | `Str "..."` |
 | `ThematicBreak` (id dropped) | `HorizontalRule` |
 | `LineBreak` | `LineBreak` |
@@ -19,7 +20,6 @@ Converts a DocSpec event stream into compact Pandoc native block-list syntax, su
 
 The following DocSpec events are silently ignored:
 
-- Headings — `StartHeading` / `EndHeading`
 - Block quotes — `StartBlockQuote` / `EndBlockQuote`
 - Preformatted / code blocks — `StartPreformatted` / `EndPreformatted`
 - Images — `Image`

--- a/crates/docspec-pandoc-native-writer/src/lib.rs
+++ b/crates/docspec-pandoc-native-writer/src/lib.rs
@@ -28,8 +28,8 @@ use std::io::Write;
 pub struct PandocNativeWriter<W: Write> {
     finished: bool,
     first_block: bool,
-    in_paragraph: bool,
-    paragraph_has_inline: bool,
+    in_inline_block: bool,
+    inline_block_has_content: bool,
     started: bool,
     writer: W,
 }
@@ -42,8 +42,8 @@ impl<W: Write> PandocNativeWriter<W> {
         Self {
             finished: false,
             first_block: true,
-            in_paragraph: false,
-            paragraph_has_inline: false,
+            in_inline_block: false,
+            inline_block_has_content: false,
             started: false,
             writer,
         }
@@ -51,7 +51,7 @@ impl<W: Write> PandocNativeWriter<W> {
 
     #[inline]
     fn write_block_literal(&mut self, token: &[u8]) -> Result<()> {
-        if self.started && !self.finished && !self.in_paragraph {
+        if self.started && !self.finished && !self.in_inline_block {
             if !self.first_block {
                 self.writer.write_all(b",")?;
             }
@@ -63,12 +63,12 @@ impl<W: Write> PandocNativeWriter<W> {
 
     #[inline]
     fn write_inline_literal(&mut self, token: &[u8]) -> Result<()> {
-        if self.in_paragraph {
-            if self.paragraph_has_inline {
+        if self.in_inline_block {
+            if self.inline_block_has_content {
                 self.writer.write_all(b",")?;
             }
             self.writer.write_all(token)?;
-            self.paragraph_has_inline = true;
+            self.inline_block_has_content = true;
         }
         Ok(())
     }
@@ -83,7 +83,7 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
     #[inline]
     fn finish(mut self) -> Result<()> {
         if self.started && !self.finished {
-            if self.in_paragraph {
+            if self.in_inline_block {
                 self.writer.write_all(b"]")?;
             }
             self.writer.write_all(b"]")?;
@@ -97,6 +97,7 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
     /// The following events produce output:
     /// - `StartDocument` / `EndDocument` — block-list framing
     /// - `StartParagraph` / `EndParagraph` — `Para [...]`
+    /// - `StartHeading` / `EndHeading` — `Header N ("id",[],[]) [...]` (level passed through raw)
     /// - `Text` — `Str "..."`
     /// - `ThematicBreak` — `HorizontalRule`
     /// - `LineBreak` — `LineBreak`
@@ -114,38 +115,51 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
             }
             Event::EndDocument => {
                 if self.started && !self.finished {
-                    if self.in_paragraph {
+                    if self.in_inline_block {
                         self.writer.write_all(b"]")?;
-                        self.in_paragraph = false;
+                        self.in_inline_block = false;
                     }
                     self.writer.write_all(b"]")?;
                     self.finished = true;
                 }
             }
             Event::StartParagraph { .. } => {
-                if self.started && !self.finished && !self.in_paragraph {
+                if self.started && !self.finished && !self.in_inline_block {
                     if !self.first_block {
                         self.writer.write_all(b",")?;
                     }
                     self.writer.write_all(b"Para [")?;
-                    self.in_paragraph = true;
-                    self.paragraph_has_inline = false;
+                    self.in_inline_block = true;
+                    self.inline_block_has_content = false;
                     self.first_block = false;
                 }
             }
-            Event::EndParagraph => {
-                if self.in_paragraph {
-                    self.writer.write_all(b"]")?;
-                    self.in_paragraph = false;
+            Event::StartHeading { id, level } => {
+                if self.started && !self.finished && !self.in_inline_block {
+                    if !self.first_block {
+                        self.writer.write_all(b",")?;
+                    }
+                    write!(self.writer, "Header {level} (")?;
+                    escape::write_haskell_string(&mut self.writer, id.as_deref().unwrap_or(""))?;
+                    self.writer.write_all(b",[],[]) [")?;
+                    self.in_inline_block = true;
+                    self.inline_block_has_content = false;
+                    self.first_block = false;
                 }
             }
-            Event::Text { content } if self.in_paragraph => {
-                if self.paragraph_has_inline {
+            Event::EndParagraph | Event::EndHeading => {
+                if self.in_inline_block {
+                    self.writer.write_all(b"]")?;
+                    self.in_inline_block = false;
+                }
+            }
+            Event::Text { content } if self.in_inline_block => {
+                if self.inline_block_has_content {
                     self.writer.write_all(b",")?;
                 }
                 self.writer.write_all(b"Str ")?;
                 escape::write_haskell_string(&mut self.writer, &content)?;
-                self.paragraph_has_inline = true;
+                self.inline_block_has_content = true;
             }
             Event::ThematicBreak { .. } => self.write_block_literal(b"HorizontalRule")?,
             Event::LineBreak => self.write_inline_literal(b"LineBreak")?,

--- a/crates/docspec-pandoc-native-writer/src/lib.rs
+++ b/crates/docspec-pandoc-native-writer/src/lib.rs
@@ -7,6 +7,12 @@ mod escape;
 use docspec_core::{Event, EventSink, Result};
 use std::io::Write;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InlineBlockKind {
+    Paragraph,
+    Heading,
+}
+
 /// A streaming Pandoc native writer for `DocSpec` events.
 ///
 /// Writes compact Pandoc native block-list syntax directly to the underlying
@@ -23,12 +29,12 @@ use std::io::Write;
 /// * `W` - Any type implementing [`Write`]
 #[expect(
     clippy::struct_excessive_bools,
-    reason = "PandocNativeWriter uses one boolean per state flag for a direct state machine; a separate state enum would be more complex without benefit"
+    reason = "PandocNativeWriter uses independent boolean state flags for a direct state machine; the active inline-block kind is already an Option<InlineBlockKind>, but `started`, `finished`, `first_block`, and `inline_block_has_content` track orthogonal one-shot signals where a combined enum would obscure intent"
 )]
 pub struct PandocNativeWriter<W: Write> {
     finished: bool,
     first_block: bool,
-    in_inline_block: bool,
+    inline_block: Option<InlineBlockKind>,
     inline_block_has_content: bool,
     started: bool,
     writer: W,
@@ -42,7 +48,7 @@ impl<W: Write> PandocNativeWriter<W> {
         Self {
             finished: false,
             first_block: true,
-            in_inline_block: false,
+            inline_block: None,
             inline_block_has_content: false,
             started: false,
             writer,
@@ -51,7 +57,7 @@ impl<W: Write> PandocNativeWriter<W> {
 
     #[inline]
     fn write_block_literal(&mut self, token: &[u8]) -> Result<()> {
-        if self.started && !self.finished && !self.in_inline_block {
+        if self.started && !self.finished && self.inline_block.is_none() {
             if !self.first_block {
                 self.writer.write_all(b",")?;
             }
@@ -63,7 +69,7 @@ impl<W: Write> PandocNativeWriter<W> {
 
     #[inline]
     fn write_inline_literal(&mut self, token: &[u8]) -> Result<()> {
-        if self.in_inline_block {
+        if self.inline_block.is_some() {
             if self.inline_block_has_content {
                 self.writer.write_all(b",")?;
             }
@@ -83,7 +89,7 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
     #[inline]
     fn finish(mut self) -> Result<()> {
         if self.started && !self.finished {
-            if self.in_inline_block {
+            if self.inline_block.is_some() {
                 self.writer.write_all(b"]")?;
             }
             self.writer.write_all(b"]")?;
@@ -115,45 +121,51 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
             }
             Event::EndDocument => {
                 if self.started && !self.finished {
-                    if self.in_inline_block {
+                    if self.inline_block.is_some() {
                         self.writer.write_all(b"]")?;
-                        self.in_inline_block = false;
+                        self.inline_block = None;
                     }
                     self.writer.write_all(b"]")?;
                     self.finished = true;
                 }
             }
             Event::StartParagraph { .. } => {
-                if self.started && !self.finished && !self.in_inline_block {
+                if self.started && !self.finished && self.inline_block.is_none() {
                     if !self.first_block {
                         self.writer.write_all(b",")?;
                     }
                     self.writer.write_all(b"Para [")?;
-                    self.in_inline_block = true;
+                    self.inline_block = Some(InlineBlockKind::Paragraph);
                     self.inline_block_has_content = false;
                     self.first_block = false;
                 }
             }
             Event::StartHeading { id, level } => {
-                if self.started && !self.finished && !self.in_inline_block {
+                if self.started && !self.finished && self.inline_block.is_none() {
                     if !self.first_block {
                         self.writer.write_all(b",")?;
                     }
                     write!(self.writer, "Header {level} (")?;
                     escape::write_haskell_string(&mut self.writer, id.as_deref().unwrap_or(""))?;
                     self.writer.write_all(b",[],[]) [")?;
-                    self.in_inline_block = true;
+                    self.inline_block = Some(InlineBlockKind::Heading);
                     self.inline_block_has_content = false;
                     self.first_block = false;
                 }
             }
-            Event::EndParagraph | Event::EndHeading => {
-                if self.in_inline_block {
+            Event::EndParagraph => {
+                if self.inline_block == Some(InlineBlockKind::Paragraph) {
                     self.writer.write_all(b"]")?;
-                    self.in_inline_block = false;
+                    self.inline_block = None;
                 }
             }
-            Event::Text { content } if self.in_inline_block => {
+            Event::EndHeading => {
+                if self.inline_block == Some(InlineBlockKind::Heading) {
+                    self.writer.write_all(b"]")?;
+                    self.inline_block = None;
+                }
+            }
+            Event::Text { content } if self.inline_block.is_some() => {
                 if self.inline_block_has_content {
                     self.writer.write_all(b",")?;
                 }

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -775,4 +775,36 @@ mod tests {
             "[Para [Str \"a\",Str \"b\"]]"
         );
     }
+
+    #[test]
+    fn stray_end_heading_inside_paragraph_does_not_close_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::EndHeading,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a\",Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn stray_end_paragraph_inside_heading_does_not_close_heading() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                text("a"),
+                Event::EndParagraph,
+                text("b"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Str \"a\",Str \"b\"]]"
+        );
+    }
 }

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -67,6 +67,13 @@ mod tests {
         }
     }
 
+    fn start_heading(level: u8, id: Option<&str>) -> Event {
+        Event::StartHeading {
+            level,
+            id: id.map(String::from),
+        }
+    }
+
     #[test]
     fn empty_document_emits_empty_list() {
         assert_eq!(run([start_doc(), Event::EndDocument]), "[]");
@@ -239,8 +246,11 @@ mod tests {
         assert_eq!(
             run([
                 start_doc(),
-                Event::StartHeading { level: 1, id: None },
-                Event::EndHeading,
+                Event::StartPreformatted {
+                    syntax: None,
+                    id: None
+                },
+                Event::EndPreformatted,
                 start_para(),
                 text("x"),
                 Event::EndParagraph,
@@ -545,5 +555,224 @@ mod tests {
             Event::EndDocument,
         ]);
         assert_eq!(result.unwrap(), "[Para [Str \"ok\"]]");
+    }
+
+    #[test]
+    fn heading_basic_level_1_no_id() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                text("Hello"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Str \"Hello\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_with_id() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(2, Some("sec1")),
+                text("Hello"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 2 (\"sec1\",[],[]) [Str \"Hello\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_empty_body() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) []]"
+        );
+    }
+
+    #[test]
+    fn heading_levels_1_through_9() {
+        for level in 1..=9 {
+            let out = run([
+                start_doc(),
+                start_heading(level, None),
+                text("h"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]);
+            assert_eq!(out, format!("[Header {level} (\"\",[],[]) [Str \"h\"]]"));
+        }
+    }
+
+    #[test]
+    fn heading_level_zero_passes_through_raw() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(0, None),
+                text("h"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 0 (\"\",[],[]) [Str \"h\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_level_above_nine_passes_through_raw() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(42, None),
+                text("h"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 42 (\"\",[],[]) [Str \"h\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_level_u8_max_passes_through_raw() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(u8::MAX, None),
+                text("h"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 255 (\"\",[],[]) [Str \"h\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_with_multiple_text_runs_separated_by_comma() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                text("first"),
+                text("second"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Str \"first\",Str \"second\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_with_line_break_inline() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                text("a"),
+                Event::LineBreak,
+                text("b"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Str \"a\",LineBreak,Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_with_soft_break_inline() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                text("a"),
+                Event::SoftBreak,
+                text("b"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Str \"a\",SoftBreak,Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_id_with_special_chars_is_escaped() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, Some("a\"b\\c")),
+                text("x"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"a\\\"b\\\\c\",[],[]) [Str \"x\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_between_paragraphs_with_comma_separation() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("before"),
+                Event::EndParagraph,
+                start_heading(2, None),
+                text("title"),
+                Event::EndHeading,
+                start_para(),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"before\"],Header 2 (\"\",[],[]) [Str \"title\"],Para [Str \"after\"]]"
+        );
+    }
+
+    #[test]
+    fn multiple_consecutive_headings() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                text("one"),
+                Event::EndHeading,
+                start_heading(2, Some("two")),
+                text("two"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Str \"one\"],Header 2 (\"two\",[],[]) [Str \"two\"]]"
+        );
+    }
+
+    #[test]
+    fn heading_outside_document_ignored() {
+        assert_eq!(
+            run([start_heading(1, None), text("dropped"), Event::EndHeading,]),
+            ""
+        );
+    }
+
+    #[test]
+    fn start_heading_inside_paragraph_is_silently_dropped() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                start_heading(1, None),
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a\",Str \"b\"]]"
+        );
     }
 }


### PR DESCRIPTION
Adds `Header` emission to the pandoc-native-writer.

- `StartHeading { id, level }` / `EndHeading` → `Header N ("id",[],[]) [...]`
- Level passed through raw (no clamping)
- Classes and key-value attrs always empty (DocSpec has no fields for them)
- ID populated from event, escaped via existing Haskell-string escaper
- Internal: renamed `in_paragraph` → `in_inline_block` (and `paragraph_has_inline` → `inline_block_has_content`) to reflect that the same state serves Header bodies. `EndParagraph` and `EndHeading` share one match arm
- 15 new tests; real-pandoc CLI round-trip verified through markdown and HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Headings are now supported in Pandoc native writer output, including multiple heading levels and id attributes

* **Documentation**
  * Updated documentation to reflect heading support

* **Tests**
  * Comprehensive test suite added for heading rendering across various scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->