### PR TITLE
refactor(http): centralize MIME constants

### DIFF
--- a/crates/docspec-http/src/format.rs
+++ b/crates/docspec-http/src/format.rs
@@ -1,32 +1,9 @@
-//! MIME type and HTTP header constants for the conversion API.
+//! HTTP header value and body constants for the conversion API.
+//!
+//! MIME type constants live in the sibling [`crate::mime`] module.
 
 /// Cache-Control header value applied to all responses.
 pub const CACHE_CONTROL_VALUE: &str = "max-age=0, private, must-revalidate";
 
 /// Health endpoint response body.
 pub const HEALTH_BODY: &str = "Healthy.";
-
-/// The MIME type accepted as request body.
-pub const INPUT_MIME_MARKDOWN: &str = "text/markdown";
-
-/// The MIME type accepted as request body for HTML input.
-pub const INPUT_MIME_HTML: &str = "text/html";
-
-/// MIME type for DOCX documents. Strict — must be sent verbatim with no parameters.
-pub const INPUT_MIME_DOCX_PRIMARY: &str =
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-
-/// Accepted alias for the output MIME type (input-only; server always returns primary).
-pub const OUTPUT_MIME_ALIAS: &str = "application/vnd.blocknote+json";
-
-/// The primary output MIME type returned on success.
-pub const OUTPUT_MIME_PRIMARY: &str = "application/vnd.docspec.blocknote+json";
-
-/// The primary HTML output MIME type returned when the HTML writer is selected.
-pub const OUTPUT_MIME_HTML_PRIMARY: &str = "text/html";
-
-/// The primary `oxa.dev` output MIME type returned when the `oxa.dev` writer is selected.
-pub const OUTPUT_MIME_OXA_PRIMARY: &str = "application/vnd.oxa+json";
-
-/// The primary Pandoc native output MIME type returned when the Pandoc native writer is selected.
-pub const OUTPUT_MIME_PANDOC_NATIVE_PRIMARY: &str = "application/vnd.pandoc.native";

--- a/crates/docspec-http/src/lib.rs
+++ b/crates/docspec-http/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 pub mod format;
 pub mod handlers;
 pub mod metrics;
+pub mod mime;
 pub mod mime_parser;
 pub mod router;
 pub mod server;

--- a/crates/docspec-http/src/metrics/mod.rs
+++ b/crates/docspec-http/src/metrics/mod.rs
@@ -78,35 +78,23 @@ pub const RESULT_SERVER_ERROR: &str = "server_error";
 /// Value for [`LABEL_ERROR_CLASS`] when no error occurred.
 pub const ERROR_CLASS_NONE: &str = "none";
 
-/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was text/markdown.
-pub const INPUT_MIME_MARKDOWN: &str = "text/markdown";
-
-/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was text/html.
-pub const INPUT_MIME_HTML: &str = "text/html";
-
-/// Value for [`LABEL_INPUT_MIME_TYPE`] when the request was a DOCX document.
-pub const INPUT_MIME_DOCX: &str =
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
-
-/// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was present but not a supported reader format.
-pub const INPUT_MIME_UNSUPPORTED: &str = "unsupported";
-
 /// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was absent.
+///
+/// This is a label sentinel, not a real MIME type. Real MIME types live in
+/// [`crate::mime`].
 pub const INPUT_MIME_NONE: &str = "none";
 
-/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `BlockNote` JSON.
-pub const OUTPUT_MIME_BLOCKNOTE: &str = "application/vnd.docspec.blocknote+json";
-
-/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced HTML.
-pub const OUTPUT_MIME_HTML: &str = "text/html";
-
-/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced `oxa.dev` JSON.
-pub const OUTPUT_MIME_OXA: &str = "application/vnd.oxa+json";
-
-/// Value for [`LABEL_OUTPUT_MIME_TYPE`] when the conversion produced Pandoc native syntax.
-pub const OUTPUT_MIME_PANDOC_NATIVE: &str = "application/vnd.pandoc.native";
+/// Value for [`LABEL_INPUT_MIME_TYPE`] when the Content-Type header was present
+/// but not a supported reader format.
+///
+/// This is a label sentinel, not a real MIME type. Real MIME types live in
+/// [`crate::mime`].
+pub const INPUT_MIME_UNSUPPORTED: &str = "unsupported";
 
 /// Value for [`LABEL_OUTPUT_MIME_TYPE`] when no output was produced (any error path).
+///
+/// This is a label sentinel, not a real MIME type. Real MIME types live in
+/// [`crate::mime`].
 pub const OUTPUT_MIME_NONE: &str = "none";
 
 // ─── Histogram bucket arrays ───────────────────────────────────────────────

--- a/crates/docspec-http/src/mime.rs
+++ b/crates/docspec-http/src/mime.rs
@@ -1,0 +1,48 @@
+//! Centralized MIME type constants for the conversion API.
+//!
+//! These constants are bare MIME types — no parameters (no `charset=utf-8`,
+//! no `q=...`). The `Content-Type` and `Accept` parsers strip parameters
+//! before comparing against these values; the conversion handler appends
+//! `; charset=utf-8` when constructing response `Content-Type` headers.
+//!
+//! # Why one canonical home
+//!
+//! These strings appear in three places at runtime:
+//!
+//! 1. [`crate::mime_parser`] — validating `Content-Type` and negotiating `Accept`.
+//! 2. [`crate::metrics`] — as bounded label values for the `input_mime_type`
+//!    and `output_mime_type` Prometheus labels.
+//! 3. Integration tests — asserting response shapes and error messages.
+//!
+//! Defining them once here eliminates the risk that the validator and the
+//! metrics layer disagree on what counts as a "supported" MIME.
+
+/// MIME type for `BlockNote` JSON output. The primary output type returned
+/// on success when the client did not request a different format.
+pub const MIME_BLOCKNOTE: &str = "application/vnd.docspec.blocknote+json";
+
+/// Accepted alias for the `BlockNote` output MIME (input-only on `Accept`;
+/// the server always returns [`MIME_BLOCKNOTE`] in its `Content-Type`).
+pub const MIME_BLOCKNOTE_ALIAS: &str = "application/vnd.blocknote+json";
+
+/// MIME type for DOCX input. Strict — accepted as `Content-Type` only when
+/// sent verbatim with no parameters (binary format; charset is meaningless).
+pub const MIME_DOCX: &str =
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+
+/// MIME type for HTML. Accepted as both input `Content-Type` and output
+/// `Accept`; emitted as the response `Content-Type` when the HTML writer
+/// is selected.
+pub const MIME_HTML: &str = "text/html";
+
+/// MIME type for Markdown input. Accepted as `Content-Type` on
+/// `POST /conversion`.
+pub const MIME_MARKDOWN: &str = "text/markdown";
+
+/// MIME type for `oxa.dev` JSON output, emitted when the `oxa.dev` writer is
+/// selected.
+pub const MIME_OXA: &str = "application/vnd.oxa+json";
+
+/// MIME type for Pandoc native output, emitted when the Pandoc native writer
+/// is selected.
+pub const MIME_PANDOC_NATIVE: &str = "application/vnd.pandoc.native";

--- a/crates/docspec-http/src/mime_parser.rs
+++ b/crates/docspec-http/src/mime_parser.rs
@@ -4,10 +4,7 @@ use axum::http::HeaderValue;
 use docspec::{InputFormat, OutputFormat};
 
 use crate::error::HttpError;
-use crate::format::{
-    OUTPUT_MIME_ALIAS, OUTPUT_MIME_HTML_PRIMARY, OUTPUT_MIME_OXA_PRIMARY,
-    OUTPUT_MIME_PANDOC_NATIVE_PRIMARY, OUTPUT_MIME_PRIMARY,
-};
+use crate::mime::{MIME_BLOCKNOTE, MIME_BLOCKNOTE_ALIAS, MIME_HTML, MIME_OXA, MIME_PANDOC_NATIVE};
 
 /// Negotiates the `Accept` header for the `/conversion` endpoint.
 ///
@@ -34,19 +31,19 @@ pub fn negotiate_accept(header_value: Option<&HeaderValue>) -> Result<OutputForm
 
     for part in header_str.split(',') {
         let type_part = part.trim().split(';').next().map_or("", str::trim);
-        if type_part.eq_ignore_ascii_case(OUTPUT_MIME_OXA_PRIMARY) {
+        if type_part.eq_ignore_ascii_case(MIME_OXA) {
             return Ok(OutputFormat::Oxa);
         }
-        if type_part.eq_ignore_ascii_case(OUTPUT_MIME_PANDOC_NATIVE_PRIMARY) {
+        if type_part.eq_ignore_ascii_case(MIME_PANDOC_NATIVE) {
             return Ok(OutputFormat::PandocNative);
         }
-        if type_part.eq_ignore_ascii_case(OUTPUT_MIME_HTML_PRIMARY) {
+        if type_part.eq_ignore_ascii_case(MIME_HTML) {
             return Ok(OutputFormat::Html);
         }
         if type_part.eq_ignore_ascii_case("*/*")
             || type_part.eq_ignore_ascii_case("application/*")
-            || type_part.eq_ignore_ascii_case(OUTPUT_MIME_PRIMARY)
-            || type_part.eq_ignore_ascii_case(OUTPUT_MIME_ALIAS)
+            || type_part.eq_ignore_ascii_case(MIME_BLOCKNOTE)
+            || type_part.eq_ignore_ascii_case(MIME_BLOCKNOTE_ALIAS)
         {
             return Ok(OutputFormat::Blocknote);
         }
@@ -139,9 +136,9 @@ pub fn validate_content_type(header_value: Option<&HeaderValue>) -> Result<Input
 /// # Label values
 ///
 /// - [`crate::metrics::INPUT_MIME_NONE`] — header absent
-/// - [`crate::metrics::INPUT_MIME_MARKDOWN`] — `text/markdown` (any params)
-/// - [`crate::metrics::INPUT_MIME_HTML`] — `text/html` (any params)
-/// - [`crate::metrics::INPUT_MIME_DOCX`] — `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (any params)
+/// - [`crate::mime::MIME_MARKDOWN`] — `text/markdown` (any params)
+/// - [`crate::mime::MIME_HTML`] — `text/html` (any params)
+/// - [`crate::mime::MIME_DOCX`] — `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (any params)
 /// - [`crate::metrics::INPUT_MIME_UNSUPPORTED`] — anything else
 #[must_use]
 #[inline]
@@ -156,10 +153,10 @@ pub fn bucket_input_mime(header_value: Option<&HeaderValue>) -> &'static str {
         return crate::metrics::INPUT_MIME_UNSUPPORTED;
     };
     match (parsed.type_(), parsed.subtype().as_str()) {
-        (mime::TEXT, "markdown") => crate::metrics::INPUT_MIME_MARKDOWN,
-        (mime::TEXT, "html") => crate::metrics::INPUT_MIME_HTML,
+        (mime::TEXT, "markdown") => crate::mime::MIME_MARKDOWN,
+        (mime::TEXT, "html") => crate::mime::MIME_HTML,
         (mime::APPLICATION, "vnd.openxmlformats-officedocument.wordprocessingml.document") => {
-            crate::metrics::INPUT_MIME_DOCX
+            crate::mime::MIME_DOCX
         }
         _ => crate::metrics::INPUT_MIME_UNSUPPORTED,
     }
@@ -172,10 +169,10 @@ pub fn bucket_input_mime(header_value: Option<&HeaderValue>) -> &'static str {
 #[must_use]
 pub fn bucket_output_mime(chosen_format: Option<OutputFormat>) -> &'static str {
     match chosen_format {
-        Some(OutputFormat::Blocknote) => crate::metrics::OUTPUT_MIME_BLOCKNOTE,
-        Some(OutputFormat::Html) => crate::metrics::OUTPUT_MIME_HTML,
-        Some(OutputFormat::Oxa) => crate::metrics::OUTPUT_MIME_OXA,
-        Some(OutputFormat::PandocNative) => crate::metrics::OUTPUT_MIME_PANDOC_NATIVE,
+        Some(OutputFormat::Blocknote) => crate::mime::MIME_BLOCKNOTE,
+        Some(OutputFormat::Html) => crate::mime::MIME_HTML,
+        Some(OutputFormat::Oxa) => crate::mime::MIME_OXA,
+        Some(OutputFormat::PandocNative) => crate::mime::MIME_PANDOC_NATIVE,
         None | Some(_) => crate::metrics::OUTPUT_MIME_NONE,
     }
 }
@@ -201,64 +198,43 @@ mod bucket_tests {
     #[test]
     fn bucket_input_mime_markdown_when_text_markdown() {
         let val = HeaderValue::from_static("text/markdown");
-        assert_eq!(
-            bucket_input_mime(Some(&val)),
-            crate::metrics::INPUT_MIME_MARKDOWN
-        );
+        assert_eq!(bucket_input_mime(Some(&val)), crate::mime::MIME_MARKDOWN);
     }
 
     #[test]
     fn bucket_input_mime_markdown_when_text_markdown_with_charset() {
         let val = HeaderValue::from_static("text/markdown; charset=utf-8");
-        assert_eq!(
-            bucket_input_mime(Some(&val)),
-            crate::metrics::INPUT_MIME_MARKDOWN
-        );
+        assert_eq!(bucket_input_mime(Some(&val)), crate::mime::MIME_MARKDOWN);
     }
 
     #[test]
     fn bucket_input_mime_markdown_case_insensitive() {
         let val = HeaderValue::from_static("TEXT/MARKDOWN");
-        assert_eq!(
-            bucket_input_mime(Some(&val)),
-            crate::metrics::INPUT_MIME_MARKDOWN
-        );
+        assert_eq!(bucket_input_mime(Some(&val)), crate::mime::MIME_MARKDOWN);
     }
 
     #[test]
     fn bucket_input_mime_html_when_text_html() {
         let val = HeaderValue::from_static("text/html");
-        assert_eq!(
-            bucket_input_mime(Some(&val)),
-            crate::metrics::INPUT_MIME_HTML
-        );
+        assert_eq!(bucket_input_mime(Some(&val)), crate::mime::MIME_HTML);
     }
 
     #[test]
     fn bucket_input_mime_html_when_text_html_with_charset() {
         let val = HeaderValue::from_static("text/html; charset=utf-8");
-        assert_eq!(
-            bucket_input_mime(Some(&val)),
-            crate::metrics::INPUT_MIME_HTML
-        );
+        assert_eq!(bucket_input_mime(Some(&val)), crate::mime::MIME_HTML);
     }
 
     #[test]
     fn bucket_input_mime_html_case_insensitive() {
         let val = HeaderValue::from_static("TEXT/HTML");
-        assert_eq!(
-            bucket_input_mime(Some(&val)),
-            crate::metrics::INPUT_MIME_HTML
-        );
+        assert_eq!(bucket_input_mime(Some(&val)), crate::mime::MIME_HTML);
     }
 
     #[test]
     fn bucket_input_mime_html_with_non_utf8_charset_still_buckets_html() {
         let val = HeaderValue::from_static("text/html; charset=iso-8859-1");
-        assert_eq!(
-            bucket_input_mime(Some(&val)),
-            crate::metrics::INPUT_MIME_HTML
-        );
+        assert_eq!(bucket_input_mime(Some(&val)), crate::mime::MIME_HTML);
     }
 
     #[test]
@@ -294,7 +270,7 @@ mod bucket_tests {
     fn bucket_output_mime_blocknote_when_blocknote_succeeded() {
         assert_eq!(
             bucket_output_mime(Some(OutputFormat::Blocknote)),
-            crate::metrics::OUTPUT_MIME_BLOCKNOTE
+            crate::mime::MIME_BLOCKNOTE
         );
     }
 
@@ -302,7 +278,7 @@ mod bucket_tests {
     fn bucket_output_mime_html_when_html_succeeded() {
         assert_eq!(
             bucket_output_mime(Some(OutputFormat::Html)),
-            crate::metrics::OUTPUT_MIME_HTML
+            crate::mime::MIME_HTML
         );
     }
 
@@ -310,7 +286,7 @@ mod bucket_tests {
     fn bucket_output_mime_oxa_when_oxa_succeeded() {
         assert_eq!(
             bucket_output_mime(Some(OutputFormat::Oxa)),
-            crate::metrics::OUTPUT_MIME_OXA
+            crate::mime::MIME_OXA
         );
     }
 
@@ -318,7 +294,7 @@ mod bucket_tests {
     fn bucket_output_mime_pandoc_native_when_pandoc_native_succeeded() {
         assert_eq!(
             bucket_output_mime(Some(OutputFormat::PandocNative)),
-            crate::metrics::OUTPUT_MIME_PANDOC_NATIVE
+            crate::mime::MIME_PANDOC_NATIVE
         );
     }
 

--- a/crates/docspec-http/tests/mime_parser.rs
+++ b/crates/docspec-http/tests/mime_parser.rs
@@ -313,7 +313,7 @@ fn bucket_input_mime_docx_returns_docx_label() {
     );
     assert_eq!(
         docspec_http::mime_parser::bucket_input_mime(Some(&header)),
-        docspec_http::metrics::INPUT_MIME_DOCX
+        docspec_http::mime::MIME_DOCX
     );
 }
 
@@ -324,6 +324,6 @@ fn bucket_input_mime_docx_with_params_returns_docx_label() {
     );
     assert_eq!(
         docspec_http::mime_parser::bucket_input_mime(Some(&header)),
-        docspec_http::metrics::INPUT_MIME_DOCX
+        docspec_http::mime::MIME_DOCX
     );
 }


### PR DESCRIPTION
Centralizes MIME constants into a new `crate::mime` module. Removes the duplication between `format.rs` and `metrics/mod.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized MIME type constant definitions into a dedicated module for improved code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->