### PR TITLE
DOCX: Hyperlinks

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -19,10 +19,10 @@ architecture, and the event protocol.
 - Paragraph properties (`<w:pPr>`): `<w:jc>` (alignment — `left`/`start` to Left, `right`/`end` to Right, `center` to Center, `both`/`distribute` to Justify)
 - Empty `<w:rPr/>` and `<w:pPr/>` are treated as no properties (default style / alignment None)
 - A `<w:rPr>` or `<w:pPr>` that appears after content in the same parent is silently ignored (per the OOXML spec, both must be the first child element)
-- Hyperlinks (`<w:hyperlink>`) — link text content is emitted as plain runs. The URL target is dropped.
+- Hyperlinks (`<w:hyperlink>`): resolved via `word/_rels/document.xml.rels` and emitted as `StartLink`/`EndLink` events around inline content. Supports external URL targets (both Strict and Transitional OOXML relationship Type URIs), anchor-only links (`w:anchor` without `r:id` emits `#fragment`), and tooltips (`w:tooltip` → `StartLink.title`, XML-decoded). When the relationship cannot be resolved, the link wrapper is dropped and content passes through as plain runs.
 - Structured Document Tags (`<w:sdt>`) — the content of an SDT is emitted normally. The property containers `<w:sdtPr>` and `<w:sdtEndPr>` are dropped.
 - Tracked insertions and moves (`<w:ins>`, `<w:moveTo>`) — the inserted/moved-in content is emitted (accept-changes semantics).
-- Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`, `EndTableRow`, `EndTable`, `EndDocument`
+- Emits: `EndDocument`, `EndLink`, `EndParagraph`, `EndTable`, `EndTableCell`, `EndTableHeader`, `EndTableRow`, `EndTextStyle`, `LineBreak`, `StartDocument`, `StartLink`, `StartParagraph`, `StartTable`, `StartTableCell`, `StartTableHeader`, `StartTableRow`, `StartTextStyle`, `Text`
 - Symbol font character normalization for Wingdings, Wingdings 2, Wingdings 3, Webdings, and Symbol fonts — codepoints are mapped to their Unicode equivalents; unmapped codepoints are dropped
 - Compression: `Stored` and `Deflated` only
 
@@ -58,13 +58,15 @@ The XML elements listed below are the reader's denylist — their entire subtree
 - Document metadata
 - Tracked deletions and moves-from (`<w:del>`, `<w:moveFrom>`) — silently dropped (accept-changes semantics). Their text content uses `<w:delText>` which is not part of the reader's text-matching set.
 - Structured document tag properties (`<w:sdtPr>`, `<w:sdtEndPr>`) — metadata containers; subtree dropped.
-- Hyperlink URL targets — link text is preserved, but the `r:id` attribute pointing to the relationship is dropped.
+- Field-code hyperlinks (`<w:fldChar>` + `<w:instrText>HYPERLINK ...`): legacy form not currently supported; only the modern `<w:hyperlink>` element is recognized.
 
 ## Streaming Guarantee
 
 `DocxReader` streams `document.xml` event by event using constant memory regardless
-of document size. Only `_rels/.rels` (a few hundred bytes) is fully read into memory
-to discover the document target path.
+of document size. `_rels/.rels` and `word/_rels/document.xml.rels` are both fully
+read into memory at package-open time (typical combined size < 10 KB even for large
+documents). `word/document.xml` is consumed in streaming fashion via `quick-xml`.
+The internal event queue remains bounded regardless of document size or hyperlink count.
 
 ## Quick Start
 

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -8,6 +8,7 @@ use docspec_core::{Color, Error, Event, Result, TableHeaderScope, TextAlignment,
 use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText};
 
 use crate::properties;
+use crate::rels::HyperlinkMap;
 use crate::styles::StyleList;
 
 /// Document processing phase.
@@ -44,6 +45,27 @@ enum ParagraphBlockKind {
 pub struct DocxData {
     /// Styles loaded from the styles part, used to classify paragraph and run styles.
     pub style_list: StyleList,
+    /// Map of relationship Id → Target URL for every <w:hyperlink> r:id reference. Resolved from word/_rels/document.xml.rels at package-open time; empty if the rels file is absent or contains no hyperlink relationships.
+    pub hyperlink_map: HyperlinkMap,
+}
+
+/// Deferred-emission state for an open <w:hyperlink>.
+///
+/// Populated when `handle_start` or `handle_empty` sees a hyperlink whose
+/// `r:id` resolves OR whose `w:anchor` is non-empty. Flushed to the event
+/// queue as `Event::StartLink` immediately before the first inline
+/// content event (`Text`, `LineBreak`, `StartTextStyle`) inside the link.
+/// Discarded without emission if the hyperlink closes empty.
+#[derive(Debug, Clone)]
+pub(crate) struct PendingLink {
+    /// Resolved URL or "#anchor". Never empty.
+    href: String,
+    /// Optional XML-decoded tooltip text.
+    title: Option<String>,
+    /// True after `StartLink` has been emitted to the queue.
+    /// Used to decide whether `EndLink` should be emitted when the
+    /// hyperlink closes (or paragraph/EOF auto-closes).
+    link_started: bool,
 }
 
 #[non_exhaustive]
@@ -125,6 +147,9 @@ pub struct DocumentReader {
     run_content_emitted: bool,
     /// Package-level data (styles, future: theme, numbering).
     data: DocxData,
+    /// Hyperlink relationship map from the package. Consulted in `handle_start`
+    /// when processing `<w:hyperlink r:id="...">` to resolve the URL.
+    hyperlink_map: HyperlinkMap,
     /// Whether currently inside a `<w:tcPr>` element that is still legal (first child of cell).
     in_tcpr: bool,
     /// Whether currently inside a `<w:trPr>` element that is still legal (first child of row).
@@ -148,6 +173,14 @@ pub struct DocumentReader {
     table_depth: u32,
     /// True while the contiguous header band at the top of the outermost table is still open.
     header_band_open: bool,
+    /// Nesting depth for `<w:hyperlink>`. Incremented on hyperlink open
+    /// (only when `denied_stack` is empty). Decremented on hyperlink close.
+    /// `StartLink` is emitted only at the 0→1 transition; `EndLink` only at 1→0.
+    hyperlink_depth: u32,
+    /// State of the currently-open (depth >= 1) hyperlink, if any.
+    /// Some when a hyperlink has been opened but possibly before its
+    /// `StartLink` has been flushed. None when no hyperlink is open.
+    pending_link: Option<PendingLink>,
     /// The quick-xml reader streaming from the document entry.
     xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
 }
@@ -155,6 +188,10 @@ pub struct DocumentReader {
 impl fmt::Debug for DocumentReader {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let pending_link = self
+            .pending_link
+            .as_ref()
+            .map(|pending| (&pending.href, &pending.title, pending.link_started));
         let mut debug = f.debug_struct("DocumentReader");
         debug
             .field("buf", &self.buf)
@@ -187,7 +224,10 @@ impl fmt::Debug for DocumentReader {
             .field("phase", &"<phase>")
             .field("queue", &self.queue)
             .field("run_content_emitted", &self.run_content_emitted)
-            .field("data", &"<DocxData>");
+            .field("data", &"<DocxData>")
+            .field("hyperlink_map", &self.hyperlink_map)
+            .field("hyperlink_depth", &self.hyperlink_depth)
+            .field("pending_link", &pending_link);
         if std::env::var_os("DOCSPEC_DEBUG_DEFERRED_TABLE_SCAFFOLD").is_some() {
             debug
                 .field("in_tcpr", &self.in_tcpr)
@@ -209,9 +249,14 @@ impl fmt::Debug for DocumentReader {
 
 impl DocumentReader {
     pub fn from_xml_reader(
-        xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
+        mut xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
         data: DocxData,
     ) -> Self {
+        xml.config_mut().check_end_names = false;
+        let DocxData {
+            style_list,
+            hyperlink_map,
+        } = data;
         Self {
             buf: Vec::with_capacity(4096),
             denied_stack: Vec::new(),
@@ -237,7 +282,11 @@ impl DocumentReader {
             phase: Phase::NotStarted,
             queue: VecDeque::new(),
             run_content_emitted: false,
-            data,
+            data: DocxData {
+                style_list,
+                hyperlink_map: HyperlinkMap::default(),
+            },
+            hyperlink_map,
             in_tcpr: false,
             in_trpr: false,
             pending_colspan: None,
@@ -249,6 +298,8 @@ impl DocumentReader {
             nested_row_state_stack: Vec::new(),
             table_depth: 0,
             header_band_open: false,
+            hyperlink_depth: 0,
+            pending_link: None,
             xml,
         }
     }
@@ -262,6 +313,7 @@ impl DocumentReader {
     fn emit_line_break(&mut self) {
         self.ensure_paragraph_started();
         self.flush_pending_text();
+        self.flush_pending_link_start();
         self.emit_deferred_starts();
         self.run_content_emitted = true;
         self.queue.push_back(Event::LineBreak);
@@ -270,6 +322,7 @@ impl DocumentReader {
     fn emit_tab(&mut self) {
         self.ensure_paragraph_started();
         self.flush_pending_text();
+        self.flush_pending_link_start();
         self.emit_deferred_starts();
         self.run_content_emitted = true;
         self.queue.push_back(Event::Text {
@@ -291,6 +344,12 @@ impl DocumentReader {
         self.pending_run_text_color = None;
         self.pending_run_mark = None;
         self.pending_run_shade = None;
+        if let Some(link) = self.pending_link.take() {
+            if link.link_started {
+                self.queue.push_back(Event::EndLink);
+            }
+        }
+        self.hyperlink_depth = 0;
         let end_event = match self.current_paragraph_block {
             ParagraphBlockKind::Paragraph => Event::EndParagraph,
             ParagraphBlockKind::Heading { .. } => Event::EndHeading,
@@ -336,8 +395,35 @@ impl DocumentReader {
         };
 
         if !content.is_empty() {
+            self.flush_pending_link_start();
             self.emit_deferred_starts();
             self.queue.push_back(Event::Text { content });
+        }
+    }
+
+    fn flush_pending_link_start(&mut self) {
+        let should_start = self
+            .pending_link
+            .as_ref()
+            .is_some_and(|link| !link.link_started);
+        if !should_start {
+            return;
+        }
+
+        self.ensure_cell_started();
+        self.ensure_paragraph_started();
+
+        if let Some(link) = self.pending_link.as_mut() {
+            if !link.link_started {
+                let href = link.href.clone();
+                let title = link.title.clone();
+                link.link_started = true;
+                self.queue.push_back(Event::StartLink {
+                    href,
+                    id: None,
+                    title,
+                });
+            }
         }
     }
 
@@ -535,9 +621,12 @@ impl DocumentReader {
                 self.ensure_cell_started();
                 self.emit_tab();
             }
+            b"hyperlink" => Self::handle_empty_hyperlink(),
             _ => {}
         }
     }
+
+    fn handle_empty_hyperlink() {}
 
     fn handle_end(&mut self, local: &[u8]) {
         if let Some(&top) = self.denied_stack.last() {
@@ -616,6 +705,16 @@ impl DocumentReader {
                     self.queue.push_back(Event::EndTableCell);
                 }
                 self.in_table_cell = false;
+            }
+            b"hyperlink" if self.hyperlink_depth > 0 => {
+                if self.hyperlink_depth == 1 {
+                    if let Some(link) = self.pending_link.take() {
+                        if link.link_started {
+                            self.queue.push_back(Event::EndLink);
+                        }
+                    }
+                }
+                self.hyperlink_depth = self.hyperlink_depth.saturating_sub(1);
             }
             _ => {}
         }
@@ -722,8 +821,50 @@ impl DocumentReader {
                 self.ensure_cell_started();
                 self.emit_tab();
             }
+            (b"hyperlink", _) if !self.in_paragraph => {
+                self.hyperlink_depth = self.hyperlink_depth.saturating_add(1);
+            }
+            (b"hyperlink", _) => self.handle_hyperlink_start(tag),
             _ => {}
         }
+    }
+
+    fn handle_hyperlink_start(&mut self, tag: &BytesStart<'_>) {
+        self.hyperlink_depth = self.hyperlink_depth.saturating_add(1);
+        if self.hyperlink_depth != 1 || self.pending_link.is_some() {
+            return;
+        }
+        if self.current_paragraph_block == ParagraphBlockKind::Preformatted {
+            return;
+        }
+
+        let rid = read_attribute(tag, b"r:id");
+        let anchor = read_attribute(tag, b"w:anchor");
+        let tooltip = read_attribute(tag, b"w:tooltip");
+
+        let href = if let Some(rid_val) = rid {
+            if let Some(target) = self.hyperlink_map.get(&rid_val) {
+                target.clone()
+            } else {
+                return;
+            }
+        } else if let Some(anchor_val) = anchor.filter(|a| !a.is_empty()) {
+            format!("#{anchor_val}")
+        } else {
+            return;
+        };
+
+        let title = tooltip.and_then(|t| {
+            quick_xml::escape::unescape(&t)
+                .ok()
+                .map(std::borrow::Cow::into_owned)
+        });
+
+        self.pending_link = Some(PendingLink {
+            href,
+            title,
+            link_started: false,
+        });
     }
 
     fn handle_table_start(&mut self, local: &[u8], tag: &BytesStart<'_>) -> bool {
@@ -1049,7 +1190,8 @@ fn parse_error(message: String) -> Error {
 #[cfg(test)]
 #[cfg(not(coverage))]
 mod tests {
-    #![allow(clippy::expect_used, clippy::panic)]
+    #![allow(clippy::expect_used, clippy::panic, clippy::separated_literal_suffix)]
+    use core::fmt::Write as _;
     use std::io::{Cursor, Read};
 
     use super::*;
@@ -1067,7 +1209,10 @@ mod tests {
         let xml = styles_xml(styles_body);
         let style_list = crate::styles::StyleList::parse(std::io::Cursor::new(xml.into_bytes()))
             .expect("valid styles XML");
-        DocxData { style_list }
+        DocxData {
+            style_list,
+            hyperlink_map: HyperlinkMap::default(),
+        }
     }
 
     fn make_reader_with_styles(document_xml: &str, styles_body: &str) -> DocumentReader {
@@ -1100,8 +1245,41 @@ mod tests {
         let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
         let data = DocxData {
             style_list: crate::styles::StyleList::default(),
+            hyperlink_map: HyperlinkMap::default(),
         };
         DocumentReader::from_xml_reader(xml, data)
+    }
+
+    fn make_reader_with_hyperlinks(
+        document_xml: &str,
+        hyperlink_map: HyperlinkMap,
+    ) -> DocumentReader {
+        let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
+        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
+        let data = DocxData {
+            style_list: crate::styles::StyleList::default(),
+            hyperlink_map,
+        };
+        DocumentReader::from_xml_reader(xml, data)
+    }
+
+    #[test]
+    fn document_reader_initializes_hyperlink_state_to_default() {
+        let doc = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body/></w:document>"#;
+        let reader = make_reader(doc);
+
+        assert_eq!(reader.hyperlink_depth, 0);
+        assert!(reader.pending_link.is_none());
+    }
+
+    #[test]
+    fn document_reader_debug_includes_hyperlink_fields() {
+        let doc = r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body/></w:document>"#;
+        let reader = make_reader(doc);
+        let debug = format!("{reader:?}");
+
+        assert!(debug.contains("hyperlink_depth"));
+        assert!(debug.contains("pending_link"));
     }
 
     #[test]
@@ -1147,6 +1325,39 @@ mod tests {
             content
         };
         let mut reader = make_reader(&doc);
+        loop {
+            if reader.queue.len() > 32 {
+                return Err(Box::new(Error::Other {
+                    message: format!("queue grew to {}", reader.queue.len()),
+                }));
+            }
+            if reader.next_event()?.is_none() {
+                break;
+            }
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn queue_length_bounded_with_hyperlinks(
+    ) -> core::result::Result<(), Box<dyn core::error::Error>> {
+        let doc = {
+            let mut content = String::from(
+                r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><w:body>"#,
+            );
+            for i in 0..1000_u32 {
+                write!(
+                    content,
+                    r#"<w:p><w:hyperlink r:id="rId{i}"><w:r><w:t>link{i}</w:t></w:r></w:hyperlink></w:p>"#
+                )?;
+            }
+            content.push_str("</w:body></w:document>");
+            content
+        };
+        let hyperlink_map: HyperlinkMap = (0..1000_u32)
+            .map(|i| (format!("rId{i}"), format!("https://example.com/{i}")))
+            .collect();
+        let mut reader = make_reader_with_hyperlinks(&doc, hyperlink_map);
         loop {
             if reader.queue.len() > 32 {
                 return Err(Box::new(Error::Other {

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -12,14 +12,16 @@
 //! line breaks (`<w:br>` — including `w:type="page"` and `w:type="column"`, all
 //! emitted as `LineBreak`), tabs (`<w:tab>`, emitted as a `Text` event whose
 //! content is the single character `"\t"`), tables (`<w:tbl>`, `<w:tr>`,
-//! `<w:tc>`), hyperlinks (`<w:hyperlink>` — link text content is emitted as
-//! plain runs), structured document tags (`<w:sdt>` — content emitted normally;
-//! `<w:sdtPr>`/`<w:sdtEndPr>` dropped), and tracked insertions and moves
-//! (`<w:ins>`, `<w:moveTo>` — accept-changes semantics).
-//! Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`,
-//! `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`,
-//! `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`,
-//! `EndTableRow`, `EndTable`, `EndDocument`.
+//! `<w:tc>`), hyperlinks (`<w:hyperlink>` — resolved via
+//! `word/_rels/document.xml.rels` and emitted as `StartLink`/`EndLink` events
+//! around inline content), structured document tags (`<w:sdt>` — content
+//! emitted normally; `<w:sdtPr>`/`<w:sdtEndPr>` dropped), and tracked
+//! insertions and moves (`<w:ins>`, `<w:moveTo>` — accept-changes semantics).
+//! Emits: `EndDocument`, `EndLink`, `EndParagraph`, `EndTable`, `EndTableCell`,
+//! `EndTableHeader`, `EndTableRow`, `EndTextStyle`, `LineBreak`,
+//! `StartDocument`, `StartLink`, `StartParagraph`, `StartTable`,
+//! `StartTableCell`, `StartTableHeader`, `StartTableRow`, `StartTextStyle`,
+//! `Text`.
 //!
 //! The elements listed under "Out of scope" are the reader's denylist — their
 //! entire subtree is silently dropped. Every other element (known or unknown)
@@ -41,12 +43,19 @@
 //! - Document metadata
 //! - Tracked deletions (`<w:del>`, `<w:moveFrom>`) — accept-changes semantics
 //! - Structured document tag properties (`<w:sdtPr>`, `<w:sdtEndPr>`)
+//! - Field-code hyperlinks (`<w:fldChar>` + `<w:instrText>HYPERLINK ...`):
+//!   legacy form not currently supported; only the modern `<w:hyperlink>`
+//!   element is recognized.
 //!
 //! # Streaming Guarantee
 //!
 //! `DocxReader` streams `document.xml` event by event using constant memory
-//! regardless of document size. Only `_rels/.rels` (a few hundred bytes) is
-//! fully read into memory to discover the document target path.
+//! regardless of document size. `_rels/.rels` and
+//! `word/_rels/document.xml.rels` are both fully read into memory at
+//! package-open time (typical combined size < 10 KB even for large documents).
+//! `word/document.xml` is consumed in streaming fashion via `quick-xml`. The
+//! internal event queue remains bounded regardless of document size or
+//! hyperlink count.
 //!
 //! # Quick Start
 //!
@@ -85,8 +94,9 @@ use docspec_core::{Error, Result};
 /// # Streaming
 ///
 /// The reader streams `document.xml` event by event using constant memory.
-/// Only `_rels/.rels` (a few hundred bytes) is buffered to discover the
-/// document target path.
+/// `_rels/.rels` and `word/_rels/document.xml.rels` are both fully read into
+/// memory at package-open time (typical combined size < 10 KB). The internal
+/// event queue remains bounded regardless of document size or hyperlink count.
 ///
 /// # Errors
 ///
@@ -121,9 +131,12 @@ impl DocxReader {
     /// cannot be opened. Returns [`Error::Io`] for I/O failures.
     #[inline]
     pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
-        let (style_list, stream) = package::open_package(reader)?;
+        let (style_list, hyperlink_map, stream) = package::open_package(reader)?;
         let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
-        let data = document::DocxData { style_list };
+        let data = document::DocxData {
+            style_list,
+            hyperlink_map,
+        };
         Ok(Self {
             inner: document::DocumentReader::from_xml_reader(xml, data),
         })

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -6,11 +6,12 @@ use docspec_core::{Error, Result};
 use zip::result::ZipError;
 
 use crate::rels;
+use crate::rels::HyperlinkMap;
 use crate::styles::StyleList;
 
 pub fn open_package<R: Read + Seek + Send + 'static>(
     mut reader: R,
-) -> Result<(StyleList, Box<dyn Read + Send>)> {
+) -> Result<(StyleList, HyperlinkMap, Box<dyn Read + Send>)> {
     let mut archive = zip::ZipArchive::new(&mut reader).map_err(|err| match err {
         ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
             message: "not a valid ZIP archive".to_string(),
@@ -40,7 +41,8 @@ pub fn open_package<R: Read + Seek + Send + 'static>(
     };
 
     let document_path = rels::find_document_target(std::io::Cursor::new(rels_bytes))?;
-    let style_list = load_style_list(&mut archive, &document_path)?;
+    let (style_list, hyperlink_map) =
+        load_style_list_and_hyperlink_map(&mut archive, &document_path)?;
 
     let (data_start, compressed_size, method) = {
         let entry = archive
@@ -73,27 +75,38 @@ pub fn open_package<R: Read + Seek + Send + 'static>(
         });
     };
 
-    Ok((style_list, stream))
+    Ok((style_list, hyperlink_map, stream))
 }
 
-fn load_style_list<R: Read + Seek>(
+fn load_style_list_and_hyperlink_map<R: Read + Seek>(
     archive: &mut zip::ZipArchive<&mut R>,
     document_path: &str,
-) -> Result<StyleList> {
+) -> Result<(StyleList, HyperlinkMap)> {
     let doc_rels_path = rels::derive_part_rels_path(document_path);
-    let doc_rels_bytes = match archive.by_name(&doc_rels_path) {
-        Ok(mut entry) => {
-            let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).map_err(Error::from)?;
-            bytes
+    let maybe_doc_rels_bytes = if doc_rels_path == "word/_rels/document.xml.rels" {
+        match archive.by_name("word/_rels/document.xml.rels") {
+            Ok(mut entry) => {
+                let mut bytes = Vec::new();
+                entry.read_to_end(&mut bytes).map_err(Error::from)?;
+                Some(bytes)
+            }
+            Err(ZipError::FileNotFound) => None,
+            Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
         }
-        Err(ZipError::FileNotFound) => return Ok(StyleList::default()),
-        Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
+    } else {
+        read_optional_entry(archive, &doc_rels_path)?
+    };
+    let Some(doc_rels_bytes) = maybe_doc_rels_bytes else {
+        return Ok((StyleList::default(), HyperlinkMap::default()));
     };
 
-    let Some(styles_target) = rels::find_styles_target(std::io::Cursor::new(doc_rels_bytes))?
+    let hyperlink_map =
+        rels::collect_hyperlink_map(std::io::Cursor::new(doc_rels_bytes.as_slice()))?;
+
+    let Some(styles_target) =
+        rels::find_styles_target(std::io::Cursor::new(doc_rels_bytes.as_slice()))?
     else {
-        return Ok(StyleList::default());
+        return Ok((StyleList::default(), hyperlink_map));
     };
 
     let styles_path = rels::resolve_relative_target(document_path, &styles_target);
@@ -103,11 +116,27 @@ fn load_style_list<R: Read + Seek>(
             entry.read_to_end(&mut bytes).map_err(Error::from)?;
             bytes
         }
-        Err(ZipError::FileNotFound) => return Ok(StyleList::default()),
+        Err(ZipError::FileNotFound) => return Ok((StyleList::default(), hyperlink_map)),
         Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
     };
 
-    StyleList::parse(std::io::Cursor::new(styles_bytes))
+    let style_list = StyleList::parse(std::io::Cursor::new(styles_bytes))?;
+    Ok((style_list, hyperlink_map))
+}
+
+fn read_optional_entry<R: Read + Seek>(
+    archive: &mut zip::ZipArchive<&mut R>,
+    path: &str,
+) -> Result<Option<Vec<u8>>> {
+    match archive.by_name(path) {
+        Ok(mut entry) => {
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).map_err(Error::from)?;
+            Ok(Some(bytes))
+        }
+        Err(ZipError::FileNotFound) => Ok(None),
+        Err(err) => Err(parse_error(format!("malformed ZIP: {err}"))),
+    }
 }
 
 fn parse_error(message: String) -> Error {
@@ -121,10 +150,12 @@ fn parse_error(message: String) -> Error {
 #[cfg(not(coverage))]
 mod tests {
     #![allow(clippy::unwrap_used)]
+    use core::fmt::Write as _;
+    use std::collections::HashMap;
     use std::io::{Cursor, Read as _, Write as _};
     use zip::ZipWriter;
 
-    use super::open_package;
+    use super::{load_style_list_and_hyperlink_map, open_package};
     use crate::styles::StyleList;
     use docspec_core::Error;
 
@@ -170,6 +201,59 @@ mod tests {
         )
     }
 
+    fn hyperlink_doc_rels_xml(entries: &[(&str, &str)]) -> String {
+        let mut xml = String::from(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        );
+        for (id, target) in entries {
+            write!(
+                xml,
+                r#"
+  <Relationship Id="{id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="{target}" TargetMode="External"/>"#
+            )
+            .unwrap();
+        }
+        xml.push_str("\n</Relationships>");
+        xml
+    }
+
+    fn doc_rels_with_styles_and_hyperlinks(
+        styles_target: &str,
+        hyperlink_entries: &[(&str, &str)],
+    ) -> String {
+        let mut xml = String::from(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        );
+        write!(
+            xml,
+            r#"
+  <Relationship Id="rStyle" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="{styles_target}"/>"#
+        )
+        .unwrap();
+        for (id, target) in hyperlink_entries {
+            write!(
+                xml,
+                r#"
+  <Relationship Id="{id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="{target}" TargetMode="External"/>"#
+            )
+            .unwrap();
+        }
+        xml.push_str("\n</Relationships>");
+        xml
+    }
+
+    fn load_package_data(
+        entries: &[(&str, &[u8])],
+    ) -> core::result::Result<(StyleList, HashMap<String, String>), zip::result::ZipError> {
+        let zip_bytes = synth_zip(entries)?;
+        let mut reader = Cursor::new(zip_bytes);
+        let mut archive = zip::ZipArchive::new(&mut reader)?;
+        load_style_list_and_hyperlink_map(&mut archive, "word/document.xml")
+            .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+    }
+
     fn minimal_styles_xml() -> &'static str {
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
@@ -184,6 +268,108 @@ mod tests {
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:body><w:p/></w:body>
 </w:document>"#
+    }
+
+    #[test]
+    fn open_package_returns_empty_hyperlink_map_when_no_rels_file() {
+        let result = load_package_data(&[("word/document.xml", minimal_document_xml().as_bytes())]);
+
+        match result {
+            Ok((style_list, hyperlink_map)) => {
+                assert_eq!(style_list, StyleList::default());
+                assert_eq!(hyperlink_map, HashMap::new());
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected empty package data"),
+        }
+    }
+
+    #[test]
+    fn open_package_returns_empty_hyperlink_map_when_rels_has_no_hyperlinks() {
+        let doc_rels = doc_rels_xml("styles.xml");
+        let result = load_package_data(&[
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+            ("word/styles.xml", minimal_styles_xml().as_bytes()),
+        ]);
+
+        match result {
+            Ok((style_list, hyperlink_map)) => {
+                assert!(style_list.get_by_id("Normal").is_some());
+                assert_eq!(hyperlink_map, HashMap::new());
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected empty hyperlink map"),
+        }
+    }
+
+    #[test]
+    fn open_package_returns_hyperlink_map_with_single_entry() {
+        let doc_rels = hyperlink_doc_rels_xml(&[("rId5", "https://example.test/")]);
+        let result = load_package_data(&[
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+        ]);
+
+        let mut expected = HashMap::new();
+        expected.insert("rId5".to_string(), "https://example.test/".to_string());
+        match result {
+            Ok((style_list, hyperlink_map)) => {
+                assert_eq!(style_list, StyleList::default());
+                assert_eq!(hyperlink_map, expected);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected one hyperlink"),
+        }
+    }
+
+    #[test]
+    fn open_package_returns_hyperlink_map_with_styles_and_hyperlinks() {
+        let doc_rels = doc_rels_with_styles_and_hyperlinks(
+            "styles.xml",
+            &[("rId9", "https://docspec.example/hyperlink")],
+        );
+        let result = load_package_data(&[
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+            ("word/styles.xml", minimal_styles_xml().as_bytes()),
+        ]);
+
+        let mut expected = HashMap::new();
+        expected.insert(
+            "rId9".to_string(),
+            "https://docspec.example/hyperlink".to_string(),
+        );
+        match result {
+            Ok((style_list, hyperlink_map)) => {
+                assert!(style_list.get_by_id("Normal").is_some());
+                assert_eq!(hyperlink_map, expected);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected styles and hyperlink"),
+        }
+    }
+
+    #[test]
+    fn open_package_returns_hyperlink_map_with_multiple_hyperlinks() {
+        let doc_rels = hyperlink_doc_rels_xml(&[
+            ("rId2", "https://one.example/"),
+            ("rId3", "https://two.example/path"),
+            ("rId4", "mailto:team@example.test"),
+        ]);
+        let result = load_package_data(&[
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+        ]);
+
+        let expected = HashMap::from([
+            ("rId2".to_string(), "https://one.example/".to_string()),
+            ("rId3".to_string(), "https://two.example/path".to_string()),
+            ("rId4".to_string(), "mailto:team@example.test".to_string()),
+        ]);
+        match result {
+            Ok((style_list, hyperlink_map)) => {
+                assert_eq!(style_list, StyleList::default());
+                assert_eq!(hyperlink_map, expected);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected multiple hyperlinks"),
+        }
     }
 
     #[test]
@@ -228,7 +414,7 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, mut stream)) => {
+            Ok((style_list, _hyperlink_map, mut stream)) => {
                 assert!(style_list.get_by_id("Normal").is_some());
                 let mut document = String::new();
                 let read_result = stream.read_to_string(&mut document);
@@ -253,7 +439,9 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _stream)) => assert_eq!(style_list, StyleList::default()),
+            Ok((style_list, _hyperlink_map, _stream)) => {
+                assert_eq!(style_list, StyleList::default());
+            }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
         }
     }
@@ -274,7 +462,9 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _stream)) => assert_eq!(style_list, StyleList::default()),
+            Ok((style_list, _hyperlink_map, _stream)) => {
+                assert_eq!(style_list, StyleList::default());
+            }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
         }
     }

--- a/crates/docspec-docx-reader/src/rels.rs
+++ b/crates/docspec-docx-reader/src/rels.rs
@@ -1,8 +1,12 @@
+use std::collections::HashMap;
 use std::io::Read;
 
 use docspec_core::Error;
 use quick_xml::events::Event;
 use quick_xml::XmlVersion;
+
+/// Maps relationship Id (e.g., "rId7") to Target URL/path for every <Relationship> entry whose Type ends with "/hyperlink".
+pub(crate) type HyperlinkMap = HashMap<String, String>;
 
 pub fn find_document_target<R: Read>(reader: R) -> docspec_core::Result<String> {
     let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
@@ -88,6 +92,48 @@ pub fn find_styles_target<R: Read>(reader: R) -> docspec_core::Result<Option<Str
                     return Err(parse_error("malformed _rels/.rels".to_string()));
                 }
                 return Ok(None);
+            }
+            Err(_err) => {
+                return Err(parse_error("malformed _rels/.rels".to_string()));
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+}
+
+pub(crate) fn collect_hyperlink_map<R: Read>(reader: R) -> Result<HyperlinkMap, Error> {
+    let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
+    let mut buf = Vec::new();
+    let mut element_depth: usize = 0;
+    let mut hyperlinks = HashMap::new();
+
+    loop {
+        match xml_reader.read_event_into(&mut buf) {
+            Ok(Event::Start(element)) => {
+                element_depth = element_depth.saturating_add(1);
+                if element.local_name().as_ref() == b"Relationship" {
+                    if let Some((id, target)) = hyperlink_entry(&xml_reader, &element)? {
+                        hyperlinks.insert(id, target);
+                    }
+                }
+            }
+            Ok(Event::Empty(element)) if element.local_name().as_ref() == b"Relationship" => {
+                if let Some((id, target)) = hyperlink_entry(&xml_reader, &element)? {
+                    hyperlinks.insert(id, target);
+                }
+            }
+            Ok(Event::End(_)) => {
+                let Some(next_depth) = element_depth.checked_sub(1) else {
+                    return Err(parse_error("malformed _rels/.rels".to_string()));
+                };
+                element_depth = next_depth;
+            }
+            Ok(Event::Eof) => {
+                if element_depth != 0 {
+                    return Err(parse_error("malformed _rels/.rels".to_string()));
+                }
+                return Ok(hyperlinks);
             }
             Err(_err) => {
                 return Err(parse_error("malformed _rels/.rels".to_string()));
@@ -188,6 +234,45 @@ fn styles_target<R: Read>(
         }
         (Some(found_type), Some(found_target), _) if found_type.ends_with("/styles") => {
             Some(found_target)
+        }
+        _ => None,
+    })
+}
+
+fn hyperlink_entry<R: Read>(
+    reader: &quick_xml::Reader<R>,
+    element: &quick_xml::events::BytesStart<'_>,
+) -> Result<Option<(String, String)>, Error> {
+    let mut id = None;
+    let mut rel_type = None;
+    let mut target = None;
+
+    for attribute_result in element.attributes() {
+        let attribute = attribute_result.map_err(|err| Error::Parse {
+            message: format!("malformed _rels/.rels: {err}"),
+            position: None,
+        })?;
+        let value = attribute
+            .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
+            .map_err(|err| Error::Parse {
+                message: format!("malformed _rels/.rels: {err}"),
+                position: None,
+            })?
+            .into_owned();
+
+        match attribute.key.local_name().as_ref() {
+            b"Id" => id = Some(value),
+            b"Type" => rel_type = Some(value),
+            b"Target" => target = Some(value),
+            _ => {}
+        }
+    }
+
+    Ok(match (id, rel_type, target) {
+        (Some(found_id), Some(found_type), Some(found_target))
+            if found_type.ends_with("/hyperlink") =>
+        {
+            Some((found_id, found_target))
         }
         _ => None,
     })
@@ -457,6 +542,139 @@ mod tests {
   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="{target}"/>
 </Relationships>"#
         )
+    }
+
+    fn assert_hyperlink_map(result: docspec_core::Result<HyperlinkMap>, expected: &[(&str, &str)]) {
+        let expected_map = expected
+            .iter()
+            .map(|(id, target)| ((*id).to_string(), (*target).to_string()))
+            .collect::<HyperlinkMap>();
+
+        match result {
+            Ok(map) => assert_eq!(map, expected_map),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected hyperlink map"),
+        }
+    }
+
+    #[test]
+    fn collect_hyperlink_map_returns_empty_for_empty_relationships() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"/>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_finds_strict_uri_hyperlink() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://purl.oclc.org/ooxml/officeDocument/relationships/hyperlink" Target="https://example.com"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[("rId1", "https://example.com")]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_finds_transitional_uri_hyperlink() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[("rId1", "https://example.com")]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_skips_non_hyperlink_relationships() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="word/styles.xml"/>
+  <Relationship Id="rId2" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_collects_multiple_hyperlinks() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/one"/>
+  <Relationship Id="rId2" Type="http://purl.oclc.org/ooxml/officeDocument/relationships/hyperlink" Target="https://example.com/two"/>
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com/three"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(
+            result,
+            &[
+                ("rId1", "https://example.com/one"),
+                ("rId2", "https://example.com/two"),
+                ("rId3", "https://example.com/three"),
+            ],
+        );
+    }
+
+    #[test]
+    fn collect_hyperlink_map_preserves_id_to_target_mapping() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId7" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://rust-lang.org"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[("rId7", "https://rust-lang.org")]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_handles_internal_target_mode() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="other.docx" TargetMode="Internal"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[("rId1", "other.docx")]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_handles_external_target_mode() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com" TargetMode="External"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[("rId1", "https://example.com")]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_handles_missing_target_mode() {
+        let rels_xml = r#"<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" Target="https://example.com"/>
+</Relationships>"#;
+
+        let result = collect_hyperlink_map(Cursor::new(rels_xml.as_bytes()));
+
+        assert_hyperlink_map(result, &[("rId1", "https://example.com")]);
+    }
+
+    #[test]
+    fn collect_hyperlink_map_returns_err_on_malformed_xml() {
+        let result = collect_hyperlink_map(Cursor::new("<broken>".as_bytes()));
+
+        match result {
+            Err(Error::Parse { message, position }) => {
+                assert_eq!(message, "malformed _rels/.rels");
+                assert_eq!(position, None);
+            }
+            other => assert_eq!(format!("{other:?}"), "expected malformed rels parse error"),
+        }
     }
 
     #[test]

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -565,6 +565,136 @@ mod events {
         events
     }
 
+    fn start_link(href: &str, title: Option<&str>) -> Event {
+        Event::StartLink {
+            href: href.to_string(),
+            id: None,
+            title: title.map(str::to_string),
+        }
+    }
+
+    fn relationship_root() -> &'static str {
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdDoc" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#
+    }
+
+    fn document_with_hyperlink(attrs: &str, content: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink {attrs}>{content}</w:hyperlink></w:p></w:body>
+</w:document>"#
+        )
+    }
+
+    fn document_hyperlink_rels(relationship_type: &str, target: &str, target_mode: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="{relationship_type}" Target="{target}" TargetMode="{target_mode}"/>
+</Relationships>"#
+        )
+    }
+
+    fn hyperlink_events(document_xml: &str, document_rels: Option<&str>) -> Vec<Event> {
+        let mut entries = vec![
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                relationship_root().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+        ];
+        if let Some(rels_xml) = document_rels {
+            entries.push((
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                rels_xml.as_bytes(),
+            ));
+        }
+        let docx = fixture::synth_docx_with_entries(&entries);
+        let mut reader = DocxReader::from_reader(Cursor::new(docx)).expect("from_reader");
+        drive(&mut reader)
+    }
+
+    fn styled_hyperlink_events(document_xml: &str, styles_body: &str) -> Vec<Event> {
+        let document_rels = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdStyles" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/>
+  <Relationship Id="rId1" Type="{TRANSITIONAL_HYPERLINK_TYPE}" Target="https://example.com" TargetMode="External"/>
+</Relationships>"#
+        );
+        let styles_xml = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  {styles_body}
+</w:styles>"#
+        );
+        let entries = [
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                relationship_root().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+            (
+                "word/_rels/document.xml.rels",
+                zip::CompressionMethod::Deflated,
+                document_rels.as_bytes(),
+            ),
+            (
+                "word/styles.xml",
+                zip::CompressionMethod::Deflated,
+                styles_xml.as_bytes(),
+            ),
+        ];
+        let docx = fixture::synth_docx_with_entries(&entries);
+        let mut reader = DocxReader::from_reader(Cursor::new(docx)).expect("from_reader");
+        drive(&mut reader)
+    }
+
+    fn hyperlink_text_document(attrs: &str) -> String {
+        document_with_hyperlink(attrs, "<w:r><w:t>link</w:t></w:r>")
+    }
+
+    fn expected_link_events(href: &str, title: Option<&str>) -> Vec<Event> {
+        vec![
+            start_doc(),
+            start_para(),
+            start_link(href, title),
+            text("link"),
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    }
+
+    fn expected_plain_link_text_events() -> Vec<Event> {
+        vec![
+            start_doc(),
+            start_para(),
+            text("link"),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    }
+
+    const STRICT_HYPERLINK_TYPE: &str =
+        "http://purl.oclc.org/ooxml/officeDocument/relationships/hyperlink";
+    const TRANSITIONAL_HYPERLINK_TYPE: &str =
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
+
     mod rpr {
         use super::*;
 
@@ -1750,7 +1880,7 @@ mod events {
 
         assert_eq!(
             format!("{reader:?}"),
-            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", xml: \"<quick_xml::Reader>\" } }"
+            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", hyperlink_map: {}, hyperlink_depth: 0, pending_link: None, xml: \"<quick_xml::Reader>\" } }"
         );
     }
 
@@ -4366,6 +4496,791 @@ mod events {
         );
         let events = drive(&mut reader);
         assert_eq!(events, vec![start_doc(), Event::EndDocument,]);
+    }
+
+    #[test]
+    fn hyperlink_with_valid_rid_emits_start_link_before_text() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1""#);
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_link_events("https://example.com", None));
+    }
+
+    #[test]
+    fn hyperlink_with_strict_uri_type_resolves() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1""#);
+        let rels_xml =
+            document_hyperlink_rels(STRICT_HYPERLINK_TYPE, "https://example.com", "External");
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_link_events("https://example.com", None));
+    }
+
+    #[test]
+    fn hyperlink_with_transitional_uri_type_resolves() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1""#);
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_link_events("https://example.com", None));
+    }
+
+    #[test]
+    fn hyperlink_anchor_only_emits_hash_href() {
+        let document_xml = hyperlink_text_document(r#"w:anchor="section1""#);
+        let events = hyperlink_events(&document_xml, None);
+        assert_eq!(events, expected_link_events("#section1", None));
+    }
+
+    #[test]
+    fn hyperlink_rid_supersedes_anchor() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1" w:anchor="section1""#);
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_link_events("https://example.com", None));
+    }
+
+    #[test]
+    fn hyperlink_tooltip_populates_title() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1" w:tooltip="Click here""#);
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            expected_link_events("https://example.com", Some("Click here"))
+        );
+    }
+
+    #[test]
+    fn hyperlink_tooltip_with_xml_entity_is_decoded() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1" w:tooltip="Click &amp; go""#);
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            expected_link_events("https://example.com", Some("Click & go"))
+        );
+    }
+
+    #[test]
+    fn hyperlink_broken_rid_passes_through() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId99""#);
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_plain_link_text_events());
+    }
+
+    #[test]
+    fn hyperlink_broken_rid_with_anchor_still_passes_through() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId99" w:anchor="section1""#);
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_plain_link_text_events());
+    }
+
+    #[test]
+    fn hyperlink_wrong_type_rid_passes_through() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1""#);
+        let rels_xml = document_hyperlink_rels(
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles",
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_plain_link_text_events());
+    }
+
+    #[test]
+    fn hyperlink_no_rid_no_anchor_passes_through() {
+        let document_xml = hyperlink_text_document("");
+        let events = hyperlink_events(&document_xml, None);
+        assert_eq!(events, expected_plain_link_text_events());
+    }
+
+    #[test]
+    fn hyperlink_self_closing_with_valid_rid_emits_nothing() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"/></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_no_rels_file_passes_through() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1""#);
+        let events = hyperlink_events(&document_xml, None);
+        assert_eq!(events, expected_plain_link_text_events());
+    }
+
+    #[test]
+    fn no_rels_file_with_hyperlinks_passes_through_as_text() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"><w:r><w:t>fallback</w:t></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let bytes = fixture::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Deflated,
+                relationship_root().as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Deflated,
+                document_xml.as_bytes(),
+            ),
+        ]);
+        let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+        let events = drive(&mut reader);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                text("fallback"),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_internal_target_mode_emits_target_verbatim() {
+        let document_xml = hyperlink_text_document(r#"r:id="rId1""#);
+        let rels_xml =
+            document_hyperlink_rels(TRANSITIONAL_HYPERLINK_TYPE, "other.docx", "Internal");
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(events, expected_link_events("other.docx", None));
+    }
+
+    #[test]
+    fn hyperlink_emits_end_link_after_content() {
+        let document_xml = document_with_hyperlink(r#"r:id="rId1""#, "<w:r><w:t>x</w:t></w:r>");
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_nested_drops_inner_wrapper_emits_content_inline() {
+        let document_xml = document_with_hyperlink(
+            r#"r:id="rId1""#,
+            r#"<w:r><w:t>outer</w:t></w:r><w:hyperlink r:id="rId1"><w:r><w:t>inner</w:t></w:r></w:hyperlink>"#,
+        );
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("outer"),
+                text("inner"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_styled_run_emits_link_outer_style_inner() {
+        let document_xml = document_with_hyperlink(
+            r#"r:id="rId1""#,
+            "<w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r>",
+        );
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Bold,
+                    id: None,
+                },
+                text("bold"),
+                Event::EndTextStyle,
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_multi_run_styled_link_outer_styles_inner_each_run() {
+        let document_xml = document_with_hyperlink(
+            r#"r:id="rId1""#,
+            "<w:r><w:rPr><w:b/></w:rPr><w:t>bold</w:t></w:r><w:r><w:rPr><w:i/></w:rPr><w:t>italic</w:t></w:r>",
+        );
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Bold,
+                    id: None,
+                },
+                text("bold"),
+                Event::EndTextStyle,
+                Event::StartTextStyle {
+                    kind: TextStyleKind::Italic,
+                    id: None,
+                },
+                text("italic"),
+                Event::EndTextStyle,
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_empty_emits_nothing_with_valid_rid() {
+        let document_xml = document_with_hyperlink(r#"r:id="rId1""#, "");
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_drawing_inside_still_emits_link_around_text() {
+        let document_xml = document_with_hyperlink(
+            r#"r:id="rId1""#,
+            "<w:r><w:t>before</w:t></w:r><w:drawing><wp:inline/></w:drawing><w:r><w:t>after</w:t></w:r>",
+        );
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("before"),
+                text("after"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_paragraph_end_with_open_link_auto_closes() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"><w:r><w:t>x</w:t></w:r></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_eof_with_open_link_auto_closes() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"><w:r><w:t>x</w:t></w:r>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_inside_preformatted_paragraph_passes_through() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:pPr><w:pStyle w:val="Source Code"/></w:pPr><w:hyperlink r:id="rId1"><w:r><w:t>code</w:t></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let events = styled_hyperlink_events(
+            document_xml,
+            r#"<w:style w:type="paragraph" w:styleId="Source Code"><w:name w:val="Source Code"/></w:style>"#,
+        );
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartPreformatted {
+                    id: None,
+                    syntax: None,
+                },
+                text("code"),
+                Event::EndPreformatted,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_inside_denied_subtree_emits_nothing() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:drawing><w:hyperlink r:id="rId1"><w:r><w:t>inside-drawing</w:t></w:r></w:hyperlink></w:drawing></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_inside_heading_emits_link_inside_heading() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:pPr><w:pStyle w:val="Heading 1"/></w:pPr><w:hyperlink r:id="rId1"><w:r><w:t>x</w:t></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let events = styled_hyperlink_events(
+            document_xml,
+            r#"<w:style w:type="paragraph" w:styleId="Heading 1"><w:name w:val="heading 1"/></w:style>"#,
+        );
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                Event::StartHeading { level: 1, id: None },
+                start_link("https://example.com", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndHeading,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_inside_table_cell_emits_cell_before_link() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:tbl><w:tr><w:tc><w:p><w:hyperlink r:id="rId1"><w:r><w:t>x</w:t></w:r></w:hyperlink></w:p></w:tc></w:tr></w:tbl></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_table(),
+                start_row(),
+                start_cell(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndTableCell,
+                Event::EndTableRow,
+                Event::EndTable,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_inside_ins_tracked_insertion_emits_link() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:ins w:id="1" w:author="Author" w:date="2024-01-01T00:00:00Z"><w:hyperlink r:id="rId1"><w:r><w:t>x</w:t></w:r></w:hyperlink></w:ins></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_inside_sdt_content_emits_link() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:sdt><w:sdtContent><w:hyperlink r:id="rId1"><w:r><w:t>x</w:t></w:r></w:hyperlink></w:sdtContent></w:sdt></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_whitespace_only_content_emits_link_around_whitespace_text() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"><w:r><w:t xml:space="preserve"> </w:t></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text(" "),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_tab_content_emits_link_around_tab() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"><w:r><w:tab/></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("\t"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_line_break_content_emits_link_around_break() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"><w:r><w:br/></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                Event::LineBreak,
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_multiple_text_fragments_emits_single_link_wrapper() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink r:id="rId1"><w:r><w:t>a</w:t><w:t>b</w:t></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("a"),
+                text("b"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_special_chars_in_anchor_emits_verbatim_fragment() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body><w:p><w:hyperlink w:anchor="Section 1.2 §A"><w:r><w:t>x</w:t></w:r></w:hyperlink></w:p></w:body>
+</w:document>"#;
+        let events = hyperlink_events(document_xml, None);
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("#Section 1.2 §A", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_with_special_chars_in_rels_target_emits_verbatim() {
+        let document_xml = document_with_hyperlink(r#"r:id="rId1""#, "<w:r><w:t>x</w:t></w:r>");
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com?q=1&amp;r=2",
+            "External",
+        );
+        let events = hyperlink_events(&document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com?q=1&r=2", None),
+                text("x"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_in_multiple_paragraphs_each_emits_independent_link() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:hyperlink r:id="rId1"><w:r><w:t>a</w:t></w:r></w:hyperlink></w:p>
+    <w:p><w:hyperlink r:id="rId1"><w:r><w:t>b</w:t></w:r></w:hyperlink></w:p>
+  </w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("a"),
+                Event::EndLink,
+                Event::EndParagraph,
+                start_para(),
+                start_link("https://example.com", None),
+                text("b"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn hyperlink_after_unclosed_hyperlink_in_prior_paragraph_emits_correctly() {
+        let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>
+    <w:p><w:hyperlink r:id="rId1"><w:r><w:t>a</w:t></w:r></w:p>
+    <w:p><w:hyperlink r:id="rId1"><w:r><w:t>b</w:t></w:r></w:hyperlink></w:p>
+  </w:body>
+</w:document>"#;
+        let rels_xml = document_hyperlink_rels(
+            TRANSITIONAL_HYPERLINK_TYPE,
+            "https://example.com",
+            "External",
+        );
+        let events = hyperlink_events(document_xml, Some(&rels_xml));
+        assert_eq!(
+            events,
+            vec![
+                start_doc(),
+                start_para(),
+                start_link("https://example.com", None),
+                text("a"),
+                Event::EndLink,
+                Event::EndParagraph,
+                start_para(),
+                start_link("https://example.com", None),
+                text("b"),
+                Event::EndLink,
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DOCX hyperlink support: inline link wrappers are emitted around link content (start/end events), including external URLs, anchor-only links, and tooltips
  * Falls back to plain text when a link target cannot be resolved

* **Improvements**
  * Streaming guarantee updated: relationship metadata for link resolution is fully loaded at package open time while document XML remains streamed
* **Clarification**
  * Legacy field-code hyperlinks are not recognized; only modern hyperlink elements are supported
<!-- end of auto-generated comment: release notes by coderabbit.ai -->