### PR TITLE
feat(pandoc-native-writer): CodeBlock, Code

### DIFF
--- a/crates/docspec-pandoc-native-writer/README.md
+++ b/crates/docspec-pandoc-native-writer/README.md
@@ -21,13 +21,14 @@ Converts a DocSpec event stream into compact Pandoc native block-list syntax, su
 | `StartTextStyle { kind: Underline }` / `EndTextStyle` | `Underline [` / `]` |
 | `StartTextStyle { kind: Subscript }` / `EndTextStyle` | `Subscript [` / `]` |
 | `StartTextStyle { kind: Superscript }` / `EndTextStyle` | `Superscript [` / `]` |
+| `StartTextStyle { kind: Code, id }` / `EndTextStyle` | `Code ("id",[],[]) "..."` (Text payload buffered between Start and End) |
+| `StartPreformatted { id, syntax }` / `EndPreformatted` | `CodeBlock ("id",["syntax"],[]) "..."` (Text payload buffered; literal newlines preserved) |
 
 ## Not Supported
 
 The following DocSpec events are silently ignored:
 
 - Block quotes — `StartBlockQuote` / `EndBlockQuote`
-- Preformatted / code blocks — `StartPreformatted` / `EndPreformatted`
 - Images — `Image`
 - Tables — `StartTable` / `EndTable` and related events
 - List items — `StartOrderedListItem` / `StartUnorderedListItem` and related events
@@ -35,7 +36,7 @@ The following DocSpec events are silently ignored:
 - Footnotes — `StartFootnote` / `EndFootnote` / `FootnoteRef`
 - Definition lists — `StartDefinitionList` / `StartDefinitionTerm` / `StartDefinitionDetail`
 - Captions — `StartCaption` / `EndCaption`
-- Text formatting styles — `StartTextStyle { kind: Code | Mark | TextColor }` are accepted but silently flattened (text inside is preserved without a wrapper)
+- Text formatting styles — `StartTextStyle { kind: Mark | TextColor }` are accepted but silently flattened (text inside is preserved without a wrapper)
 
 ## Usage
 

--- a/crates/docspec-pandoc-native-writer/src/lib.rs
+++ b/crates/docspec-pandoc-native-writer/src/lib.rs
@@ -19,6 +19,20 @@ enum TextStyleFrame {
     Flattened,
 }
 
+#[derive(Debug)]
+enum CodeFrame {
+    Block {
+        id: Option<String>,
+        syntax: Option<String>,
+        buffer: String,
+    },
+    Inline {
+        id: Option<String>,
+        buffer: String,
+        nested_style_depth: u32,
+    },
+}
+
 /// A streaming Pandoc native writer for `DocSpec` events.
 ///
 /// Writes compact Pandoc native block-list syntax directly to the underlying
@@ -34,6 +48,7 @@ enum TextStyleFrame {
 ///
 /// * `W` - Any type implementing [`Write`]
 pub struct PandocNativeWriter<W: Write> {
+    code_frame: Option<CodeFrame>,
     finished: bool,
     first_block: bool,
     inline_block: Option<InlineBlockKind>,
@@ -49,6 +64,7 @@ impl<W: Write> PandocNativeWriter<W> {
     #[must_use]
     pub fn new(writer: W) -> Self {
         Self {
+            code_frame: None,
             finished: false,
             first_block: true,
             inline_block: None,
@@ -57,6 +73,150 @@ impl<W: Write> PandocNativeWriter<W> {
             text_style_frames: Vec::new(),
             writer,
         }
+    }
+
+    #[inline]
+    fn write_attr(&mut self, id: &str, classes: &[&str]) -> Result<()> {
+        self.writer.write_all(b"(")?;
+        escape::write_haskell_string(&mut self.writer, id)?;
+        self.writer.write_all(b",[")?;
+        for (i, class) in classes.iter().enumerate() {
+            if i > 0 {
+                self.writer.write_all(b",")?;
+            }
+            escape::write_haskell_string(&mut self.writer, class)?;
+        }
+        self.writer.write_all(b"],[])")?;
+        Ok(())
+    }
+
+    #[inline]
+    fn handle_event_in_code_frame(&mut self, event: Event) -> Result<()> {
+        match event {
+            Event::Text { content } => {
+                if let Some(frame) = self.code_frame.as_mut() {
+                    let buffer = match frame {
+                        CodeFrame::Block { buffer, .. } | CodeFrame::Inline { buffer, .. } => {
+                            buffer
+                        }
+                    };
+                    buffer.push_str(&content);
+                }
+            }
+            Event::StartTextStyle { .. } => {
+                if let Some(CodeFrame::Inline {
+                    nested_style_depth, ..
+                }) = self.code_frame.as_mut()
+                {
+                    *nested_style_depth = nested_style_depth.saturating_add(1);
+                }
+            }
+            Event::EndTextStyle => match self.code_frame.as_mut() {
+                Some(CodeFrame::Inline {
+                    nested_style_depth, ..
+                }) if *nested_style_depth > 0 => {
+                    *nested_style_depth = nested_style_depth.saturating_sub(1);
+                }
+                Some(CodeFrame::Inline { .. }) => self.flush_code_frame()?,
+                _ => {}
+            },
+            Event::EndPreformatted if matches!(&self.code_frame, Some(CodeFrame::Block { .. })) => {
+                self.flush_code_frame()?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn handle_start_text_style(&mut self, kind: &TextStyleKind, id: Option<String>) -> Result<()> {
+        if matches!(kind, TextStyleKind::Code) {
+            self.code_frame = Some(CodeFrame::Inline {
+                id,
+                buffer: String::new(),
+                nested_style_depth: 0,
+            });
+            return Ok(());
+        }
+        let opener: Option<&[u8]> = match kind {
+            TextStyleKind::Bold => Some(b"Strong ["),
+            TextStyleKind::Italic => Some(b"Emph ["),
+            TextStyleKind::Strikethrough => Some(b"Strikeout ["),
+            TextStyleKind::Underline => Some(b"Underline ["),
+            TextStyleKind::Subscript => Some(b"Subscript ["),
+            TextStyleKind::Superscript => Some(b"Superscript ["),
+            _ => None,
+        };
+        if let Some(open) = opener {
+            self.write_inline_separator()?;
+            self.writer.write_all(open)?;
+            self.inline_has_content.push(false);
+            self.text_style_frames.push(TextStyleFrame::Wrapped);
+        } else {
+            self.text_style_frames.push(TextStyleFrame::Flattened);
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn handle_end_document(&mut self) -> Result<()> {
+        if matches!(&self.code_frame, Some(CodeFrame::Inline { .. })) {
+            self.flush_code_frame()?;
+        }
+        while !self.inline_has_content.is_empty() {
+            self.writer.write_all(b"]")?;
+            self.inline_has_content.pop();
+        }
+        self.text_style_frames.clear();
+        self.inline_block = None;
+        if self.code_frame.is_some() {
+            self.flush_code_frame()?;
+        }
+        self.writer.write_all(b"]")?;
+        self.finished = true;
+        Ok(())
+    }
+
+    #[inline]
+    fn handle_start_preformatted(
+        &mut self,
+        id: Option<String>,
+        syntax: Option<String>,
+    ) -> Result<()> {
+        if !self.first_block {
+            self.writer.write_all(b",")?;
+        }
+        self.code_frame = Some(CodeFrame::Block {
+            id,
+            syntax,
+            buffer: String::new(),
+        });
+        self.first_block = false;
+        Ok(())
+    }
+
+    #[inline]
+    fn flush_code_frame(&mut self) -> Result<()> {
+        match self.code_frame.take() {
+            Some(CodeFrame::Block { id, syntax, buffer }) => {
+                self.writer.write_all(b"CodeBlock ")?;
+                match syntax.as_deref() {
+                    Some(s) => self.write_attr(id.as_deref().unwrap_or(""), &[s])?,
+                    None => self.write_attr(id.as_deref().unwrap_or(""), &[])?,
+                }
+                self.writer.write_all(b" ")?;
+                escape::write_haskell_string(&mut self.writer, &buffer)?;
+            }
+            Some(CodeFrame::Inline { id, buffer, .. }) => {
+                self.write_inline_separator()?;
+                self.writer.write_all(b"Code ")?;
+                self.write_attr(id.as_deref().unwrap_or(""), &[])?;
+                self.writer.write_all(b" ")?;
+                escape::write_haskell_string(&mut self.writer, &buffer)?;
+            }
+            None => {}
+        }
+        Ok(())
     }
 
     #[inline]
@@ -111,9 +271,15 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
     #[inline]
     fn finish(mut self) -> Result<()> {
         if self.started && !self.finished {
+            if matches!(&self.code_frame, Some(CodeFrame::Inline { .. })) {
+                self.flush_code_frame()?;
+            }
             while !self.inline_has_content.is_empty() {
                 self.writer.write_all(b"]")?;
                 self.inline_has_content.pop();
+            }
+            if self.code_frame.is_some() {
+                self.flush_code_frame()?;
             }
             self.writer.write_all(b"]")?;
         }
@@ -131,12 +297,21 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
     /// - `ThematicBreak` — `HorizontalRule`
     /// - `LineBreak` — `LineBreak`
     /// - `SoftBreak` — `SoftBreak`
-    /// - `StartTextStyle` / `EndTextStyle` — `Strong`/`Emph`/`Strikeout`/`Underline`/`Subscript`/`Superscript` wrappers
-    ///   (kinds `Code`, `Mark`, `TextColor` are silently flattened — text inside is preserved without a wrapper)
+    /// - `StartTextStyle` / `EndTextStyle` — `Strong`/`Emph`/`Strikeout`/`Underline`/`Subscript`/`Superscript` wrappers,
+    ///   and `Code Attr Text` for the `Code` kind (kinds `Mark`, `TextColor` are silently flattened)
+    /// - `StartPreformatted` / `EndPreformatted` — `CodeBlock ("id",["syntax"],[]) "..."`
     ///
     /// All other events are silently ignored.
     #[inline]
     fn handle_event(&mut self, event: Event) -> Result<()> {
+        if self.code_frame.is_some()
+            && !matches!(
+                event,
+                Event::EndParagraph | Event::EndHeading | Event::EndDocument
+            )
+        {
+            return self.handle_event_in_code_frame(event);
+        }
         match event {
             Event::StartDocument { .. } => {
                 if !self.started && !self.finished {
@@ -146,14 +321,7 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
             }
             Event::EndDocument => {
                 if self.started && !self.finished {
-                    while !self.inline_has_content.is_empty() {
-                        self.writer.write_all(b"]")?;
-                        self.inline_has_content.pop();
-                    }
-                    self.text_style_frames.clear();
-                    self.inline_block = None;
-                    self.writer.write_all(b"]")?;
-                    self.finished = true;
+                    self.handle_end_document()?;
                 }
             }
             Event::StartParagraph { .. } => {
@@ -182,6 +350,9 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
             }
             Event::EndParagraph => {
                 if self.inline_block == Some(InlineBlockKind::Paragraph) {
+                    if matches!(&self.code_frame, Some(CodeFrame::Inline { .. })) {
+                        self.flush_code_frame()?;
+                    }
                     self.close_orphaned_inline_frames()?;
                     self.writer.write_all(b"]")?;
                     self.inline_has_content.pop();
@@ -190,33 +361,22 @@ impl<W: Write> EventSink for PandocNativeWriter<W> {
             }
             Event::EndHeading => {
                 if self.inline_block == Some(InlineBlockKind::Heading) {
+                    if matches!(&self.code_frame, Some(CodeFrame::Inline { .. })) {
+                        self.flush_code_frame()?;
+                    }
                     self.close_orphaned_inline_frames()?;
                     self.writer.write_all(b"]")?;
                     self.inline_has_content.pop();
                     self.inline_block = None;
                 }
             }
-            Event::StartTextStyle { kind, .. } if !self.inline_has_content.is_empty() => {
-                let opener: Option<&[u8]> = match kind {
-                    TextStyleKind::Bold => Some(b"Strong ["),
-                    TextStyleKind::Italic => Some(b"Emph ["),
-                    TextStyleKind::Strikethrough => Some(b"Strikeout ["),
-                    TextStyleKind::Underline => Some(b"Underline ["),
-                    TextStyleKind::Subscript => Some(b"Subscript ["),
-                    TextStyleKind::Superscript => Some(b"Superscript ["),
-                    TextStyleKind::Code | TextStyleKind::Mark(_) | TextStyleKind::TextColor(_) => {
-                        None
-                    }
-                    _ => None,
-                };
-                if let Some(open) = opener {
-                    self.write_inline_separator()?;
-                    self.writer.write_all(open)?;
-                    self.inline_has_content.push(false);
-                    self.text_style_frames.push(TextStyleFrame::Wrapped);
-                } else {
-                    self.text_style_frames.push(TextStyleFrame::Flattened);
-                }
+            Event::StartTextStyle { kind, id } if !self.inline_has_content.is_empty() => {
+                self.handle_start_text_style(&kind, id)?;
+            }
+            Event::StartPreformatted { id, syntax }
+                if self.started && !self.finished && self.inline_block.is_none() =>
+            {
+                self.handle_start_preformatted(id, syntax)?;
             }
             Event::EndTextStyle => match self.text_style_frames.pop() {
                 Some(TextStyleFrame::Wrapped) if self.inline_has_content.len() > 1 => {

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -206,11 +206,6 @@ mod tests {
         assert_eq!(
             run([
                 start_doc(),
-                Event::StartPreformatted {
-                    syntax: None,
-                    id: None
-                },
-                Event::EndPreformatted,
                 start_para(),
                 text("x"),
                 Event::EndParagraph,
@@ -940,7 +935,7 @@ mod tests {
     }
 
     #[test]
-    fn code_style_text_flattens_into_paragraph() {
+    fn code_style_emits_code_construct_inside_paragraph() {
         assert_eq!(
             run([
                 start_doc(),
@@ -953,12 +948,12 @@ mod tests {
                 Event::EndParagraph,
                 Event::EndDocument,
             ]),
-            "[Para [Str \"a \",Str \"code\",Str \" b\"]]"
+            "[Para [Str \"a \",Code (\"\",[],[]) \"code\",Str \" b\"]]"
         );
     }
 
     #[test]
-    fn flattened_style_inside_bold_keeps_bold_open() {
+    fn code_style_inside_bold_emits_code_inside_strong() {
         assert_eq!(
             run([
                 start_doc(),
@@ -972,12 +967,12 @@ mod tests {
                 Event::EndParagraph,
                 Event::EndDocument,
             ]),
-            "[Para [Strong [Str \"a\",Str \"b\"]]]"
+            "[Para [Strong [Code (\"\",[],[]) \"a\",Str \"b\"]]]"
         );
     }
 
     #[test]
-    fn bold_inside_flattened_style_closes_before_following_text() {
+    fn nested_styles_inside_code_are_absorbed_into_buffer() {
         assert_eq!(
             run([
                 start_doc(),
@@ -991,7 +986,7 @@ mod tests {
                 Event::EndParagraph,
                 Event::EndDocument,
             ]),
-            "[Para [Strong [Str \"a\"],Str \"b\"]]"
+            "[Para [Code (\"\",[],[]) \"ab\"]]"
         );
     }
 
@@ -1116,6 +1111,405 @@ mod tests {
                 Event::EndDocument,
             ]),
             "[Para [Strong [Str \"a\"]]]"
+        );
+    }
+
+    fn start_pre(id: Option<&str>, syntax: Option<&str>) -> Event {
+        Event::StartPreformatted {
+            id: id.map(String::from),
+            syntax: syntax.map(String::from),
+        }
+    }
+
+    #[test]
+    fn preformatted_with_no_id_no_syntax_emits_empty_attr() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, None),
+                text("hello"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[],[]) \"hello\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_with_syntax_emits_language_class() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, Some("rust")),
+                text("fn main() {}"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[\"rust\"],[]) \"fn main() {}\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_with_id_and_syntax_emits_both() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(Some("ex1"), Some("python")),
+                text("print('hi')"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"ex1\",[\"python\"],[]) \"print('hi')\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_concatenates_multiple_text_events() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, None),
+                text("line1\n"),
+                text("line2\n"),
+                text("line3"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[],[]) \"line1\\nline2\\nline3\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_preserves_literal_newlines_in_text() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, None),
+                text("a\nb\nc"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[],[]) \"a\\nb\\nc\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_with_empty_content_emits_empty_string() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, None),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[],[]) \"\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_escapes_quotes_and_backslashes_in_content() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, Some("c")),
+                text("printf(\"hello\\n\");"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[\"c\"],[]) \"printf(\\\"hello\\\\n\\\");\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_escapes_id_attribute() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(Some("a\"b"), None),
+                text("x"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"a\\\"b\",[],[]) \"x\"]"
+        );
+    }
+
+    #[test]
+    fn preformatted_between_paragraphs_emits_block_separators() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("before"),
+                Event::EndParagraph,
+                start_pre(None, Some("sh")),
+                text("ls -la"),
+                Event::EndPreformatted,
+                start_para(),
+                text("after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"before\"],CodeBlock (\"\",[\"sh\"],[]) \"ls -la\",Para [Str \"after\"]]"
+        );
+    }
+
+    #[test]
+    fn start_preformatted_inside_paragraph_is_dropped_but_text_passes_through() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("a"),
+                start_pre(None, Some("rust")),
+                text("nope"),
+                Event::EndPreformatted,
+                text("b"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"a\",Str \"nope\",Str \"b\"]]"
+        );
+    }
+
+    #[test]
+    fn stray_end_preformatted_is_noop() {
+        assert_eq!(
+            run([start_doc(), Event::EndPreformatted, Event::EndDocument]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn inline_code_with_no_id_emits_empty_attr() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("let x = 1;"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Code (\"\",[],[]) \"let x = 1;\"]]"
+        );
+    }
+
+    #[test]
+    fn inline_code_with_id_emits_id() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                Event::StartTextStyle {
+                    kind: docspec_core::TextStyleKind::Code,
+                    id: Some("ref1".to_string()),
+                },
+                text("ref"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Code (\"ref1\",[],[]) \"ref\"]]"
+        );
+    }
+
+    #[test]
+    fn inline_code_between_plain_text_emits_separators() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                text("before "),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("x"),
+                Event::EndTextStyle,
+                text(" after"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Str \"before \",Code (\"\",[],[]) \"x\",Str \" after\"]]"
+        );
+    }
+
+    #[test]
+    fn inline_code_inside_heading() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, Some("h")),
+                text("Use "),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("foo()"),
+                Event::EndTextStyle,
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"h\",[],[]) [Str \"Use \",Code (\"\",[],[]) \"foo()\"]]"
+        );
+    }
+
+    #[test]
+    fn inline_code_inside_wrapper_style() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Bold),
+                text("bold "),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("code"),
+                Event::EndTextStyle,
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Strong [Str \"bold \",Code (\"\",[],[]) \"code\"]]]"
+        );
+    }
+
+    #[test]
+    fn inline_code_concatenates_multiple_text_events() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("a"),
+                text("b"),
+                text("c"),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Code (\"\",[],[]) \"abc\"]]"
+        );
+    }
+
+    #[test]
+    fn inline_code_escapes_quotes_in_content() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("say \"hi\""),
+                Event::EndTextStyle,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Code (\"\",[],[]) \"say \\\"hi\\\"\"]]"
+        );
+    }
+
+    #[test]
+    fn inline_code_outside_inline_block_is_dropped() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("x"),
+                Event::EndTextStyle,
+                Event::EndDocument,
+            ]),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn unclosed_inline_code_at_end_of_paragraph_does_not_swallow_following_block() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("x"),
+                Event::EndParagraph,
+                start_para(),
+                text("y"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Code (\"\",[],[]) \"x\"],Para [Str \"y\"]]"
+        );
+    }
+
+    #[test]
+    fn unclosed_inline_code_at_end_of_heading_does_not_swallow_following_block() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("x"),
+                Event::EndHeading,
+                start_para(),
+                text("y"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Code (\"\",[],[]) \"x\"],Para [Str \"y\"]]"
+        );
+    }
+
+    #[test]
+    fn unclosed_inline_code_at_end_of_paragraph_is_flushed_defensively() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_para(),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("x"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]),
+            "[Para [Code (\"\",[],[]) \"x\"]]"
+        );
+    }
+
+    #[test]
+    fn unclosed_inline_code_at_end_of_heading_is_flushed_defensively() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_heading(1, None),
+                start_style(docspec_core::TextStyleKind::Code),
+                text("x"),
+                Event::EndHeading,
+                Event::EndDocument,
+            ]),
+            "[Header 1 (\"\",[],[]) [Code (\"\",[],[]) \"x\"]]"
+        );
+    }
+
+    #[test]
+    fn unclosed_preformatted_at_end_of_document_is_flushed_defensively() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, Some("rust")),
+                text("fn main"),
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[\"rust\"],[]) \"fn main\"]"
+        );
+    }
+
+    #[test]
+    fn nested_inline_events_inside_preformatted_are_ignored() {
+        assert_eq!(
+            run([
+                start_doc(),
+                start_pre(None, None),
+                text("a"),
+                Event::LineBreak,
+                Event::SoftBreak,
+                text("b"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]),
+            "[CodeBlock (\"\",[],[]) \"ab\"]"
         );
     }
 }


### PR DESCRIPTION
Maps `StartPreformatted { id, syntax }` / `EndPreformatted` to pandoc `CodeBlock ("id",["syntax"],[]) "..."` and `StartTextStyle { kind: Code, id }` / `EndTextStyle` to inline `Code ("id",[],[]) "..."`. Both buffer all intermediate `Text` events into a single Haskell-escaped string payload (literal newlines preserved). `Code` works at block and inline scope including inside headings and wrapper styles like `Strong`. `Mark` and `TextColor` continue to flatten until separate `Span` work lands.

Real-pandoc CLI round-trip verified through markdown and canonical native pretty-print.