### PR TITLE
feat(pandoc-native-writer): Strong, Emph, Strikeout, Underline, Subscript, Superscript

### DIFF
--- a/crates/docspec-pandoc-native-writer/README.md
+++ b/crates/docspec-pandoc-native-writer/README.md
@@ -11,10 +11,16 @@ Converts a DocSpec event stream into compact Pandoc native block-list syntax, su
 | `StartDocument` / `EndDocument` | `[` / `]` (block list framing) |
 | `StartParagraph` / `EndParagraph` | `Para [` / `]` |
 | `StartHeading { level, id }` / `EndHeading` | `Header N ("id",[],[]) [` / `]` (level passed through raw; classes and key-value attrs always empty) |
-| `Text` (styles dropped) | `Str "..."` |
+| `Text` | `Str "..."` |
 | `ThematicBreak` (id dropped) | `HorizontalRule` |
 | `LineBreak` | `LineBreak` |
 | `SoftBreak` | `SoftBreak` |
+| `StartTextStyle { kind: Bold }` / `EndTextStyle` | `Strong [` / `]` |
+| `StartTextStyle { kind: Italic }` / `EndTextStyle` | `Emph [` / `]` |
+| `StartTextStyle { kind: Strikethrough }` / `EndTextStyle` | `Strikeout [` / `]` |
+| `StartTextStyle { kind: Underline }` / `EndTextStyle` | `Underline [` / `]` |
+| `StartTextStyle { kind: Subscript }` / `EndTextStyle` | `Subscript [` / `]` |
+| `StartTextStyle { kind: Superscript }` / `EndTextStyle` | `Superscript [` / `]` |
 
 ## Not Supported
 
@@ -29,7 +35,7 @@ The following DocSpec events are silently ignored:
 - Footnotes — `StartFootnote` / `EndFootnote` / `FootnoteRef`
 - Definition lists — `StartDefinitionList` / `StartDefinitionTerm` / `StartDefinitionDetail`
 - Captions — `StartCaption` / `EndCaption`
-- Text formatting styles — `StartTextStyle` / `EndTextStyle` are accepted but silently dropped
+- Text formatting styles — `StartTextStyle { kind: Code | Mark | TextColor }` are accepted but silently flattened (text inside is preserved without a wrapper)
 
 ## Usage
 

--- a/crates/docspec-pandoc-native-writer/src/lib.rs
+++ b/crates/docspec-pandoc-native-writer/src/lib.rs
@@ -4,13 +4,19 @@
 
 mod escape;
 
-use docspec_core::{Event, EventSink, Result};
+use docspec_core::{Event, EventSink, Result, TextStyleKind};
 use std::io::Write;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum InlineBlockKind {
     Paragraph,
     Heading,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TextStyleFrame {
+    Wrapped,
+    Flattened,
 }
 
 /// A streaming Pandoc native writer for `DocSpec` events.
@@ -27,16 +33,13 @@ enum InlineBlockKind {
 /// # Type Parameters
 ///
 /// * `W` - Any type implementing [`Write`]
-#[expect(
-    clippy::struct_excessive_bools,
-    reason = "PandocNativeWriter uses independent boolean state flags for a direct state machine; the active inline-block kind is already an Option<InlineBlockKind>, but `started`, `finished`, `first_block`, and `inline_block_has_content` track orthogonal one-shot signals where a combined enum would obscure intent"
-)]
 pub struct PandocNativeWriter<W: Write> {
     finished: bool,
     first_block: bool,
     inline_block: Option<InlineBlockKind>,
-    inline_block_has_content: bool,
+    inline_has_content: Vec<bool>,
     started: bool,
+    text_style_frames: Vec<TextStyleFrame>,
     writer: W,
 }
 
@@ -49,8 +52,9 @@ impl<W: Write> PandocNativeWriter<W> {
             finished: false,
             first_block: true,
             inline_block: None,
-            inline_block_has_content: false,
+            inline_has_content: Vec::new(),
             started: false,
+            text_style_frames: Vec::new(),
             writer,
         }
     }
@@ -68,14 +72,32 @@ impl<W: Write> PandocNativeWriter<W> {
     }
 
     #[inline]
-    fn write_inline_literal(&mut self, token: &[u8]) -> Result<()> {
-        if self.inline_block.is_some() {
-            if self.inline_block_has_content {
+    fn write_inline_separator(&mut self) -> Result<()> {
+        if let Some(has_content) = self.inline_has_content.last_mut() {
+            if *has_content {
                 self.writer.write_all(b",")?;
             }
-            self.writer.write_all(token)?;
-            self.inline_block_has_content = true;
+            *has_content = true;
         }
+        Ok(())
+    }
+
+    #[inline]
+    fn write_inline_literal(&mut self, token: &[u8]) -> Result<()> {
+        if !self.inline_has_content.is_empty() {
+            self.write_inline_separator()?;
+            self.writer.write_all(token)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn close_orphaned_inline_frames(&mut self) -> Result<()> {
+        while self.inline_has_content.len() > 1 {
+            self.writer.write_all(b"]")?;
+            self.inline_has_content.pop();
+        }
+        self.text_style_frames.clear();
         Ok(())
     }
 }
@@ -84,13 +106,14 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
     /// Finalizes the output.
     ///
     /// If the document was started but not finished (i.e., `EndDocument` was never
-    /// received), performs a best-effort close: closes any open paragraph and emits
-    /// the closing `]` for the block list.
+    /// received), performs a best-effort close: closes any open inline wrappers and
+    /// emits the closing `]` for the block list.
     #[inline]
     fn finish(mut self) -> Result<()> {
         if self.started && !self.finished {
-            if self.inline_block.is_some() {
+            while !self.inline_has_content.is_empty() {
                 self.writer.write_all(b"]")?;
+                self.inline_has_content.pop();
             }
             self.writer.write_all(b"]")?;
         }
@@ -108,6 +131,8 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
     /// - `ThematicBreak` — `HorizontalRule`
     /// - `LineBreak` — `LineBreak`
     /// - `SoftBreak` — `SoftBreak`
+    /// - `StartTextStyle` / `EndTextStyle` — `Strong`/`Emph`/`Strikeout`/`Underline`/`Subscript`/`Superscript` wrappers
+    ///   (kinds `Code`, `Mark`, `TextColor` are silently flattened — text inside is preserved without a wrapper)
     ///
     /// All other events are silently ignored.
     #[inline]
@@ -121,10 +146,12 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
             }
             Event::EndDocument => {
                 if self.started && !self.finished {
-                    if self.inline_block.is_some() {
+                    while !self.inline_has_content.is_empty() {
                         self.writer.write_all(b"]")?;
-                        self.inline_block = None;
+                        self.inline_has_content.pop();
                     }
+                    self.text_style_frames.clear();
+                    self.inline_block = None;
                     self.writer.write_all(b"]")?;
                     self.finished = true;
                 }
@@ -136,7 +163,7 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
                     }
                     self.writer.write_all(b"Para [")?;
                     self.inline_block = Some(InlineBlockKind::Paragraph);
-                    self.inline_block_has_content = false;
+                    self.inline_has_content.push(false);
                     self.first_block = false;
                 }
             }
@@ -149,29 +176,59 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
                     escape::write_haskell_string(&mut self.writer, id.as_deref().unwrap_or(""))?;
                     self.writer.write_all(b",[],[]) [")?;
                     self.inline_block = Some(InlineBlockKind::Heading);
-                    self.inline_block_has_content = false;
+                    self.inline_has_content.push(false);
                     self.first_block = false;
                 }
             }
             Event::EndParagraph => {
                 if self.inline_block == Some(InlineBlockKind::Paragraph) {
+                    self.close_orphaned_inline_frames()?;
                     self.writer.write_all(b"]")?;
+                    self.inline_has_content.pop();
                     self.inline_block = None;
                 }
             }
             Event::EndHeading => {
                 if self.inline_block == Some(InlineBlockKind::Heading) {
+                    self.close_orphaned_inline_frames()?;
                     self.writer.write_all(b"]")?;
+                    self.inline_has_content.pop();
                     self.inline_block = None;
                 }
             }
-            Event::Text { content } if self.inline_block.is_some() => {
-                if self.inline_block_has_content {
-                    self.writer.write_all(b",")?;
+            Event::StartTextStyle { kind, .. } if !self.inline_has_content.is_empty() => {
+                let opener: Option<&[u8]> = match kind {
+                    TextStyleKind::Bold => Some(b"Strong ["),
+                    TextStyleKind::Italic => Some(b"Emph ["),
+                    TextStyleKind::Strikethrough => Some(b"Strikeout ["),
+                    TextStyleKind::Underline => Some(b"Underline ["),
+                    TextStyleKind::Subscript => Some(b"Subscript ["),
+                    TextStyleKind::Superscript => Some(b"Superscript ["),
+                    TextStyleKind::Code | TextStyleKind::Mark(_) | TextStyleKind::TextColor(_) => {
+                        None
+                    }
+                    _ => None,
+                };
+                if let Some(open) = opener {
+                    self.write_inline_separator()?;
+                    self.writer.write_all(open)?;
+                    self.inline_has_content.push(false);
+                    self.text_style_frames.push(TextStyleFrame::Wrapped);
+                } else {
+                    self.text_style_frames.push(TextStyleFrame::Flattened);
                 }
+            }
+            Event::EndTextStyle => match self.text_style_frames.pop() {
+                Some(TextStyleFrame::Wrapped) if self.inline_has_content.len() > 1 => {
+                    self.writer.write_all(b"]")?;
+                    self.inline_has_content.pop();
+                }
+                Some(TextStyleFrame::Wrapped | TextStyleFrame::Flattened) | None => {}
+            },
+            Event::Text { content } if !self.inline_has_content.is_empty() => {
+                self.write_inline_separator()?;
                 self.writer.write_all(b"Str ")?;
                 escape::write_haskell_string(&mut self.writer, &content)?;
-                self.inline_block_has_content = true;
             }
             Event::ThematicBreak { .. } => self.write_block_literal(b"HorizontalRule")?,
             Event::LineBreak => self.write_inline_literal(b"LineBreak")?,

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -74,6 +74,10 @@ mod tests {
         }
     }
 
+    fn start_style(kind: docspec_core::TextStyleKind) -> Event {
+        Event::StartTextStyle { kind, id: None }
+    }
+
     #[test]
     fn empty_document_emits_empty_list() {
         assert_eq!(run([start_doc(), Event::EndDocument]), "[]");
@@ -153,50 +157,6 @@ mod tests {
             ]),
             "[Para [Str \"x\"]]"
         );
-    }
-
-    #[test]
-    fn styled_input_dropped() {
-        let styled_events = vec![
-            Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            },
-            Event::StartParagraph {
-                id: None,
-                alignment: None,
-            },
-            Event::StartTextStyle {
-                kind: docspec_core::TextStyleKind::Bold,
-                id: None,
-            },
-            Event::Text {
-                content: "x".to_string(),
-            },
-            Event::EndTextStyle,
-            Event::EndParagraph,
-            Event::EndDocument,
-        ];
-        let unstyled_events = vec![
-            Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            },
-            Event::StartParagraph {
-                id: None,
-                alignment: None,
-            },
-            Event::Text {
-                content: "x".to_string(),
-            },
-            Event::EndParagraph,
-            Event::EndDocument,
-        ];
-        let styled_output = run(styled_events);
-        let unstyled_output = run(unstyled_events);
-        assert_eq!(styled_output, unstyled_output);
     }
 
     #[test]
@@ -805,6 +765,357 @@ mod tests {
                 Event::EndDocument,
             ]),
             "[Header 1 (\"\",[],[]) [Str \"a\",Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn bold_wraps_text_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("b"),
+                Event::EndTextStyle,
+                text("c"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a\",Strong [Str \"b\"],Str \"c\"]]"
+        );
+    }
+
+    #[test]
+    fn italic_wraps_text_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Italic),
+                text("hello"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Emph [Str \"hello\"]]]"
+        );
+    }
+
+    #[test]
+    fn strikethrough_wraps_text_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Strikethrough),
+                text("gone"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strikeout [Str \"gone\"]]]"
+        );
+    }
+
+    #[test]
+    fn underline_wraps_text_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Underline),
+                text("under"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Underline [Str \"under\"]]]"
+        );
+    }
+
+    #[test]
+    fn subscript_wraps_text_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Subscript),
+                text("2"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Subscript [Str \"2\"]]]"
+        );
+    }
+
+    #[test]
+    fn superscript_wraps_text_inside_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Superscript),
+                text("th"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Superscript [Str \"th\"]]]"
+        );
+    }
+
+    #[test]
+    fn adjacent_styles_each_emit_their_wrapper() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("b"),
+                Event::EndTextStyle,
+                start_style(docspec_core::TextStyleKind::Italic),
+                text("i"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Str \"b\"],Emph [Str \"i\"]]]"
+        );
+    }
+
+    #[test]
+    fn nested_styles_emit_nested_wrappers() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                start_style(docspec_core::TextStyleKind::Italic),
+                text("bi"),
+                Event::EndTextStyle,
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Emph [Str \"bi\"]]]]"
+        );
+    }
+
+    #[test]
+    fn style_inside_heading_emits_wrapper() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(2, Some("h")),
+                text("a "),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("bold"),
+                Event::EndTextStyle,
+                text(" b"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 2 (\"h\",[],[]) [Str \"a \",Strong [Str \"bold\"],Str \" b\"]]"
+        );
+    }
+
+    #[test]
+    fn style_with_multiple_inlines_inside_wrapper() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("a"),
+                Event::SoftBreak,
+                text("b"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Str \"a\",SoftBreak,Str \"b\"]]]"
+        );
+    }
+
+    #[test]
+    fn code_style_text_flattens_into_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a "),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("code"),
+                Event::EndTextStyle,
+                text(" b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a \",Str \"code\",Str \" b\"]]"
+        );
+    }
+
+    #[test]
+    fn flattened_style_inside_bold_keeps_bold_open() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("a"),
+                Event::EndTextStyle,
+                text("b"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Str \"a\",Str \"b\"]]]"
+        );
+    }
+
+    #[test]
+    fn bold_inside_flattened_style_closes_before_following_text() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Code),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("a"),
+                Event::EndTextStyle,
+                text("b"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Str \"a\"],Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn mark_style_text_flattens_into_paragraph() {
+        let color = docspec_core::Color::Rgb {
+            r: 255,
+            g: 255,
+            b: 0,
+        };
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a "),
+                start_style(docspec_core::TextStyleKind::Mark(color)),
+                text("mark"),
+                Event::EndTextStyle,
+                text(" b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a \",Str \"mark\",Str \" b\"]]"
+        );
+    }
+
+    #[test]
+    fn text_color_style_text_flattens_into_paragraph() {
+        let color = docspec_core::Color::Rgb { r: 255, g: 0, b: 0 };
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a "),
+                start_style(docspec_core::TextStyleKind::TextColor(color)),
+                text("red"),
+                Event::EndTextStyle,
+                text(" b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a \",Str \"red\",Str \" b\"]]"
+        );
+    }
+
+    #[test]
+    fn start_text_style_outside_inline_block_is_dropped() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("b"),
+                Event::EndTextStyle,
+                Event::EndDocument,
+            ]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn stray_end_text_style_outside_inline_block_is_noop() {
+        assert_eq!(
+            run([start_doc(), Event::EndTextStyle, Event::EndDocument]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn stray_end_text_style_inside_paragraph_does_not_close_paragraph() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                Event::EndTextStyle,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a\",Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn unclosed_style_at_end_of_paragraph_is_closed_defensively() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("a"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Str \"a\"]]]"
+        );
+    }
+
+    #[test]
+    fn unclosed_style_at_end_of_heading_is_closed_defensively() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                start_style(docspec_core::TextStyleKind::Italic),
+                text("x"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Emph [Str \"x\"]]]"
+        );
+    }
+
+    #[test]
+    fn unclosed_style_at_end_of_document_is_closed_defensively() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("a"),
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Str \"a\"]]]"
         );
     }
 }


### PR DESCRIPTION
Maps `StartTextStyle` { Bold, Italic, Strikethrough, Underline, Subscript, Superscript } to pandoc `Strong`/`Emph`/`Strikeout`/`Underline`/`Subscript`/`Superscript` wrappers. Works inside paragraphs and headings (and nested). `Code`/`Mark`/`TextColor` continue to flatten until separate work lands.

Real-pandoc CLI round-trip verified through markdown.