### PR TITLE
Minimal list support

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -17,12 +17,14 @@ architecture, and the event protocol.
   - `<w:highlight w:val="namedColor">` — highlight color using the 17-entry ECMA-376 named palette. Emitted as `StartTextStyle { kind: Mark(Color::Rgb { r, g, b }) }`. `w:val="none"` and unknown names are silently dropped.
   - `<w:shd w:fill="HEX">` — background fill, used as a fallback highlight when `<w:highlight>` is absent. Emitted as `StartTextStyle { kind: Mark(Color::Rgb { r, g, b }) }`. `w:fill="auto"` and a missing `w:fill` attribute are silently dropped.
 - Paragraph properties (`<w:pPr>`): `<w:jc>` (alignment — `left`/`start` to Left, `right`/`end` to Right, `center` to Center, `both`/`distribute` to Justify)
+- Lists (`<w:p>` with `<w:numPr>`): ordered (Decimal/LowerAlpha/UpperAlpha/LowerRoman/UpperRoman) and unordered (Disc) — emitted as `Start*ListItem`/`End*ListItem` with `id` (numId stringified), `level` (ilvl), `start` (`Some(1)` on first item per numId), and `style_type`. Per-level classification: same numId can mix ordered and unordered levels.
 - Empty `<w:rPr/>` and `<w:pPr/>` are treated as no properties (default style / alignment None)
 - A `<w:rPr>` or `<w:pPr>` that appears after content in the same parent is silently ignored (per the OOXML spec, both must be the first child element)
 - Hyperlinks (`<w:hyperlink>`): resolved via `word/_rels/document.xml.rels` and emitted as `StartLink`/`EndLink` events around inline content. Supports external URL targets (both Strict and Transitional OOXML relationship Type URIs), anchor-only links (`w:anchor` without `r:id` emits `#fragment`), and tooltips (`w:tooltip` → `StartLink.title`, XML-decoded). When the relationship cannot be resolved, the link wrapper is dropped and content passes through as plain runs.
 - Structured Document Tags (`<w:sdt>`) — the content of an SDT is emitted normally. The property containers `<w:sdtPr>` and `<w:sdtEndPr>` are dropped.
 - Tracked insertions and moves (`<w:ins>`, `<w:moveTo>`) — the inserted/moved-in content is emitted (accept-changes semantics).
-- Emits: `EndDocument`, `EndLink`, `EndParagraph`, `EndTable`, `EndTableCell`, `EndTableHeader`, `EndTableRow`, `EndTextStyle`, `LineBreak`, `StartDocument`, `StartLink`, `StartParagraph`, `StartTable`, `StartTableCell`, `StartTableHeader`, `StartTableRow`, `StartTextStyle`, `Text`
+- Hyperlinks (`<w:hyperlink>`): resolved via `word/_rels/document.xml.rels` and emitted as `StartLink`/`EndLink` events around inline content. Supports external URL targets (both Strict and Transitional OOXML relationship Type URIs), anchor-only links (`w:anchor` without `r:id` emits `#fragment`), and tooltips (`w:tooltip` → `StartLink.title`, XML-decoded). When the relationship cannot be resolved, the link wrapper is dropped and content passes through as plain runs.
+- Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`, `EndTableRow`, `EndTable`, `StartLink`, `EndLink`, `StartOrderedListItem`, `EndOrderedListItem`, `StartUnorderedListItem`, `EndUnorderedListItem`, `EndDocument`
 - Symbol font character normalization for Wingdings, Wingdings 2, Wingdings 3, Webdings, and Symbol fonts — codepoints are mapped to their Unicode equivalents; unmapped codepoints are dropped
 - Compression: `Stored` and `Deflated` only
 
@@ -44,7 +46,7 @@ The XML elements listed below are the reader's denylist — their entire subtree
 - `<w:rFonts>` (general font tracking is not exposed as events, *except for symbol font resolution (Wingdings, Wingdings 2, Wingdings 3, Webdings, Symbol) which is used internally to normalize codepoints to Unicode*)
 - `themeColor` / `themeTint` / `themeShade` attributes on `<w:color>` and `<w:shd>` — silently dropped. The reader does not parse `styles.xml` or `theme1.xml`, so theme-referenced colors cannot be resolved. Future work.
 - Revision tracking (`<w:rPrChange>`, `<w:pPrChange>`)
-- Advanced paragraph layout beyond alignment: `<w:numPr>`, `<w:ind>`, `<w:tabs>`, `<w:framePr>`, `<w:sectPr>`
+- Advanced paragraph layout beyond alignment: `<w:ind>`, `<w:tabs>`, `<w:framePr>`, `<w:sectPr>`
 - `<w:rPr>` nested inside `<w:pPr>` (paragraph mark / pilcrow run properties)
 - BiDi-aware logical alignment (`start`/`end` flipping based on paragraph direction is not tracked)
 - Math (`m:rPr`) and DrawingML (`a:rPr`) namespaces
@@ -52,13 +54,25 @@ The XML elements listed below are the reader's denylist — their entire subtree
 - Header rows in nested tables — only the outermost table honors `<w:tblHeader>`
 - Table-level property exceptions (`<w:tblPrEx>`) — silently ignored (consistent with `<w:tblPr>`)
 - Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual fields, `<w:tcPr>` visual fields, `<w:tblGrid>`) — silently dropped
-- Lists
 - Drawings and images (`<w:drawing>`, `<w:pict>`)
 - Comments, footnotes, headers, footers
 - Document metadata
 - Tracked deletions and moves-from (`<w:del>`, `<w:moveFrom>`) — silently dropped (accept-changes semantics). Their text content uses `<w:delText>` which is not part of the reader's text-matching set.
 - Structured document tag properties (`<w:sdtPr>`, `<w:sdtEndPr>`) — metadata containers; subtree dropped.
 - Field-code hyperlinks (`<w:fldChar>` + `<w:instrText>HYPERLINK ...`): legacy form not currently supported; only the modern `<w:hyperlink>` element is recognized.
+
+### Lists (V1 cuts)
+
+The following list features are intentionally out of scope for V1:
+- No `<w:start>` element parsing — `start` is always `Some(1)` on the first item of each list, `None` thereafter
+- No `<w:lvlOverride>` resolution — abstractNum's level definitions are authoritative
+- No picture bullets (`<w:lvlPicBulletId>`) — picture-bullet levels emit `Disc`
+- No style-linked lists (`<w:numStyleLink>`, `<w:styleLink>`) — fall back to `Decimal` defaults
+- No continuation-paragraph attachment — paragraphs without `<w:numPr>` between list items emit `StartParagraph` and close the list stack
+- `<w:multiLevelType>` is ignored — per-level `<w:numFmt>` is authoritative (§17.9.12)
+- No per-level marker text (`<w:lvlText>`) — not parsed
+- No level-specific font, color, or indent
+- No per-level resolution for synthesised phantom levels — when the first authored item appears at `ilvl > 0`, intermediate levels inherit the target item's ordered/unordered classification and use `Decimal`/`Disc` defaults instead of resolving each phantom level's own `numFmt`
 
 ## Streaming Guarantee
 

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -11,6 +11,8 @@ use crate::properties;
 use crate::rels::HyperlinkMap;
 use crate::styles::StyleList;
 
+const MAX_LIST_LEVEL: u32 = 8;
+
 /// Document processing phase.
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum Phase {
@@ -26,7 +28,7 @@ enum Phase {
 ///
 /// Set in `ensure_paragraph_started()` based on `pending_paragraph_classification`.
 /// Consumed in `end_paragraph()` to emit the matching End event.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 enum ParagraphBlockKind {
     /// Plain paragraph (default).
     Paragraph,
@@ -36,17 +38,43 @@ enum ParagraphBlockKind {
     BlockQuote,
     /// Preformatted / code block.
     Preformatted,
+    /// Ordered list item at the given nesting depth.
+    OrderedListItem {
+        num_id: u32,
+        ilvl: u32,
+        start: Option<u64>,
+        style_type: docspec_core::ListStyleType,
+    },
+    /// Unordered list item at the given nesting depth.
+    UnorderedListItem {
+        num_id: u32,
+        ilvl: u32,
+        style_type: docspec_core::ListStyleType,
+    },
+}
+
+/// One open level on the list nesting stack.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+struct ListStackEntry {
+    /// The w:numId of the list this entry belongs to.
+    num_id: u32,
+    /// The 0-indexed nesting depth (w:ilvl).
+    ilvl: u32,
+    /// Whether this entry's level is ordered (true) or unordered (false).
+    is_ordered: bool,
 }
 
 /// Bundle of package-level data the document reader consults during streaming.
 ///
-/// Forward-compatible: additional package parts (theme, numbering, settings)
+/// Forward-compatible: additional package parts (theme, settings)
 /// will be added as fields here without breaking the constructor signature.
 pub struct DocxData {
     /// Styles loaded from the styles part, used to classify paragraph and run styles.
     pub style_list: StyleList,
     /// Map of relationship Id → Target URL for every <w:hyperlink> r:id reference. Resolved from word/_rels/document.xml.rels at package-open time; empty if the rels file is absent or contains no hyperlink relationships.
     pub hyperlink_map: HyperlinkMap,
+    /// Numbering definitions loaded from the numbering part, used to resolve list styles.
+    pub numbering: crate::numbering::MinimalNumbering,
 }
 
 /// Deferred-emission state for an open <w:hyperlink>.
@@ -181,6 +209,21 @@ pub struct DocumentReader {
     /// Some when a hyperlink has been opened but possibly before its
     /// `StartLink` has been flushed. None when no hyperlink is open.
     pending_link: Option<PendingLink>,
+    /// Open list nesting stack. Each entry represents one open list level.
+    list_stack: Vec<ListStackEntry>,
+    /// Set of numIds whose first item has been emitted document-wide.
+    /// Persists across non-list paragraph breaks.
+    seen_lists: std::collections::HashSet<u32>,
+    /// (numId, ilvl) captured from `<w:numPr>` during `<w:pPr>` parsing.
+    /// Consumed by `ensure_paragraph_started`.
+    pending_paragraph_list: Option<(u32, u32)>,
+    /// True while inside `<w:numPr>` and capturing children.
+    /// Mirrors the `in_ppr` field pattern.
+    in_numpr: bool,
+    /// w:numId captured from `<w:numId w:val="..."/>` inside `<w:numPr>` (None until seen).
+    pending_num_pr_id: Option<u32>,
+    /// w:ilvl captured from `<w:ilvl w:val="..."/>` inside `<w:numPr>` (None until seen).
+    pending_num_pr_ilvl: Option<u32>,
     /// The quick-xml reader streaming from the document entry.
     xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
 }
@@ -227,7 +270,13 @@ impl fmt::Debug for DocumentReader {
             .field("data", &"<DocxData>")
             .field("hyperlink_map", &self.hyperlink_map)
             .field("hyperlink_depth", &self.hyperlink_depth)
-            .field("pending_link", &pending_link);
+            .field("pending_link", &pending_link)
+            .field("list_stack", &self.list_stack)
+            .field("seen_lists", &self.seen_lists)
+            .field("pending_paragraph_list", &self.pending_paragraph_list)
+            .field("in_numpr", &self.in_numpr)
+            .field("pending_num_pr_id", &self.pending_num_pr_id)
+            .field("pending_num_pr_ilvl", &self.pending_num_pr_ilvl);
         if std::env::var_os("DOCSPEC_DEBUG_DEFERRED_TABLE_SCAFFOLD").is_some() {
             debug
                 .field("in_tcpr", &self.in_tcpr)
@@ -256,6 +305,7 @@ impl DocumentReader {
         let DocxData {
             style_list,
             hyperlink_map,
+            numbering,
         } = data;
         Self {
             buf: Vec::with_capacity(4096),
@@ -285,6 +335,7 @@ impl DocumentReader {
             data: DocxData {
                 style_list,
                 hyperlink_map: HyperlinkMap::default(),
+                numbering,
             },
             hyperlink_map,
             in_tcpr: false,
@@ -300,6 +351,12 @@ impl DocumentReader {
             header_band_open: false,
             hyperlink_depth: 0,
             pending_link: None,
+            list_stack: Vec::new(),
+            seen_lists: std::collections::HashSet::new(),
+            pending_paragraph_list: None,
+            in_numpr: false,
+            pending_num_pr_id: None,
+            pending_num_pr_ilvl: None,
             xml,
         }
     }
@@ -350,8 +407,10 @@ impl DocumentReader {
             }
         }
         self.hyperlink_depth = 0;
-        let end_event = match self.current_paragraph_block {
-            ParagraphBlockKind::Paragraph => Event::EndParagraph,
+        let end_event = match &self.current_paragraph_block {
+            ParagraphBlockKind::Paragraph
+            | ParagraphBlockKind::OrderedListItem { .. }
+            | ParagraphBlockKind::UnorderedListItem { .. } => Event::EndParagraph,
             ParagraphBlockKind::Heading { .. } => Event::EndHeading,
             ParagraphBlockKind::BlockQuote => Event::EndBlockQuote,
             ParagraphBlockKind::Preformatted => Event::EndPreformatted,
@@ -361,10 +420,91 @@ impl DocumentReader {
         self.in_text = false;
         self.pending_text.clear();
         self.in_ppr = false;
+        self.in_numpr = false;
+        self.pending_num_pr_id = None;
+        self.pending_num_pr_ilvl = None;
         self.pending_paragraph_alignment = None;
         self.pending_paragraph_classification = None;
         self.current_paragraph_block = ParagraphBlockKind::Paragraph;
         self.paragraph_started_emitted = false;
+    }
+
+    fn flush_list_stack(&mut self) {
+        while let Some(entry) = self.list_stack.pop() {
+            let event = if entry.is_ordered {
+                Event::EndOrderedListItem
+            } else {
+                Event::EndUnorderedListItem
+            };
+            self.queue.push_back(event);
+        }
+    }
+
+    fn compute_start(&mut self, num_id: u32) -> Option<u64> {
+        self.seen_lists.insert(num_id).then_some(1)
+    }
+
+    fn reconcile_list_stack(&mut self, num_id: u32, ilvl: u32, is_ordered: bool) {
+        while let Some(top) = self.list_stack.last().copied() {
+            match top.ilvl.cmp(&ilvl) {
+                core::cmp::Ordering::Greater => {
+                    self.list_stack.pop();
+                    let end = if top.is_ordered {
+                        Event::EndOrderedListItem
+                    } else {
+                        Event::EndUnorderedListItem
+                    };
+                    self.queue.push_back(end);
+                }
+                core::cmp::Ordering::Equal => {
+                    self.list_stack.pop();
+                    let end = if top.is_ordered {
+                        Event::EndOrderedListItem
+                    } else {
+                        Event::EndUnorderedListItem
+                    };
+                    self.queue.push_back(end);
+                    break;
+                }
+                core::cmp::Ordering::Less => break,
+            }
+        }
+
+        let target_depth = usize::try_from(ilvl).unwrap_or(usize::MAX);
+        while self.list_stack.len() < target_depth {
+            let phantom_ilvl = u32::try_from(self.list_stack.len()).unwrap_or(u32::MAX);
+            let phantom_style = if is_ordered {
+                docspec_core::ListStyleType::Decimal
+            } else {
+                docspec_core::ListStyleType::Disc
+            };
+            let start_event = if is_ordered {
+                Event::StartOrderedListItem {
+                    id: Some(num_id.to_string()),
+                    level: phantom_ilvl,
+                    start: None,
+                    style_type: phantom_style,
+                }
+            } else {
+                Event::StartUnorderedListItem {
+                    id: Some(num_id.to_string()),
+                    level: phantom_ilvl,
+                    style_type: phantom_style,
+                }
+            };
+            self.list_stack.push(ListStackEntry {
+                num_id,
+                ilvl: phantom_ilvl,
+                is_ordered,
+            });
+            self.queue.push_back(start_event);
+        }
+
+        self.list_stack.push(ListStackEntry {
+            num_id,
+            ilvl,
+            is_ordered,
+        });
     }
 
     fn flush_pending_text(&mut self) {
@@ -583,6 +723,20 @@ impl DocumentReader {
                 self.pending_row_is_header =
                     properties::parse_on_off(read_val_attribute(tag).as_deref());
             }
+            b"numId" if self.in_numpr => {
+                if let Some(val) = read_val_attribute(tag) {
+                    if let Ok(n) = val.parse::<u32>() {
+                        self.pending_num_pr_id = Some(n);
+                    }
+                }
+            }
+            b"ilvl" if self.in_numpr => {
+                if let Some(val) = read_val_attribute(tag) {
+                    if let Ok(n) = val.parse::<u32>() {
+                        self.pending_num_pr_ilvl = Some(n);
+                    }
+                }
+            }
             b"vMerge" if self.in_tcpr => {
                 // vMerge (rowspan) deferred — requires event model change or table buffering, out of scope
             }
@@ -638,6 +792,15 @@ impl DocumentReader {
 
         match local {
             b"p" if self.in_paragraph => self.end_paragraph(),
+            b"numPr" if self.in_numpr => {
+                if let Some(num_id) = self.pending_num_pr_id {
+                    let ilvl = self.pending_num_pr_ilvl.unwrap_or(0);
+                    self.pending_paragraph_list = Some((num_id, ilvl));
+                }
+                self.in_numpr = false;
+                self.pending_num_pr_id = None;
+                self.pending_num_pr_ilvl = None;
+            }
             b"pPr" if self.in_ppr => {
                 self.ensure_paragraph_started();
                 self.in_ppr = false;
@@ -681,6 +844,7 @@ impl DocumentReader {
                 self.in_text = false;
             }
             b"tbl" => {
+                self.flush_list_stack();
                 self.table_depth = self.table_depth.saturating_sub(1);
                 self.queue.push_back(Event::EndTable);
             }
@@ -699,6 +863,7 @@ impl DocumentReader {
             }
             b"tc" => {
                 self.ensure_cell_started();
+                self.flush_list_stack();
                 if self.current_cell_is_header && self.table_depth == 1 {
                     self.queue.push_back(Event::EndTableHeader);
                 } else {
@@ -727,6 +892,7 @@ impl DocumentReader {
         if self.in_paragraph {
             self.end_paragraph();
         }
+        self.flush_list_stack();
         self.queue.push_back(Event::EndDocument);
         self.phase = Phase::Finished;
     }
@@ -781,6 +947,11 @@ impl DocumentReader {
                 self.pending_paragraph_classification = read_val_attribute(tag)
                     .filter(|s| !s.is_empty())
                     .and_then(|s| self.data.style_list.classify(&s));
+            }
+            (b"numPr", _) if self.in_ppr && !self.paragraph_started_emitted => {
+                self.in_numpr = true;
+                self.pending_num_pr_id = None;
+                self.pending_num_pr_ilvl = None;
             }
             (b"rPr", _) if self.in_ppr => {
                 self.denied_stack.push(DeniedKind::RPr);
@@ -871,6 +1042,7 @@ impl DocumentReader {
         match local {
             b"tbl" => {
                 self.ensure_cell_started();
+                self.flush_list_stack();
                 self.table_depth = self.table_depth.saturating_add(1);
                 if self.table_depth == 1 {
                     self.header_band_open = true;
@@ -985,37 +1157,123 @@ impl DocumentReader {
         self.paragraph_started_emitted = false;
         self.pending_paragraph_alignment = None;
         self.pending_paragraph_classification = None;
+        self.pending_paragraph_list = None;
         self.current_paragraph_block = ParagraphBlockKind::Paragraph;
     }
 
     /// Queues the appropriate Start event once paragraph properties have been parsed.
     fn ensure_paragraph_started(&mut self) {
         if self.in_paragraph && !self.paragraph_started_emitted {
+            let list_classification = match self.pending_paragraph_list.take() {
+                None => None,
+                Some((num_id, raw_ilvl)) => {
+                    let ilvl = core::cmp::min(raw_ilvl, MAX_LIST_LEVEL);
+                    let result = self.data.numbering.resolve(num_id, ilvl);
+                    result
+                        .is_list
+                        .then_some((num_id, ilvl, result.is_ordered, result.style_type))
+                }
+            };
+
             let kind = match self.pending_paragraph_classification.take() {
                 Some(crate::styles::StyleClassification::Heading { level }) => {
+                    self.flush_list_stack();
                     ParagraphBlockKind::Heading { level }
                 }
                 Some(crate::styles::StyleClassification::BlockQuote) => {
+                    self.flush_list_stack();
                     ParagraphBlockKind::BlockQuote
                 }
-                Some(crate::styles::StyleClassification::Code) => ParagraphBlockKind::Preformatted,
-                _ => ParagraphBlockKind::Paragraph,
+                Some(crate::styles::StyleClassification::Code) => {
+                    self.flush_list_stack();
+                    ParagraphBlockKind::Preformatted
+                }
+                _ => match list_classification {
+                    None => {
+                        self.flush_list_stack();
+                        ParagraphBlockKind::Paragraph
+                    }
+                    Some((num_id, ilvl, is_ordered, style_type)) => {
+                        self.reconcile_list_stack(num_id, ilvl, is_ordered);
+                        let start = self.compute_start(num_id);
+                        if is_ordered {
+                            ParagraphBlockKind::OrderedListItem {
+                                num_id,
+                                ilvl,
+                                start,
+                                style_type,
+                            }
+                        } else {
+                            ParagraphBlockKind::UnorderedListItem {
+                                num_id,
+                                ilvl,
+                                style_type,
+                            }
+                        }
+                    }
+                },
             };
             self.current_paragraph_block = kind;
-            let event = match kind {
-                ParagraphBlockKind::Paragraph => Event::StartParagraph {
+            self.emit_paragraph_start_for_current_block();
+            self.paragraph_started_emitted = true;
+        }
+    }
+
+    fn emit_paragraph_start_for_current_block(&mut self) {
+        match &self.current_paragraph_block {
+            ParagraphBlockKind::Paragraph => {
+                self.queue.push_back(Event::StartParagraph {
                     alignment: self.pending_paragraph_alignment.clone(),
                     id: None,
-                },
-                ParagraphBlockKind::Heading { level } => Event::StartHeading { level, id: None },
-                ParagraphBlockKind::BlockQuote => Event::StartBlockQuote { id: None },
-                ParagraphBlockKind::Preformatted => Event::StartPreformatted {
+                });
+            }
+            ParagraphBlockKind::Heading { level } => {
+                self.queue.push_back(Event::StartHeading {
+                    level: *level,
+                    id: None,
+                });
+            }
+            ParagraphBlockKind::BlockQuote => {
+                self.queue.push_back(Event::StartBlockQuote { id: None });
+            }
+            ParagraphBlockKind::Preformatted => {
+                self.queue.push_back(Event::StartPreformatted {
                     id: None,
                     syntax: None,
-                },
-            };
-            self.queue.push_back(event);
-            self.paragraph_started_emitted = true;
+                });
+            }
+            ParagraphBlockKind::OrderedListItem {
+                num_id,
+                ilvl,
+                start,
+                style_type,
+            } => {
+                self.queue.push_back(Event::StartOrderedListItem {
+                    id: Some(num_id.to_string()),
+                    level: *ilvl,
+                    start: *start,
+                    style_type: style_type.clone(),
+                });
+                self.queue.push_back(Event::StartParagraph {
+                    alignment: self.pending_paragraph_alignment.clone(),
+                    id: None,
+                });
+            }
+            ParagraphBlockKind::UnorderedListItem {
+                num_id,
+                ilvl,
+                style_type,
+            } => {
+                self.queue.push_back(Event::StartUnorderedListItem {
+                    id: Some(num_id.to_string()),
+                    level: *ilvl,
+                    style_type: style_type.clone(),
+                });
+                self.queue.push_back(Event::StartParagraph {
+                    alignment: self.pending_paragraph_alignment.clone(),
+                    id: None,
+                });
+            }
         }
     }
 
@@ -1194,6 +1452,8 @@ mod tests {
     use core::fmt::Write as _;
     use std::io::{Cursor, Read};
 
+    use docspec_core::ListStyleType;
+
     use super::*;
 
     fn styles_xml(body: &str) -> String {
@@ -1212,7 +1472,62 @@ mod tests {
         DocxData {
             style_list,
             hyperlink_map: HyperlinkMap::default(),
+            numbering: crate::numbering::MinimalNumbering::new(),
         }
+    }
+
+    fn numbering_xml(body: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+{body}
+</w:numbering>"#
+        )
+    }
+
+    fn decimal_numbering() -> crate::numbering::MinimalNumbering {
+        let xml = numbering_xml(
+            r#"<w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:numFmt w:val="decimal"/></w:lvl>
+</w:abstractNum>
+<w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>"#,
+        );
+        crate::numbering::parse_numbering(Cursor::new(xml.into_bytes()))
+            .expect("valid numbering XML")
+    }
+
+    fn make_reader_with_numbering(
+        document_xml: &str,
+        numbering: crate::numbering::MinimalNumbering,
+    ) -> DocumentReader {
+        let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
+        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
+        let data = DocxData {
+            style_list: crate::styles::StyleList::default(),
+            hyperlink_map: HyperlinkMap::default(),
+            numbering,
+        };
+        DocumentReader::from_xml_reader(xml, data)
+    }
+
+    fn list_paragraph(num_id: u32, ilvl: u32, text: &str) -> String {
+        format!(
+            r#"<w:p><w:pPr><w:numPr><w:numId w:val="{num_id}"/><w:ilvl w:val="{ilvl}"/></w:numPr></w:pPr><w:r><w:t>{text}</w:t></w:r></w:p>"#
+        )
+    }
+
+    fn plain_paragraph(text: &str) -> String {
+        format!("<w:p><w:r><w:t>{text}</w:t></w:r></w:p>")
+    }
+
+    fn document_with_body(body: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>{body}</w:body>
+</w:document>"#
+        )
     }
 
     fn make_reader_with_styles(document_xml: &str, styles_body: &str) -> DocumentReader {
@@ -1246,6 +1561,7 @@ mod tests {
         let data = DocxData {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map: HyperlinkMap::default(),
+            numbering: crate::numbering::MinimalNumbering::new(),
         };
         DocumentReader::from_xml_reader(xml, data)
     }
@@ -1259,6 +1575,7 @@ mod tests {
         let data = DocxData {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map,
+            numbering: crate::numbering::MinimalNumbering::new(),
         };
         DocumentReader::from_xml_reader(xml, data)
     }
@@ -1891,5 +2208,580 @@ mod tests {
                 docspec_core::Event::EndDocument,
             ]
         );
+    }
+
+    #[test]
+    fn single_ordered_list_item_emits_correct_events() {
+        let doc = document_with_body(&list_paragraph(1, 0, "item"));
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "item".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_list_items_emit_correct_events() {
+        let body = format!(
+            "{}{}",
+            list_paragraph(1, 0, "parent"),
+            list_paragraph(1, 1, "child")
+        );
+        let doc = document_with_body(&body);
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "parent".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 1,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "child".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn level_decrease_pops_stack_correctly() {
+        let body = format!(
+            "{}{}{}",
+            list_paragraph(1, 0, "one"),
+            list_paragraph(1, 1, "child"),
+            list_paragraph(1, 0, "two")
+        );
+        let doc = document_with_body(&body);
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "one".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 1,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "child".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "two".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_list_paragraph_between_list_items_breaks_list() {
+        let body = format!(
+            "{}{}{}",
+            list_paragraph(1, 0, "one"),
+            plain_paragraph("plain"),
+            list_paragraph(1, 0, "two")
+        );
+        let doc = document_with_body(&body);
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "one".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "plain".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "two".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn document_end_flush_closes_open_list() {
+        let doc = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>{}"#,
+            r#"<w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>item</w:t></w:r>"#
+        );
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "item".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn num_id_zero_sentinel_emits_plain_paragraph() {
+        let doc = document_with_body(&list_paragraph(0, 0, "plain"));
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "plain".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn oversized_list_level_is_clamped_to_eight() {
+        let doc = document_with_body(&list_paragraph(1, 99, "deep"));
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 1,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 2,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 3,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 4,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 5,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 6,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 7,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 8,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "deep".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_item_inside_table_cell_closes_before_cell_end() {
+        let doc = document_with_body(&format!(
+            "<w:tbl><w:tr><w:tc>{}</w:tc></w:tr></w:tbl>",
+            list_paragraph(1, 0, "cell")
+        ));
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartTable { id: None },
+                docspec_core::Event::StartTableRow { id: None },
+                docspec_core::Event::StartTableCell {
+                    colspan: None,
+                    rowspan: None,
+                    id: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "cell".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::EndTableCell,
+                docspec_core::Event::EndTableRow,
+                docspec_core::Event::EndTable,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn table_after_list_item_breaks_list_before_table_start() {
+        let doc = document_with_body(&format!(
+            "{}<w:tbl><w:tr><w:tc>{}</w:tc></w:tr></w:tbl>",
+            list_paragraph(1, 0, "item"),
+            plain_paragraph("cell")
+        ));
+        let mut reader = make_reader_with_numbering(&doc, decimal_numbering());
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "item".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
+                docspec_core::Event::StartTable { id: None },
+                docspec_core::Event::StartTableRow { id: None },
+                docspec_core::Event::StartTableCell {
+                    colspan: None,
+                    rowspan: None,
+                    id: None,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "cell".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndTableCell,
+                docspec_core::Event::EndTableRow,
+                docspec_core::Event::EndTable,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn numpr_with_num_id_and_ilvl_is_consumed_by_paragraph_start() {
+        let doc = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="3"/><w:ilvl w:val="2"/></w:numPr></w:pPr>
+      <w:r><w:t>item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let mut reader = make_reader(doc);
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "item".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+        assert_eq!(reader.pending_paragraph_list, None);
+    }
+
+    #[test]
+    fn numpr_with_num_id_only_defaults_ilvl_to_zero_before_consuming() {
+        let doc = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr>
+      <w:r><w:t>item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let mut reader = make_reader(doc);
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "item".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+        assert_eq!(reader.pending_paragraph_list, None);
+    }
+
+    #[test]
+    fn numpr_without_num_id_leaves_pending_paragraph_list_none() {
+        let doc = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>plain</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let mut reader = make_reader(doc);
+        let events = collect_events(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                docspec_core::Event::StartDocument {
+                    id: None,
+                    language: None,
+                    metadata: None,
+                },
+                docspec_core::Event::StartParagraph {
+                    alignment: None,
+                    id: None,
+                },
+                docspec_core::Event::Text {
+                    content: "plain".to_string(),
+                },
+                docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndDocument,
+            ]
+        );
+        assert_eq!(reader.pending_paragraph_list, None);
     }
 }

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -12,16 +12,18 @@
 //! line breaks (`<w:br>` — including `w:type="page"` and `w:type="column"`, all
 //! emitted as `LineBreak`), tabs (`<w:tab>`, emitted as a `Text` event whose
 //! content is the single character `"\t"`), tables (`<w:tbl>`, `<w:tr>`,
-//! `<w:tc>`), hyperlinks (`<w:hyperlink>` — resolved via
-//! `word/_rels/document.xml.rels` and emitted as `StartLink`/`EndLink` events
-//! around inline content), structured document tags (`<w:sdt>` — content
-//! emitted normally; `<w:sdtPr>`/`<w:sdtEndPr>` dropped), and tracked
-//! insertions and moves (`<w:ins>`, `<w:moveTo>` — accept-changes semantics).
-//! Emits: `EndDocument`, `EndLink`, `EndParagraph`, `EndTable`, `EndTableCell`,
-//! `EndTableHeader`, `EndTableRow`, `EndTextStyle`, `LineBreak`,
-//! `StartDocument`, `StartLink`, `StartParagraph`, `StartTable`,
-//! `StartTableCell`, `StartTableHeader`, `StartTableRow`, `StartTextStyle`,
-//! `Text`.
+//! `<w:tc>`), lists (`<w:p>` with `<w:numPr>` — ordered and unordered),
+//! hyperlinks (`<w:hyperlink>` — resolved via `word/_rels/document.xml.rels`
+//! and emitted as `StartLink`/`EndLink` events around inline content),
+//! structured document tags (`<w:sdt>` — content emitted normally;
+//! `<w:sdtPr>`/`<w:sdtEndPr>` dropped), and tracked insertions and moves
+//! (`<w:ins>`, `<w:moveTo>` — accept-changes semantics).
+//! Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`,
+//! `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`,
+//! `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`,
+//! `EndTableRow`, `EndTable`, `StartLink`, `EndLink`, `StartOrderedListItem`,
+//! `EndOrderedListItem`, `StartUnorderedListItem`, `EndUnorderedListItem`,
+//! `EndDocument`.
 //!
 //! The elements listed under "Out of scope" are the reader's denylist — their
 //! entire subtree is silently dropped. Every other element (known or unknown)
@@ -37,7 +39,6 @@
 //! - Table-level property exceptions (`<w:tblPrEx>`) — silently ignored
 //! - Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual
 //!   fields, `<w:tcPr>` visual fields, `<w:tblGrid>`)
-//! - Lists
 //! - Drawings and images (`<w:drawing>`, `<w:pict>`)
 //! - Comments, footnotes, headers, footers
 //! - Document metadata
@@ -46,6 +47,10 @@
 //! - Field-code hyperlinks (`<w:fldChar>` + `<w:instrText>HYPERLINK ...`):
 //!   legacy form not currently supported; only the modern `<w:hyperlink>`
 //!   element is recognized.
+//!
+//! # Lists
+//!
+//! See the crate README for V1 list semantics and limitations.
 //!
 //! # Streaming Guarantee
 //!
@@ -72,6 +77,7 @@
 extern crate alloc;
 
 mod document;
+mod numbering;
 mod package;
 mod properties;
 mod rels;
@@ -131,11 +137,12 @@ impl DocxReader {
     /// cannot be opened. Returns [`Error::Io`] for I/O failures.
     #[inline]
     pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
-        let (style_list, hyperlink_map, stream) = package::open_package(reader)?;
+        let (style_list, numbering, hyperlink_map, stream) = package::open_package(reader)?;
         let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
         let data = document::DocxData {
             style_list,
             hyperlink_map,
+            numbering,
         };
         Ok(Self {
             inner: document::DocumentReader::from_xml_reader(xml, data),

--- a/crates/docspec-docx-reader/src/numbering.rs
+++ b/crates/docspec-docx-reader/src/numbering.rs
@@ -1,0 +1,741 @@
+//! DOCX numbering definitions (`numbering.xml`) lookup structures.
+
+use core::fmt;
+use std::{collections::HashMap, io::Read};
+
+use crate::properties;
+use docspec_core::{Error, ListStyleType};
+use quick_xml::{events::Event, XmlVersion};
+
+/// Outcome of a list level definition: either a list with a style, or not a list.
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[non_exhaustive]
+pub enum LevelOutcome {
+    /// Level is not a list (numFmt="none").
+    NotAList,
+    /// Level is a list with the given style.
+    List(ListStyleType),
+}
+
+/// Result of resolving a list item's numId and ilvl to a list style.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct ListLookupResult {
+    /// Whether this is a list item (true) or a regular paragraph (false).
+    pub is_list: bool,
+    /// Whether the list is ordered (true) or unordered (false).
+    pub is_ordered: bool,
+    /// Visual style of the list marker.
+    pub style_type: ListStyleType,
+}
+
+/// Minimal numbering lookup structure mapping numId → abstractNumId → levels.
+pub struct MinimalNumbering {
+    /// Maps abstractNumId to array of level outcomes.
+    abstract_levels: HashMap<u32, [Option<LevelOutcome>; 9]>,
+    /// Maps numId to abstractNumId.
+    num_to_abstract: HashMap<u32, u32>,
+}
+
+impl MinimalNumbering {
+    /// Creates an empty `MinimalNumbering` with no entries.
+    #[inline]
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            abstract_levels: HashMap::new(),
+            num_to_abstract: HashMap::new(),
+        }
+    }
+
+    /// Resolves a numId and ilvl to a list lookup result.
+    ///
+    /// Returns a `ListLookupResult` indicating whether the item is a list,
+    /// whether it is ordered, and its style type. Gracefully degrades on
+    /// missing entries by returning sensible defaults.
+    #[inline]
+    #[must_use]
+    pub fn resolve(&self, num_id: u32, ilvl: u32) -> ListLookupResult {
+        // numId == 0 is a sentinel meaning "paragraph escapes list membership" (§17.9.18)
+        if num_id == 0 {
+            return ListLookupResult {
+                is_list: false,
+                is_ordered: true,
+                style_type: ListStyleType::Decimal,
+            };
+        }
+
+        // Lookup numId → abstractNumId
+        let Some(&abstract_num_id) = self.num_to_abstract.get(&num_id) else {
+            // Unknown numId: graceful degradation
+            return ListLookupResult {
+                is_list: false,
+                is_ordered: true,
+                style_type: ListStyleType::Decimal,
+            };
+        };
+
+        // Lookup abstractNumId → levels array
+        let Some(levels) = self.abstract_levels.get(&abstract_num_id) else {
+            // Unknown abstractNumId: default to ordered decimal list
+            return ListLookupResult {
+                is_list: true,
+                is_ordered: true,
+                style_type: ListStyleType::Decimal,
+            };
+        };
+
+        // Clamp ilvl to 0..=8 (spec max is 8)
+        let clamped_ilvl = usize::try_from(core::cmp::min(ilvl, 8)).unwrap_or(8);
+
+        // Read the level outcome
+        match levels.get(clamped_ilvl).and_then(|opt| opt.as_ref()) {
+            None => {
+                // Level not defined: default to ordered decimal list
+                ListLookupResult {
+                    is_list: true,
+                    is_ordered: true,
+                    style_type: ListStyleType::Decimal,
+                }
+            }
+            Some(LevelOutcome::NotAList) => {
+                // Explicit numFmt="none"
+                ListLookupResult {
+                    is_list: false,
+                    is_ordered: true,
+                    style_type: ListStyleType::Decimal,
+                }
+            }
+            Some(LevelOutcome::List(style)) => {
+                // Determine if ordered based on style
+                let is_ordered = !matches!(
+                    style,
+                    ListStyleType::Disc | ListStyleType::Circle | ListStyleType::Square
+                );
+                ListLookupResult {
+                    is_list: true,
+                    is_ordered,
+                    style_type: style.clone(),
+                }
+            }
+        }
+    }
+}
+
+impl Default for MinimalNumbering {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for MinimalNumbering {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MinimalNumbering")
+            .field("abstract_levels", &self.abstract_levels)
+            .field("num_to_abstract", &self.num_to_abstract)
+            .finish()
+    }
+}
+
+/// Parses DOCX `numbering.xml` into the minimal list lookup structure.
+///
+/// # Errors
+///
+/// Returns an error for I/O failures and malformed XML structure.
+#[inline]
+pub fn parse_numbering<R: Read>(reader: R) -> docspec_core::Result<MinimalNumbering> {
+    let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
+    let mut buf = Vec::new();
+    let mut element_depth: usize = 0;
+    let mut numbering = MinimalNumbering::new();
+
+    let mut current_abstract = None;
+    let mut current_ilvl = None;
+    let mut current_level_outcome = None;
+    let mut current_num = None;
+
+    loop {
+        match xml_reader.read_event_into(&mut buf) {
+            Ok(Event::Start(element)) => {
+                element_depth = element_depth.saturating_add(1);
+                match element.local_name().as_ref() {
+                    b"abstractNum" => {
+                        current_abstract = attr_u32(&xml_reader, &element, b"abstractNumId")?;
+                    }
+                    b"lvl" if current_abstract.is_some() => {
+                        current_ilvl = attr_u32(&xml_reader, &element, b"ilvl")?;
+                        current_level_outcome = None;
+                    }
+                    b"numFmt" if current_abstract.is_some() && current_ilvl.is_some() => {
+                        if let Some(value) = attr_string(&xml_reader, &element, b"val")? {
+                            current_level_outcome = Some(properties::parse_num_fmt(&value));
+                        }
+                    }
+                    b"num" => {
+                        current_num = attr_u32(&xml_reader, &element, b"numId")?;
+                    }
+                    b"abstractNumId" => {
+                        if let (Some(num_id), Some(abstract_num_id)) =
+                            (current_num, attr_u32(&xml_reader, &element, b"val")?)
+                        {
+                            numbering.num_to_abstract.insert(num_id, abstract_num_id);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Ok(Event::Empty(element)) => match element.local_name().as_ref() {
+                b"numFmt" if current_abstract.is_some() && current_ilvl.is_some() => {
+                    if let Some(value) = attr_string(&xml_reader, &element, b"val")? {
+                        current_level_outcome = Some(properties::parse_num_fmt(&value));
+                    }
+                }
+                b"abstractNumId" => {
+                    if let (Some(num_id), Some(abstract_num_id)) =
+                        (current_num, attr_u32(&xml_reader, &element, b"val")?)
+                    {
+                        numbering.num_to_abstract.insert(num_id, abstract_num_id);
+                    }
+                }
+                _ => {}
+            },
+            Ok(Event::End(element)) => {
+                match element.local_name().as_ref() {
+                    b"lvl" => finish_level(
+                        &mut numbering,
+                        current_abstract,
+                        &mut current_ilvl,
+                        &mut current_level_outcome,
+                    ),
+                    b"abstractNum" => current_abstract = None,
+                    b"num" => current_num = None,
+                    _ => {}
+                }
+
+                let Some(next_depth) = element_depth.checked_sub(1) else {
+                    return Err(parse_error("malformed numbering.xml".to_string()));
+                };
+                element_depth = next_depth;
+            }
+            Ok(Event::Eof) => {
+                if element_depth != 0 {
+                    return Err(parse_error("malformed numbering.xml".to_string()));
+                }
+                return Ok(numbering);
+            }
+            Err(err) => {
+                return Err(parse_error(format!("malformed numbering.xml: {err}")));
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+}
+
+fn finish_level(
+    numbering: &mut MinimalNumbering,
+    current_abstract: Option<u32>,
+    current_ilvl: &mut Option<u32>,
+    current_level_outcome: &mut Option<LevelOutcome>,
+) {
+    if let (Some(abstract_num_id), Some(ilvl)) = (current_abstract, *current_ilvl) {
+        let levels = numbering
+            .abstract_levels
+            .entry(abstract_num_id)
+            .or_insert_with(|| core::array::from_fn(|_| None));
+        let clamped_ilvl = usize::try_from(core::cmp::min(ilvl, 8)).unwrap_or(8);
+        if let Some(level) = levels.get_mut(clamped_ilvl) {
+            *level = Some(
+                current_level_outcome
+                    .take()
+                    .unwrap_or(LevelOutcome::List(ListStyleType::Decimal)),
+            );
+        }
+    }
+
+    *current_ilvl = None;
+    *current_level_outcome = None;
+}
+
+fn attr_u32<R: Read>(
+    reader: &quick_xml::Reader<R>,
+    element: &quick_xml::events::BytesStart<'_>,
+    name: &[u8],
+) -> docspec_core::Result<Option<u32>> {
+    let Some(value) = attr_string(reader, element, name)? else {
+        return Ok(None);
+    };
+
+    Ok(value.parse::<u32>().ok())
+}
+
+fn attr_string<R: Read>(
+    reader: &quick_xml::Reader<R>,
+    element: &quick_xml::events::BytesStart<'_>,
+    name: &[u8],
+) -> docspec_core::Result<Option<String>> {
+    for attribute_result in element.attributes() {
+        let attribute = attribute_result
+            .map_err(|err| parse_error(format!("malformed numbering.xml attribute: {err}")))?;
+        if attribute.key.local_name().as_ref() == name {
+            return attribute
+                .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
+                .map(|value| Some(value.into_owned()))
+                .map_err(|err| parse_error(format!("malformed numbering.xml attribute: {err}")));
+        }
+    }
+
+    Ok(None)
+}
+
+fn parse_error(message: String) -> Error {
+    Error::Parse {
+        message,
+        position: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! parse_ok {
+        ($xml:expr) => {{
+            let result = parse_numbering($xml);
+            assert_eq!(result.is_ok(), true);
+            match result {
+                Ok(numbering) => numbering,
+                Err(_) => return,
+            }
+        }};
+    }
+
+    #[test]
+    fn resolve_returns_not_list_for_num_id_zero() {
+        let numbering = MinimalNumbering::new();
+
+        let result = numbering.resolve(0, 0);
+
+        assert!(!result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Decimal);
+    }
+
+    #[test]
+    fn resolve_returns_not_list_for_unknown_num_id() {
+        let numbering = MinimalNumbering::new();
+
+        let result = numbering.resolve(999, 0);
+
+        assert!(!result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Decimal);
+    }
+
+    #[test]
+    fn resolve_returns_decimal_for_unknown_abstract_num_id() {
+        let mut numbering = MinimalNumbering::new();
+        numbering.num_to_abstract.insert(1, 999);
+
+        let result = numbering.resolve(1, 0);
+
+        assert!(result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Decimal);
+    }
+
+    #[test]
+    fn resolve_returns_decimal_for_missing_ilvl_slot() {
+        let mut numbering = MinimalNumbering::new();
+        numbering.num_to_abstract.insert(1, 1);
+        numbering
+            .abstract_levels
+            .insert(1, core::array::from_fn(|_| None));
+
+        let result = numbering.resolve(1, 0);
+
+        assert!(result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Decimal);
+    }
+
+    #[test]
+    fn resolve_returns_not_list_for_not_a_list_slot() {
+        let mut numbering = MinimalNumbering::new();
+        numbering.num_to_abstract.insert(1, 1);
+        let mut levels = core::array::from_fn(|_| None);
+        levels[0] = Some(LevelOutcome::NotAList);
+        numbering.abstract_levels.insert(1, levels);
+
+        let result = numbering.resolve(1, 0);
+
+        assert!(!result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Decimal);
+    }
+
+    #[test]
+    fn resolve_returns_lower_alpha_for_level_with_lower_alpha() {
+        let mut numbering = MinimalNumbering::new();
+        numbering.num_to_abstract.insert(1, 1);
+        let mut levels = core::array::from_fn(|_| None);
+        levels[0] = Some(LevelOutcome::List(ListStyleType::LowerAlpha));
+        numbering.abstract_levels.insert(1, levels);
+
+        let result = numbering.resolve(1, 0);
+
+        assert!(result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::LowerAlpha);
+    }
+
+    #[test]
+    fn resolve_returns_correct_style_for_each_variant() {
+        let test_cases = vec![
+            (ListStyleType::Decimal, true),
+            (ListStyleType::LowerAlpha, true),
+            (ListStyleType::UpperAlpha, true),
+            (ListStyleType::LowerRoman, true),
+            (ListStyleType::UpperRoman, true),
+            (ListStyleType::Disc, false),
+            (ListStyleType::Circle, false),
+            (ListStyleType::Square, false),
+        ];
+
+        for (style, expected_ordered) in test_cases {
+            let mut numbering = MinimalNumbering::new();
+            numbering.num_to_abstract.insert(1, 1);
+            let mut levels = core::array::from_fn(|_| None);
+            levels[0] = Some(LevelOutcome::List(style.clone()));
+            numbering.abstract_levels.insert(1, levels);
+
+            let result = numbering.resolve(1, 0);
+
+            assert!(result.is_list, "Failed for style: {style:?}");
+            assert_eq!(
+                result.is_ordered, expected_ordered,
+                "Failed for style: {style:?}"
+            );
+            assert_eq!(result.style_type, style, "Failed for style: {style:?}");
+        }
+    }
+
+    #[test]
+    fn resolve_clamps_ilvl_above_eight() {
+        let mut numbering = MinimalNumbering::new();
+        numbering.num_to_abstract.insert(1, 1);
+        let mut levels = core::array::from_fn(|_| None);
+        levels[8] = Some(LevelOutcome::List(ListStyleType::UpperRoman));
+        numbering.abstract_levels.insert(1, levels);
+
+        let result = numbering.resolve(1, 15);
+
+        assert!(result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::UpperRoman);
+    }
+
+    #[test]
+    fn parse_numbering_returns_empty_for_empty_xml() {
+        let xml = br#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>"#;
+
+        let numbering = parse_ok!(&xml[..]);
+
+        assert_eq!(numbering.abstract_levels.len(), 0);
+        assert_eq!(numbering.num_to_abstract.len(), 0);
+    }
+
+    #[test]
+    fn parse_numbering_loads_single_bullet_definition() {
+        let xml = br#"
+            <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                <w:abstractNum w:abstractNumId="7">
+                    <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/></w:lvl>
+                </w:abstractNum>
+                <w:num w:numId="42"><w:abstractNumId w:val="7"/></w:num>
+            </w:numbering>
+        "#;
+
+        let numbering = parse_ok!(&xml[..]);
+        let result = numbering.resolve(42, 0);
+
+        assert_eq!(
+            result,
+            ListLookupResult {
+                is_list: true,
+                is_ordered: false,
+                style_type: ListStyleType::Disc,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numbering_handles_mixed_format_levels() {
+        let xml = br#"
+            <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                <w:abstractNum w:abstractNumId="3">
+                    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+                    <w:lvl w:ilvl="1"><w:numFmt w:val="bullet"/></w:lvl>
+                    <w:lvl w:ilvl="2"><w:numFmt w:val="lowerLetter"/></w:lvl>
+                </w:abstractNum>
+                <w:num w:numId="9"><w:abstractNumId w:val="3"/></w:num>
+            </w:numbering>
+        "#;
+
+        let numbering = parse_ok!(&xml[..]);
+
+        assert_eq!(
+            numbering.resolve(9, 0),
+            ListLookupResult {
+                is_list: true,
+                is_ordered: true,
+                style_type: ListStyleType::Decimal,
+            }
+        );
+        assert_eq!(
+            numbering.resolve(9, 1),
+            ListLookupResult {
+                is_list: true,
+                is_ordered: false,
+                style_type: ListStyleType::Disc,
+            }
+        );
+        assert_eq!(
+            numbering.resolve(9, 2),
+            ListLookupResult {
+                is_list: true,
+                is_ordered: true,
+                style_type: ListStyleType::LowerAlpha,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numbering_skips_malformed_elements() {
+        let xml = br#"
+            <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                <w:abstractNum>
+                    <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/></w:lvl>
+                </w:abstractNum>
+                <w:abstractNum w:abstractNumId="2">
+                    <w:lvl w:ilvl="not-a-number"><w:numFmt w:val="bullet"/></w:lvl>
+                </w:abstractNum>
+                <w:num w:numId="5"></w:num>
+            </w:numbering>
+        "#;
+
+        let numbering = parse_ok!(&xml[..]);
+
+        assert_eq!(numbering.abstract_levels.len(), 0);
+        assert_eq!(numbering.num_to_abstract.len(), 0);
+        assert_eq!(
+            numbering.resolve(5, 0),
+            ListLookupResult {
+                is_list: false,
+                is_ordered: true,
+                style_type: ListStyleType::Decimal,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numbering_returns_err_on_truncated_xml() {
+        let xml = br#"<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:abstractNum w:abstractNumId="1"><w:lvl"#;
+
+        let result = parse_numbering(&xml[..]);
+
+        assert!(matches!(result, Err(Error::Parse { .. })));
+    }
+
+    #[test]
+    fn parse_numbering_defaults_missing_numfmt_to_decimal() {
+        let xml = br#"
+            <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                <w:abstractNum w:abstractNumId="1">
+                    <w:lvl w:ilvl="0"></w:lvl>
+                </w:abstractNum>
+                <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+            </w:numbering>
+        "#;
+
+        let numbering = parse_ok!(&xml[..]);
+
+        assert_eq!(
+            numbering.resolve(1, 0),
+            ListLookupResult {
+                is_list: true,
+                is_ordered: true,
+                style_type: ListStyleType::Decimal,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numbering_handles_multiple_abstract_nums_and_nums() {
+        let xml = br#"
+            <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                <w:abstractNum w:abstractNumId="1"><w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl></w:abstractNum>
+                <w:abstractNum w:abstractNumId="2"><w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/></w:lvl></w:abstractNum>
+                <w:abstractNum w:abstractNumId="3"><w:lvl w:ilvl="0"><w:numFmt w:val="upperRoman"/></w:lvl></w:abstractNum>
+                <w:num w:numId="11"><w:abstractNumId w:val="1"/></w:num>
+                <w:num w:numId="22"><w:abstractNumId w:val="2"/></w:num>
+                <w:num w:numId="33"><w:abstractNumId w:val="3"/></w:num>
+            </w:numbering>
+        "#;
+
+        let numbering = parse_ok!(&xml[..]);
+
+        assert_eq!(
+            numbering.resolve(11, 0),
+            ListLookupResult {
+                is_list: true,
+                is_ordered: true,
+                style_type: ListStyleType::Decimal,
+            }
+        );
+        assert_eq!(
+            numbering.resolve(22, 0),
+            ListLookupResult {
+                is_list: true,
+                is_ordered: false,
+                style_type: ListStyleType::Disc,
+            }
+        );
+        assert_eq!(
+            numbering.resolve(33, 0),
+            ListLookupResult {
+                is_list: true,
+                is_ordered: true,
+                style_type: ListStyleType::UpperRoman,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_numbering_ignores_lvl_outside_abstract_num() {
+        let xml = br#"
+            <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/></w:lvl>
+            </w:numbering>
+        "#;
+
+        let numbering = parse_ok!(&xml[..]);
+
+        assert_eq!(numbering.abstract_levels.len(), 0);
+        assert_eq!(numbering.num_to_abstract.len(), 0);
+    }
+
+    #[test]
+    fn parse_numbering_ignores_abstract_num_id_outside_num() {
+        let xml = br#"
+            <w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+                <w:abstractNumId w:val="9"/>
+            </w:numbering>
+        "#;
+
+        let numbering = parse_ok!(&xml[..]);
+
+        assert_eq!(numbering.abstract_levels.len(), 0);
+        assert_eq!(numbering.num_to_abstract.len(), 0);
+    }
+
+    #[test]
+    fn resolve_returns_decimal_when_abstract_num_id_not_in_abstract_levels() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:num w:numId="1">
+    <w:abstractNumId w:val="99"/>
+  </w:num>
+</w:numbering>"#;
+        let numbering = parse_ok!(std::io::Cursor::new(xml));
+        let result = numbering.resolve(1, 0);
+        assert!(result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Decimal);
+    }
+
+    #[test]
+    fn resolve_returns_decimal_when_ilvl_not_defined_in_levels() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+        let numbering = parse_ok!(std::io::Cursor::new(xml));
+        let result = numbering.resolve(1, 5);
+        assert!(result.is_list);
+        assert!(result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Decimal);
+    }
+
+    #[test]
+    fn default_creates_empty_numbering() {
+        let numbering = MinimalNumbering::default();
+        let result = numbering.resolve(1, 0);
+        assert!(!result.is_list);
+    }
+
+    #[test]
+    fn debug_format_includes_struct_name() {
+        let numbering = MinimalNumbering::new();
+        let debug_str = format!("{numbering:?}");
+        assert!(debug_str.contains("MinimalNumbering"));
+    }
+
+    #[test]
+    fn parse_numbering_handles_non_self_closing_num_fmt() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0">
+      <w:numFmt w:val="bullet"></w:numFmt>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+        let numbering = parse_ok!(std::io::Cursor::new(xml));
+        let result = numbering.resolve(1, 0);
+        assert!(result.is_list);
+        assert!(!result.is_ordered);
+        assert_eq!(result.style_type, ListStyleType::Disc);
+    }
+
+    #[test]
+    fn parse_numbering_handles_non_self_closing_abstract_num_id() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1">
+    <w:abstractNumId w:val="1"></w:abstractNumId>
+  </w:num>
+</w:numbering>"#;
+        let numbering = parse_ok!(std::io::Cursor::new(xml));
+        let result = numbering.resolve(1, 0);
+        assert!(result.is_list);
+        assert!(result.is_ordered);
+    }
+
+    #[test]
+    fn parse_numbering_returns_err_on_close_tag_depth_underflow() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+</w:numbering>
+</w:extra>"#;
+        let result = parse_numbering(std::io::Cursor::new(xml));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_numbering_returns_err_on_unclosed_elements_at_eof() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">"#;
+        let result = parse_numbering(std::io::Cursor::new(xml));
+        assert!(result.is_err());
+    }
+}

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -9,9 +9,19 @@ use crate::rels;
 use crate::rels::HyperlinkMap;
 use crate::styles::StyleList;
 
+/// Opens a DOCX ZIP archive, loads `styles.xml` and `numbering.xml` from the package
+/// relationships, locates `document.xml`, and returns a streaming reader for it.
+///
+/// Returns the loaded [`StyleList`], the loaded [`crate::numbering::MinimalNumbering`],
+/// the [`HyperlinkMap`], and a byte stream positioned at the start of `document.xml` data.
 pub fn open_package<R: Read + Seek + Send + 'static>(
     mut reader: R,
-) -> Result<(StyleList, HyperlinkMap, Box<dyn Read + Send>)> {
+) -> Result<(
+    StyleList,
+    crate::numbering::MinimalNumbering,
+    HyperlinkMap,
+    Box<dyn Read + Send>,
+)> {
     let mut archive = zip::ZipArchive::new(&mut reader).map_err(|err| match err {
         ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
             message: "not a valid ZIP archive".to_string(),
@@ -43,6 +53,7 @@ pub fn open_package<R: Read + Seek + Send + 'static>(
     let document_path = rels::find_document_target(std::io::Cursor::new(rels_bytes))?;
     let (style_list, hyperlink_map) =
         load_style_list_and_hyperlink_map(&mut archive, &document_path)?;
+    let numbering = load_numbering(&mut archive, &document_path)?;
 
     let (data_start, compressed_size, method) = {
         let entry = archive
@@ -75,7 +86,7 @@ pub fn open_package<R: Read + Seek + Send + 'static>(
         });
     };
 
-    Ok((style_list, hyperlink_map, stream))
+    Ok((style_list, numbering, hyperlink_map, stream))
 }
 
 fn load_style_list_and_hyperlink_map<R: Read + Seek>(
@@ -137,6 +148,40 @@ fn read_optional_entry<R: Read + Seek>(
         Err(ZipError::FileNotFound) => Ok(None),
         Err(err) => Err(parse_error(format!("malformed ZIP: {err}"))),
     }
+}
+
+fn load_numbering<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<&mut R>,
+    document_path: &str,
+) -> Result<crate::numbering::MinimalNumbering> {
+    let doc_rels_path = rels::derive_part_rels_path(document_path);
+    let doc_rels_bytes = match archive.by_name(&doc_rels_path) {
+        Ok(mut entry) => {
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).map_err(Error::from)?;
+            bytes
+        }
+        Err(ZipError::FileNotFound) => return Ok(crate::numbering::MinimalNumbering::new()),
+        Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
+    };
+
+    let Some(numbering_target) = rels::find_numbering_target(std::io::Cursor::new(doc_rels_bytes))?
+    else {
+        return Ok(crate::numbering::MinimalNumbering::new());
+    };
+
+    let numbering_path = rels::resolve_relative_target(document_path, &numbering_target);
+    let numbering_bytes = match archive.by_name(&numbering_path) {
+        Ok(mut entry) => {
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).map_err(Error::from)?;
+            bytes
+        }
+        Err(ZipError::FileNotFound) => return Ok(crate::numbering::MinimalNumbering::new()),
+        Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
+    };
+
+    crate::numbering::parse_numbering(std::io::Cursor::new(numbering_bytes))
 }
 
 fn parse_error(message: String) -> Error {
@@ -414,7 +459,7 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _hyperlink_map, mut stream)) => {
+            Ok((style_list, _numbering, _hyperlink_map, mut stream)) => {
                 assert!(style_list.get_by_id("Normal").is_some());
                 let mut document = String::new();
                 let read_result = stream.read_to_string(&mut document);
@@ -439,7 +484,7 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _hyperlink_map, _stream)) => {
+            Ok((style_list, _numbering, _hyperlink_map, _stream)) => {
                 assert_eq!(style_list, StyleList::default());
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
@@ -462,10 +507,139 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _hyperlink_map, _stream)) => {
+            Ok((style_list, _numbering, _hyperlink_map, _stream)) => {
                 assert_eq!(style_list, StyleList::default());
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
+        }
+    }
+
+    fn doc_rels_with_numbering_xml(styles_target: &str, numbering_target: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="{styles_target}"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="{numbering_target}"/>
+</Relationships>"#
+        )
+    }
+
+    fn doc_rels_with_only_numbering(numbering_target: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="{numbering_target}"/>
+</Relationships>"#
+        )
+    }
+
+    fn minimal_numbering_xml() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0">
+      <w:numFmt w:val="decimal"/>
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1">
+    <w:abstractNumId w:val="1"/>
+  </w:num>
+</w:numbering>"#
+    }
+
+    #[test]
+    fn open_package_loads_numbering_when_present() {
+        let root_rels = root_rels_xml("word/document.xml");
+        let doc_rels = doc_rels_with_numbering_xml("styles.xml", "numbering.xml");
+        let bytes = synth_zip(&[
+            ("_rels/.rels", root_rels.as_bytes()),
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+            ("word/styles.xml", minimal_styles_xml().as_bytes()),
+            ("word/numbering.xml", minimal_numbering_xml().as_bytes()),
+        ]);
+
+        let result = bytes.and_then(|zip_bytes| {
+            open_package(Cursor::new(zip_bytes))
+                .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+        });
+
+        match result {
+            Ok((_style_list, numbering, _hyperlink_map, _stream)) => {
+                assert!(numbering.resolve(1, 0).is_list);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected numbering and document stream"),
+        }
+    }
+
+    #[test]
+    fn open_package_returns_empty_numbering_when_absent() {
+        let root_rels = root_rels_xml("word/document.xml");
+        let bytes = synth_zip(&[
+            ("_rels/.rels", root_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+        ]);
+
+        let result = bytes.and_then(|zip_bytes| {
+            open_package(Cursor::new(zip_bytes))
+                .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+        });
+
+        match result {
+            Ok((_style_list, numbering, _hyperlink_map, _stream)) => {
+                assert!(!numbering.resolve(1, 0).is_list);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected empty numbering"),
+        }
+    }
+
+    #[test]
+    fn open_package_returns_empty_numbering_when_rels_missing_link() {
+        let root_rels = root_rels_xml("word/document.xml");
+        let doc_rels = doc_rels_xml("styles.xml");
+        let bytes = synth_zip(&[
+            ("_rels/.rels", root_rels.as_bytes()),
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+            ("word/styles.xml", minimal_styles_xml().as_bytes()),
+        ]);
+
+        let result = bytes.and_then(|zip_bytes| {
+            open_package(Cursor::new(zip_bytes))
+                .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+        });
+
+        match result {
+            Ok((_style_list, numbering, _hyperlink_map, _stream)) => {
+                assert!(!numbering.resolve(1, 0).is_list);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected empty numbering"),
+        }
+    }
+
+    #[test]
+    fn open_package_returns_err_on_malformed_numbering_xml() {
+        let root_rels = root_rels_xml("word/document.xml");
+        let doc_rels = doc_rels_with_only_numbering("numbering.xml");
+        let malformed = b"<w:numbering xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:lvl";
+        let bytes = synth_zip(&[
+            ("_rels/.rels", root_rels.as_bytes()),
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+            ("word/numbering.xml", &malformed[..]),
+        ]);
+
+        let result = bytes.and_then(|zip_bytes| {
+            open_package(Cursor::new(zip_bytes))
+                .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+        });
+
+        match result {
+            Err(_) => {}
+            Ok(_) => assert_eq!(
+                "opened without error",
+                "expected parse error for malformed numbering.xml",
+            ),
         }
     }
 }

--- a/crates/docspec-docx-reader/src/properties.rs
+++ b/crates/docspec-docx-reader/src/properties.rs
@@ -1,6 +1,7 @@
 //! OOXML value parsers for run and paragraph properties.
 
-use docspec_core::{Color, TextAlignment};
+use crate::numbering::LevelOutcome;
+use docspec_core::{Color, ListStyleType, TextAlignment};
 
 /// Parses an `ST_OnOff` value (ECMA-376 §22.9.2.7).
 ///
@@ -168,6 +169,29 @@ pub(crate) fn parse_sym_char(hex: &str) -> Option<u8> {
     let raw = u16::from_str_radix(hex, 16).ok()?;
     let stripped = raw.checked_sub(0xF000).unwrap_or(raw);
     u8::try_from(stripped).ok()
+}
+
+/// Parses a `w:numFmt` attribute value (ECMA-376 §17.9.17) into a `LevelOutcome`.
+///
+/// Maps OOXML numFmt values to list style outcomes:
+/// - `"none"` → `LevelOutcome::NotAList`
+/// - `"bullet"` → `LevelOutcome::List(ListStyleType::Disc)`
+/// - `"lowerLetter"` → `LevelOutcome::List(ListStyleType::LowerAlpha)`
+/// - `"upperLetter"` → `LevelOutcome::List(ListStyleType::UpperAlpha)`
+/// - `"lowerRoman"` → `LevelOutcome::List(ListStyleType::LowerRoman)`
+/// - `"upperRoman"` → `LevelOutcome::List(ListStyleType::UpperRoman)`
+/// - All other values (including `"decimal"`, `"decimalZero"`, CJK, exotic, unknown, empty string)
+///   → `LevelOutcome::List(ListStyleType::Decimal)` (default)
+pub fn parse_num_fmt(val: &str) -> LevelOutcome {
+    match val {
+        "none" => LevelOutcome::NotAList,
+        "bullet" => LevelOutcome::List(ListStyleType::Disc),
+        "lowerLetter" => LevelOutcome::List(ListStyleType::LowerAlpha),
+        "upperLetter" => LevelOutcome::List(ListStyleType::UpperAlpha),
+        "lowerRoman" => LevelOutcome::List(ListStyleType::LowerRoman),
+        "upperRoman" => LevelOutcome::List(ListStyleType::UpperRoman),
+        _ => LevelOutcome::List(ListStyleType::Decimal),
+    }
 }
 
 #[cfg(test)]
@@ -739,5 +763,102 @@ mod tests {
     #[test]
     fn parse_grid_span_value_negative_returns_none() {
         assert_eq!(parse_grid_span_value(Some("-1")), None);
+    }
+
+    // ============================================================================
+    // parse_num_fmt tests (12 cases)
+    // ============================================================================
+
+    #[test]
+    fn parse_num_fmt_returns_disc_for_bullet() {
+        assert_eq!(
+            parse_num_fmt("bullet"),
+            LevelOutcome::List(ListStyleType::Disc)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_decimal_for_decimal() {
+        assert_eq!(
+            parse_num_fmt("decimal"),
+            LevelOutcome::List(ListStyleType::Decimal)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_decimal_for_decimal_zero() {
+        assert_eq!(
+            parse_num_fmt("decimalZero"),
+            LevelOutcome::List(ListStyleType::Decimal)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_lower_alpha_for_lower_letter() {
+        assert_eq!(
+            parse_num_fmt("lowerLetter"),
+            LevelOutcome::List(ListStyleType::LowerAlpha)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_upper_alpha_for_upper_letter() {
+        assert_eq!(
+            parse_num_fmt("upperLetter"),
+            LevelOutcome::List(ListStyleType::UpperAlpha)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_lower_roman_for_lower_roman() {
+        assert_eq!(
+            parse_num_fmt("lowerRoman"),
+            LevelOutcome::List(ListStyleType::LowerRoman)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_upper_roman_for_upper_roman() {
+        assert_eq!(
+            parse_num_fmt("upperRoman"),
+            LevelOutcome::List(ListStyleType::UpperRoman)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_not_a_list_for_none() {
+        assert_eq!(parse_num_fmt("none"), LevelOutcome::NotAList);
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_decimal_for_japanese_counting() {
+        assert_eq!(
+            parse_num_fmt("japaneseDigital"),
+            LevelOutcome::List(ListStyleType::Decimal)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_decimal_for_thai_numbers() {
+        assert_eq!(
+            parse_num_fmt("thaiNumbers"),
+            LevelOutcome::List(ListStyleType::Decimal)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_decimal_for_unknown() {
+        assert_eq!(
+            parse_num_fmt("unknownFormat"),
+            LevelOutcome::List(ListStyleType::Decimal)
+        );
+    }
+
+    #[test]
+    fn parse_num_fmt_returns_decimal_for_empty_string() {
+        assert_eq!(
+            parse_num_fmt(""),
+            LevelOutcome::List(ListStyleType::Decimal)
+        );
     }
 }

--- a/crates/docspec-docx-reader/src/rels.rs
+++ b/crates/docspec-docx-reader/src/rels.rs
@@ -144,6 +144,55 @@ pub(crate) fn collect_hyperlink_map<R: Read>(reader: R) -> Result<HyperlinkMap, 
     }
 }
 
+/// Finds the numbering part target from a part relationships file.
+///
+/// Returns `Ok(None)` if no `/numbering` relationship is present (legal per ECMA-376 §17.9).
+/// Returns `Err` if the target contains a path-traversal (`..`) segment.
+/// Ignores relationships with `TargetMode="External"`.
+pub fn find_numbering_target<R: Read>(reader: R) -> docspec_core::Result<Option<String>> {
+    let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
+    let mut buf = Vec::new();
+    let mut element_depth: usize = 0;
+
+    loop {
+        match xml_reader.read_event_into(&mut buf) {
+            Ok(Event::Start(element)) => {
+                element_depth = element_depth.saturating_add(1);
+                if element.local_name().as_ref() == b"Relationship" {
+                    if let Some(target) = numbering_target(&xml_reader, &element)? {
+                        let numbering_path =
+                            target.strip_prefix('/').unwrap_or(&target).to_string();
+                        return validate_document_path(&numbering_path).map(Some);
+                    }
+                }
+            }
+            Ok(Event::Empty(element)) if element.local_name().as_ref() == b"Relationship" => {
+                if let Some(target) = numbering_target(&xml_reader, &element)? {
+                    let numbering_path = target.strip_prefix('/').unwrap_or(&target).to_string();
+                    return validate_document_path(&numbering_path).map(Some);
+                }
+            }
+            Ok(Event::End(_)) => {
+                let Some(next_depth) = element_depth.checked_sub(1) else {
+                    return Err(parse_error("malformed _rels/.rels".to_string()));
+                };
+                element_depth = next_depth;
+            }
+            Ok(Event::Eof) => {
+                if element_depth != 0 {
+                    return Err(parse_error("malformed _rels/.rels".to_string()));
+                }
+                return Ok(None);
+            }
+            Err(_err) => {
+                return Err(parse_error("malformed _rels/.rels".to_string()));
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+}
+
 fn parse_error(message: String) -> Error {
     Error::Parse {
         message,
@@ -273,6 +322,48 @@ fn hyperlink_entry<R: Read>(
             if found_type.ends_with("/hyperlink") =>
         {
             Some((found_id, found_target))
+        }
+        _ => None,
+    })
+}
+
+fn numbering_target<R: Read>(
+    reader: &quick_xml::Reader<R>,
+    element: &quick_xml::events::BytesStart<'_>,
+) -> docspec_core::Result<Option<String>> {
+    let mut rel_type = None;
+    let mut target = None;
+    let mut target_mode = None;
+
+    for attribute_result in element.attributes() {
+        let attribute = attribute_result.map_err(|err| Error::Parse {
+            message: format!("malformed _rels/.rels: {err}"),
+            position: None,
+        })?;
+        let value = attribute
+            .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
+            .map_err(|err| Error::Parse {
+                message: format!("malformed _rels/.rels: {err}"),
+                position: None,
+            })?
+            .into_owned();
+
+        match attribute.key.local_name().as_ref() {
+            b"Type" => rel_type = Some(value),
+            b"Target" => target = Some(value),
+            b"TargetMode" => target_mode = Some(value),
+            _ => {}
+        }
+    }
+
+    Ok(match (rel_type, target, target_mode) {
+        (Some(found_type), Some(_), Some(mode))
+            if found_type.ends_with("/numbering") && mode == "External" =>
+        {
+            None
+        }
+        (Some(found_type), Some(found_target), _) if found_type.ends_with("/numbering") => {
+            Some(found_target)
         }
         _ => None,
     })
@@ -738,8 +829,8 @@ mod tests {
     fn find_styles_returns_first_styles_match() {
         let rels_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
-  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="word/styles.xml"/>
-  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="word/styles2.xml"/>
+   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="word/styles.xml"/>
+   <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="word/styles2.xml"/>
 </Relationships>"#;
 
         let result = find_styles_target(Cursor::new(rels_xml.as_bytes()));
@@ -748,6 +839,76 @@ mod tests {
             Ok(Some(path)) => assert_eq!(path, "word/styles.xml"),
             other => assert_eq!(format!("{other:?}"), "expected first match"),
         }
+    }
+
+    fn minimal_numbering_rels(target: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="{target}"/>
+</Relationships>"#
+        )
+    }
+
+    #[test]
+    fn find_numbering_target_returns_target_when_present() {
+        let rels_xml = minimal_numbering_rels("word/numbering.xml");
+
+        let result = find_numbering_target(Cursor::new(rels_xml.as_bytes()));
+
+        assert_eq!(result.ok(), Some(Some("word/numbering.xml".to_string())));
+    }
+
+    #[test]
+    fn find_numbering_target_returns_none_when_absent() {
+        let rels_xml = minimal_rels("word/document.xml");
+
+        let result = find_numbering_target(Cursor::new(rels_xml.as_bytes()));
+
+        assert_eq!(result.ok(), Some(None));
+    }
+
+    #[test]
+    fn find_numbering_target_picks_numbering_among_multiple_relationships() {
+        let rels_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="word/styles.xml"/>
+   <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="word/numbering.xml"/>
+   <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" Target="word/fontTable.xml"/>
+</Relationships>"#;
+
+        let result = find_numbering_target(Cursor::new(rels_xml.as_bytes()));
+
+        assert_eq!(result.ok(), Some(Some("word/numbering.xml".to_string())));
+    }
+
+    #[test]
+    fn find_numbering_target_rejects_target_with_dotdot_segment() {
+        let rels_xml = minimal_numbering_rels("../etc/passwd");
+
+        let result = find_numbering_target(Cursor::new(rels_xml.as_bytes()));
+
+        match result {
+            Err(Error::Parse { message, position }) => {
+                assert_eq!(
+                    message,
+                    "rels target contains parent reference: ../etc/passwd"
+                );
+                assert_eq!(position, None);
+            }
+            other => assert_eq!(format!("{other:?}"), "expected dotdot parse error"),
+        }
+    }
+
+    #[test]
+    fn find_numbering_target_returns_none_on_empty_rels() {
+        let rels_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+</Relationships>"#;
+
+        let result = find_numbering_target(Cursor::new(rels_xml.as_bytes()));
+
+        assert_eq!(result.ok(), Some(None));
     }
 
     #[test]

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -1880,7 +1880,7 @@ mod events {
 
         assert_eq!(
             format!("{reader:?}"),
-            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", hyperlink_map: {}, hyperlink_depth: 0, pending_link: None, xml: \"<quick_xml::Reader>\" } }"
+            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", hyperlink_map: {}, hyperlink_depth: 0, pending_link: None, list_stack: [], seen_lists: {}, pending_paragraph_list: None, in_numpr: false, pending_num_pr_id: None, pending_num_pr_ilvl: None, xml: \"<quick_xml::Reader>\" } }"
         );
     }
 
@@ -5834,6 +5834,1806 @@ mod events {
                 start_para_with_alignment(TextAlignment::Right),
                 text("text"),
                 Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+}
+
+mod happy_path_lists {
+    use docspec_core::{Event, ListStyleType};
+
+    use crate::fixture;
+
+    fn root_rels() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#
+    }
+
+    fn doc_rels_with_numbering() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+</Relationships>"#
+    }
+
+    fn collect_events(bytes: Vec<u8>) -> Vec<Event> {
+        use docspec_core::EventSource as _;
+        let mut reader =
+            docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes)).unwrap();
+        let mut events = Vec::new();
+        loop {
+            match reader.next_event() {
+                Ok(Some(event)) => events.push(event),
+                Ok(None) => break,
+                Err(err) => panic!("unexpected error: {err:?}"),
+            }
+        }
+        events
+    }
+
+    fn build_docx(document_xml: &str, numbering_xml: &str) -> Vec<u8> {
+        fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                root_rels().as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                doc_rels_with_numbering().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+            (
+                "word/numbering.xml",
+                zip::CompressionMethod::Deflated,
+                numbering_xml.as_bytes(),
+            ),
+        ])
+    }
+
+    fn start_doc() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    fn start_para() -> Event {
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        }
+    }
+
+    fn text(content: &str) -> Event {
+        Event::Text {
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn flat_ordered_two_items_emits_correct_sequence() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>First item</w:t></w:r>
+    </w:p>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Second item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("First item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("Second item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn flat_unordered_two_items_emits_correct_sequence() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="2">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="bullet"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="2"><w:abstractNumId w:val="2"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="2"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>First item</w:t></w:r>
+    </w:p>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="2"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Second item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartUnorderedListItem {
+                    id: Some("2".to_string()),
+                    level: 0,
+                    style_type: ListStyleType::Disc,
+                },
+                start_para(),
+                text("First item"),
+                Event::EndParagraph,
+                Event::EndUnorderedListItem,
+                Event::StartUnorderedListItem {
+                    id: Some("2".to_string()),
+                    level: 0,
+                    style_type: ListStyleType::Disc,
+                },
+                start_para(),
+                text("Second item"),
+                Event::EndParagraph,
+                Event::EndUnorderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn nested_ordered_parent_child_emits_correct_sequence() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Parent</w:t></w:r>
+    </w:p>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="1"/></w:numPr></w:pPr>
+      <w:r><w:t>Child</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("Parent"),
+                Event::EndParagraph,
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 1,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("Child"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn mixed_format_ordered_then_unordered_same_num_id_per_level() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="3">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:numFmt w:val="bullet"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="3"><w:abstractNumId w:val="3"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="3"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Ordered parent</w:t></w:r>
+    </w:p>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="3"/><w:ilvl w:val="1"/></w:numPr></w:pPr>
+      <w:r><w:t>Unordered child</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("3".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("Ordered parent"),
+                Event::EndParagraph,
+                Event::StartUnorderedListItem {
+                    id: Some("3".to_string()),
+                    level: 1,
+                    style_type: ListStyleType::Disc,
+                },
+                start_para(),
+                text("Unordered child"),
+                Event::EndParagraph,
+                Event::EndUnorderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn lower_letter_emits_lower_alpha_style_type() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="5">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="lowerLetter"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="5"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::LowerAlpha,
+                },
+                start_para(),
+                text("Item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn lower_roman_emits_lower_roman_style_type() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="6">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="lowerRoman"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="6"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::LowerRoman,
+                },
+                start_para(),
+                text("Item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn upper_letter_emits_upper_alpha_style_type() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="7">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="upperLetter"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="7"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::UpperAlpha,
+                },
+                start_para(),
+                text("Item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn upper_roman_emits_upper_roman_style_type() {
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="8">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="upperRoman"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="8"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>Item</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::UpperRoman,
+                },
+                start_para(),
+                text("Item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+}
+
+mod spec_edge_cases {
+    use docspec_core::{Event, ListStyleType};
+
+    use crate::fixture;
+
+    fn root_rels() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#
+    }
+
+    fn doc_rels_with_numbering() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+</Relationships>"#
+    }
+
+    fn collect_events(bytes: Vec<u8>) -> Vec<Event> {
+        use docspec_core::EventSource as _;
+        let mut reader =
+            docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes)).unwrap();
+        let mut events = Vec::new();
+        loop {
+            match reader.next_event() {
+                Ok(Some(event)) => events.push(event),
+                Ok(None) => break,
+                Err(err) => panic!("unexpected error: {err:?}"),
+            }
+        }
+        events
+    }
+
+    fn build_docx(document_xml: &str, numbering_xml: &str) -> Vec<u8> {
+        fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                root_rels().as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                doc_rels_with_numbering().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+            (
+                "word/numbering.xml",
+                zip::CompressionMethod::Deflated,
+                numbering_xml.as_bytes(),
+            ),
+        ])
+    }
+
+    fn start_doc() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    fn start_para() -> Event {
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        }
+    }
+
+    fn text(content: &str) -> Event {
+        Event::Text {
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn num_id_zero_sentinel_emits_plain_paragraph() {
+        // §17.9.18: numId=0 sentinel escapes list membership
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="0"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_num_fmt_defaults_to_decimal() {
+        // §17.9.17: missing numFmt defaults to decimal
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0">
+    </w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_ilvl_defaults_to_zero() {
+        // §17.9.3: missing ilvl defaults to 0
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:numFmt w:val="bullet"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn num_fmt_none_emits_plain_paragraph() {
+        // §17.9.17: numFmt=none emits plain paragraph, not a list item
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="none"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn multi_level_type_ignored_for_classification() {
+        // §17.9.12: multiLevelType is a UI hint, not authoritative
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:multiLevelType w:val="singleLevel"/>
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+    <w:lvl w:ilvl="1"><w:numFmt w:val="bullet"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>ilvl0</w:t></w:r>
+    </w:p>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="1"/></w:numPr></w:pPr>
+      <w:r><w:t>ilvl1</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("ilvl0"),
+                Event::EndParagraph,
+                Event::StartUnorderedListItem {
+                    id: Some("1".to_string()),
+                    level: 1,
+                    style_type: ListStyleType::Disc,
+                },
+                start_para(),
+                text("ilvl1"),
+                Event::EndParagraph,
+                Event::EndUnorderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn numbering_change_in_numpr_ignored() {
+        // <w:numberingChange> is a track-changes element recording previous numbering state;
+        // it MUST NOT block the numId/ilvl capture
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/><w:numberingChange w:id="1" w:originalNumId="2" w:originalIlvl="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn first_list_item_at_deep_level_keeps_start_marker_on_real_item() {
+        // Regression: when the first authored list item appears at a non-zero ilvl,
+        // reconcile_list_stack synthesizes phantom levels 0..ilvl-1 to keep the event
+        // stream well-formed. Phantoms must NOT consume the per-numId `start: Some(1)`
+        // marker — it belongs on the user-authored item at the target ilvl.
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="3"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="3"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 1,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 2,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 3,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+}
+
+mod resilience_tests {
+    use docspec_core::{Event, ListStyleType};
+
+    use crate::fixture;
+
+    fn root_rels() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#
+    }
+
+    fn doc_rels_with_numbering() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+</Relationships>"#
+    }
+
+    fn doc_rels_no_numbering() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>"#
+    }
+
+    fn collect_events(bytes: Vec<u8>) -> Vec<Event> {
+        use docspec_core::EventSource as _;
+        let mut reader =
+            docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes)).unwrap();
+        let mut events = Vec::new();
+        loop {
+            match reader.next_event() {
+                Ok(Some(event)) => events.push(event),
+                Ok(None) => break,
+                Err(err) => panic!("unexpected error: {err:?}"),
+            }
+        }
+        events
+    }
+
+    fn build_docx(document_xml: &str, numbering_xml: &str) -> Vec<u8> {
+        fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                root_rels().as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                doc_rels_with_numbering().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+            (
+                "word/numbering.xml",
+                zip::CompressionMethod::Deflated,
+                numbering_xml.as_bytes(),
+            ),
+        ])
+    }
+
+    fn start_doc() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    fn start_para() -> Event {
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        }
+    }
+
+    fn text(content: &str) -> Event {
+        Event::Text {
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn missing_numbering_xml_emits_plain_paragraphs() {
+        // No word/numbering.xml and no word/_rels/document.xml.rels — paragraphs
+        // with <w:numPr> must emit StartParagraph (graceful degradation, no error).
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let bytes = fixture::synth_docx(root_rels(), document_xml);
+        let events = collect_events(bytes);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn numbering_rel_missing_target_emits_plain_paragraphs() {
+        // word/_rels/document.xml.rels present but contains no numbering relationship.
+        // Paragraphs with <w:numPr> must emit StartParagraph (no list events, no error).
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let bytes = fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                root_rels().as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                doc_rels_no_numbering().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+        ]);
+        let events = collect_events(bytes);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_numbering_xml_emits_plain_paragraphs() {
+        // Empty <w:numbering/> — no abstractNums, no nums defined.
+        // Paragraphs with <w:numPr> must emit StartParagraph (no list events, no error).
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let numbering_xml = r#"<?xml version="1.0"?><w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"/>"#;
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn malformed_numbering_xml_returns_err() {
+        // An unclosed XML tag leaves element_depth > 0 at EOF, causing parse_numbering
+        // to return Err — which propagates as Err from DocxReader::from_reader.
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let bytes = fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                root_rels().as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                doc_rels_with_numbering().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+            (
+                "word/numbering.xml",
+                zip::CompressionMethod::Deflated,
+                b"<unclosed>",
+            ),
+        ]);
+        let result = docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn unknown_num_id_emits_plain_paragraph() {
+        // Paragraph references numId=999 which is not defined in numbering.xml.
+        // MinimalNumbering.resolve() graceful path: emit StartParagraph (no list events).
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="999"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn ilvl_overflow_clamps_to_eight() {
+        // Paragraph uses <w:ilvl w:val="99"/> — ilvl is clamped to min(99, 8) = 8.
+        // reconcile_list_stack fills phantom levels 0-7 with start: None before reaching
+        // the target level 8, which receives the `start: Some(1)` per-numId marker.
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="8"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="99"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 1,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 2,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 3,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 4,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 5,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 6,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 7,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 8,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_numeric_num_id_emits_plain_paragraph() {
+        // <w:numId w:val="abc"/> — parse failure leaves pending_num_pr_id = None.
+        // Without a numId, the paragraph emits StartParagraph (no list events).
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="abc"/><w:ilvl w:val="0"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn non_numeric_ilvl_defaults_to_zero() {
+        // <w:ilvl w:val="xyz"/> — parse failure; ilvl defaults to 0 per §17.9.3.
+        // numbering.xml defines numId=1 ilvl=0 as decimal, so level 0 is emitted.
+        let numbering_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p>
+      <w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="xyz"/></w:numPr></w:pPr>
+      <w:r><w:t>text</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+        let events = collect_events(build_docx(document_xml, numbering_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: Some(1),
+                    style_type: ListStyleType::Decimal,
+                },
+                start_para(),
+                text("text"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+}
+
+mod cross_feature_lists {
+    use docspec_core::{Event, ListStyleType, TableHeaderScope, TextStyleKind};
+
+    use crate::fixture;
+
+    fn root_rels() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#
+    }
+
+    fn doc_rels_with_numbering() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+</Relationships>"#
+    }
+
+    fn doc_rels_with_numbering_and_styles() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/numbering" Target="numbering.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+</Relationships>"#
+    }
+
+    fn collect_events(bytes: Vec<u8>) -> Vec<Event> {
+        use docspec_core::EventSource as _;
+        let mut reader =
+            docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes)).unwrap();
+        let mut events = Vec::new();
+        loop {
+            match reader.next_event() {
+                Ok(Some(event)) => events.push(event),
+                Ok(None) => break,
+                Err(err) => panic!("unexpected error: {err:?}"),
+            }
+        }
+        events
+    }
+
+    fn build_docx(document_xml: &str, numbering_xml: &str) -> Vec<u8> {
+        fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                root_rels().as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                doc_rels_with_numbering().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+            (
+                "word/numbering.xml",
+                zip::CompressionMethod::Deflated,
+                numbering_xml.as_bytes(),
+            ),
+        ])
+    }
+
+    fn build_docx_with_styles(
+        document_xml: &str,
+        numbering_xml: &str,
+        styles_xml: &str,
+    ) -> Vec<u8> {
+        fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                root_rels().as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                doc_rels_with_numbering_and_styles().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+            (
+                "word/numbering.xml",
+                zip::CompressionMethod::Deflated,
+                numbering_xml.as_bytes(),
+            ),
+            (
+                "word/styles.xml",
+                zip::CompressionMethod::Deflated,
+                styles_xml.as_bytes(),
+            ),
+        ])
+    }
+
+    fn decimal_numbering_xml() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#
+    }
+
+    fn two_decimal_lists_numbering_xml() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:numbering xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:abstractNum w:abstractNumId="1">
+    <w:lvl w:ilvl="0"><w:numFmt w:val="decimal"/></w:lvl>
+  </w:abstractNum>
+  <w:num w:numId="1"><w:abstractNumId w:val="1"/></w:num>
+  <w:num w:numId="2"><w:abstractNumId w:val="1"/></w:num>
+</w:numbering>"#
+    }
+
+    fn start_doc() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    fn start_para() -> Event {
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        }
+    }
+
+    fn text(content: &str) -> Event {
+        Event::Text {
+            content: content.to_string(),
+        }
+    }
+
+    fn start_table() -> Event {
+        Event::StartTable { id: None }
+    }
+
+    fn start_row() -> Event {
+        Event::StartTableRow { id: None }
+    }
+
+    fn start_cell() -> Event {
+        Event::StartTableCell {
+            colspan: None,
+            id: None,
+            rowspan: None,
+        }
+    }
+
+    fn start_header() -> Event {
+        Event::StartTableHeader {
+            scope: Some(TableHeaderScope::Column),
+            abbr: None,
+            colspan: None,
+            rowspan: None,
+            id: None,
+        }
+    }
+
+    fn start_ordered(id: &str, start: Option<u64>) -> Event {
+        Event::StartOrderedListItem {
+            id: Some(id.to_string()),
+            level: 0,
+            start,
+            style_type: ListStyleType::Decimal,
+        }
+    }
+
+    #[test]
+    fn list_inside_table_cell_nests_correctly() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:tbl><w:tr><w:tc><w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>list item</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, decimal_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                text("list item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_inside_table_header_cell_nests_correctly() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>list item</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, decimal_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_header(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                text("list item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndTableHeader,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn styled_text_in_list_item_closes_before_end() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r></w:p></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, decimal_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Bold,
+                    id: None,
+                },
+                text("bold"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_paragraph_with_heading_pstyle_emits_heading_not_list() {
+        let styles_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:styleId="Heading1">
+    <w:name w:val="heading 1"/>
+  </w:style>
+</w:styles>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:pPr><w:pStyle w:val="Heading1"/><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>Heading</w:t></w:r></w:p></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx_with_styles(
+            document_xml,
+            decimal_numbering_xml(),
+            styles_xml,
+        ));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartHeading { level: 1, id: None },
+                text("Heading"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_open_at_document_end_flushes_correctly() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>item</w:t></w:r></w:p></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, decimal_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                text("item"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn two_consecutive_lists_each_first_item_emits_start_some_one() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>one</w:t></w:r></w:p>
+    <w:p><w:pPr><w:numPr><w:numId w:val="2"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>two</w:t></w:r></w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, two_decimal_lists_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                text("one"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                start_ordered("2", Some(1)),
+                start_para(),
+                text("two"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn same_num_id_reused_after_break_emits_start_none_second_time() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body>
+    <w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>one</w:t></w:r></w:p>
+    <w:p><w:r><w:t>break</w:t></w:r></w:p>
+    <w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>two</w:t></w:r></w:p>
+  </w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, decimal_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                text("one"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                start_para(),
+                text("break"),
+                Event::EndParagraph,
+                start_ordered("1", None),
+                start_para(),
+                text("two"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_inside_ins_tracked_change_emits_normally() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:pPr><w:ins w:id="1" w:author="Author" w:date="2024-01-01T00:00:00Z"><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:ins></w:pPr><w:r><w:t>inserted</w:t></w:r></w:p></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, decimal_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                text("inserted"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_inside_block_quote_emits_block_quote_not_list() {
+        let styles_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:styleId="BlockQuote">
+    <w:name w:val="Block Text"/>
+  </w:style>
+</w:styles>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:pPr><w:pStyle w:val="BlockQuote"/><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>quote</w:t></w:r></w:p></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx_with_styles(
+            document_xml,
+            decimal_numbering_xml(),
+            styles_xml,
+        ));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartBlockQuote { id: None },
+                text("quote"),
+                Event::EndBlockQuote,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_inside_preformatted_emits_preformatted_not_list() {
+        let styles_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:styleId="SourceCode">
+    <w:name w:val="Source Code"/>
+  </w:style>
+</w:styles>"#;
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:p><w:pPr><w:pStyle w:val="SourceCode"/><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>code</w:t></w:r></w:p></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx_with_styles(
+            document_xml,
+            decimal_numbering_xml(),
+            styles_xml,
+        ));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartPreformatted {
+                    id: None,
+                    syntax: None,
+                },
+                text("code"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn list_inside_nested_table_emits_no_table_header() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:body><w:tbl><w:tr><w:tc><w:tbl><w:tr><w:trPr><w:tblHeader/></w:trPr><w:tc><w:p><w:pPr><w:numPr><w:numId w:val="1"/><w:ilvl w:val="0"/></w:numPr></w:pPr><w:r><w:t>nested list</w:t></w:r></w:p></w:tc></w:tr></w:tbl></w:tc></w:tr></w:tbl></w:body>
+</w:document>"#;
+
+        let events = collect_events(build_docx(document_xml, decimal_numbering_xml()));
+
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_ordered("1", Some(1)),
+                start_para(),
+                text("nested list"),
+                Event::EndParagraph,
+                Event::EndOrderedListItem,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
                 Event::EndDocument,
             ]
         );


### PR DESCRIPTION
Emit `StartOrderedListItem`/`EndOrderedListItem` and `StartUnorderedListItem`/`EndUnorderedListItem` for DOCX paragraphs with `<w:numPr>`.

Ordered styles: Decimal, LowerAlpha, UpperAlpha, LowerRoman, UpperRoman. Unordered: Disc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming support for ordered and unordered DOCX lists: nested list items, per-level classification, start-number behavior, emitted start/end list-item events, and proper closure at table/cell boundaries and document end.

* **Documentation**
  * README and crate docs updated to describe supported list behavior and a “Lists (V1 cuts)” section enumerating intentional V1 limitations.

* **Tests**
  * Extensive unit and integration tests covering numbering parsing, list emission, edge cases, boundaries, and cross-feature interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->