### PR TITLE
refactor(tests): centralize synth_docx fixture in docspec-test-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,9 +477,9 @@ dependencies = [
  "docspec-markdown-reader",
  "docspec-oxa-writer",
  "docspec-pandoc-native-writer",
+ "docspec-test-utils",
  "serde_json",
  "tempfile",
- "zip",
 ]
 
 [[package]]
@@ -504,12 +504,12 @@ dependencies = [
  "docspec",
  "docspec-core",
  "docspec-http",
+ "docspec-test-utils",
  "predicates",
  "reqwest",
  "serde_json",
  "tempfile",
  "thiserror",
- "zip",
 ]
 
 [[package]]
@@ -524,6 +524,7 @@ name = "docspec-docx-reader"
 version = "1.9.0"
 dependencies = [
  "docspec-core",
+ "docspec-test-utils",
  "flate2",
  "quick-xml",
  "tempfile",
@@ -555,6 +556,7 @@ dependencies = [
  "docspec",
  "docspec-core",
  "docspec-json",
+ "docspec-test-utils",
  "metrics",
  "metrics-exporter-prometheus",
  "mime",
@@ -568,7 +570,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
- "zip",
 ]
 
 [[package]]
@@ -602,6 +603,13 @@ name = "docspec-pandoc-native-writer"
 version = "1.9.0"
 dependencies = [
  "docspec-core",
+]
+
+[[package]]
+name = "docspec-test-utils"
+version = "1.9.0"
+dependencies = [
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "crates/docspec-http",
   "crates/docspec-oxa-writer",
   "crates/docspec-pandoc-native-writer",
+  "crates/docspec-test-utils",
   "crates/docspec-wasm",
 ]
 
@@ -34,6 +35,7 @@ docspec-html-writer = { path = "crates/docspec-html-writer", version = "1.9.0" }
 docspec-http = { path = "crates/docspec-http", version = "1.9.0" }
 docspec-oxa-writer = { path = "crates/docspec-oxa-writer", version = "1.9.0" }
 docspec-pandoc-native-writer = { path = "crates/docspec-pandoc-native-writer", version = "1.9.0" }
+docspec-test-utils = { path = "crates/docspec-test-utils" }
 self_cell = "1.2"
 
 [workspace.lints.rust]

--- a/crates/docspec-cli/Cargo.toml
+++ b/crates/docspec-cli/Cargo.toml
@@ -31,7 +31,7 @@ predicates = "3"
 tempfile = "3"
 serde_json = "1"
 reqwest = { version = "0.13", default-features = false, features = ["blocking"] }
-zip = { version = "8", default-features = false, features = ["deflate"] }
+docspec-test-utils = { workspace = true }
 
 [build-dependencies]
 clap = { version = "4", features = ["derive"] }

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -12,7 +12,8 @@ use assert_cmd::Command;
 use predicates::prelude::PredicateBooleanExt as _;
 use predicates::str::contains;
 use tempfile::NamedTempFile;
-use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+
+use docspec_test_utils::synth_docx;
 
 fn docspec_cmd() -> Command {
     let result = Command::cargo_bin("docspec");
@@ -63,19 +64,6 @@ fn read_output(path: &std::path::Path) -> String {
 }
 
 const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
-
-fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
-    use std::io::Cursor;
-    let buf = Cursor::new(Vec::new());
-    let mut writer = ZipWriter::new(buf);
-    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    writer.start_file("_rels/.rels", opts).unwrap();
-    writer.write_all(rels_xml.as_bytes()).unwrap();
-    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    writer.start_file("word/document.xml", opts_doc).unwrap();
-    writer.write_all(document_xml.as_bytes()).unwrap();
-    writer.finish().unwrap().into_inner()
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/docspec-docx-reader/Cargo.toml
+++ b/crates/docspec-docx-reader/Cargo.toml
@@ -18,6 +18,7 @@ flate2 = "1"
 [dev-dependencies]
 zip = { version = "8", default-features = false, features = ["deflate", "bzip2"] }
 tempfile = "3"
+docspec-test-utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-docx-reader/tests/fixture/mod.rs
+++ b/crates/docspec-docx-reader/tests/fixture/mod.rs
@@ -1,42 +1,9 @@
 //! In-memory DOCX fixture helpers for tests.
 //!
-//! Builds synthetic DOCX archives from string templates without touching the filesystem.
+//! Thin re-export of the workspace-internal `docspec-test-utils` crate.
 
-use std::io::{Cursor, Write as _};
-use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
-
-/// Builds a minimal 2-entry DOCX archive (Deflated) from raw XML strings.
-///
-/// Entries:
-/// - `_rels/.rels` — the relationship file
-/// - `word/document.xml` — the main document
-pub fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
-    synth_docx_with_entries(&[
-        (
-            "_rels/.rels",
-            CompressionMethod::Deflated,
-            rels_xml.as_bytes(),
-        ),
-        (
-            "word/document.xml",
-            CompressionMethod::Deflated,
-            document_xml.as_bytes(),
-        ),
-    ])
-}
-
-/// Builds a DOCX archive with arbitrary entries.
-///
-/// Each entry is a tuple of `(name, compression_method, bytes)`.
-pub fn synth_docx_with_entries(entries: &[(&str, CompressionMethod, &[u8])]) -> Vec<u8> {
-    let buf = Cursor::new(Vec::new());
-    let mut writer = ZipWriter::new(buf);
-    for (name, method, data) in entries {
-        let options = SimpleFileOptions::default().compression_method(*method);
-        writer
-            .start_file(*name, options)
-            .expect("start_file failed");
-        writer.write_all(data).expect("write_all failed");
-    }
-    writer.finish().expect("finish failed").into_inner()
-}
+// Reason: this module is included by every integration test binary in the crate.
+// Each binary uses some subset of the re-exports, so the unused-import warning
+// is unavoidable per-binary without splitting the module per test file.
+#[allow(unused_imports)]
+pub use docspec_test_utils::{synth_docx, synth_docx_with_entries};

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -54,7 +54,7 @@ tower = { version = "0.5", features = ["util"] }
 serde_json = "1"
 reqwest = { version = "0.13", features = ["blocking", "json"] }
 uuid = "1"
-zip = { version = "8", default-features = false, features = ["deflate"] }
+docspec-test-utils = { workspace = true }
 sentry = { version = "0.48", default-features = false, features = [
   "backtrace",
   "contexts",

--- a/crates/docspec-http/tests/common/mod.rs
+++ b/crates/docspec-http/tests/common/mod.rs
@@ -17,11 +17,14 @@
     dead_code
 )]
 
-use std::io::Write as _;
-
 use axum::{body::Body, http::Request, Router};
 use metrics_exporter_prometheus::PrometheusHandle;
-use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+
+// Reason: this module is included by every integration test binary in the crate.
+// Not every binary uses the re-export, so the unused-import warning is unavoidable
+// per-binary without splitting the module per test file.
+#[allow(unused_imports)]
+pub use docspec_test_utils::synth_docx;
 
 /// Builds a single-threaded Tokio runtime for synchronous integration tests.
 ///
@@ -116,24 +119,6 @@ where
 
 /// Minimal `_rels/.rels` XML for a DOCX archive pointing at `word/document.xml`.
 pub const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
-
-/// Builds a minimal 2-entry DOCX ZIP archive (Deflated) from raw XML strings.
-///
-/// # Panics
-///
-/// Panics if the ZIP writer fails (should never happen in tests).
-pub fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
-    use std::io::Cursor;
-    let buf = Cursor::new(Vec::new());
-    let mut writer = ZipWriter::new(buf);
-    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    writer.start_file("_rels/.rels", opts).unwrap();
-    writer.write_all(rels_xml.as_bytes()).unwrap();
-    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    writer.start_file("word/document.xml", opts_doc).unwrap();
-    writer.write_all(document_xml.as_bytes()).unwrap();
-    writer.finish().unwrap().into_inner()
-}
 
 /// Builds a valid DOCX conversion request.
 ///

--- a/crates/docspec-test-utils/Cargo.toml
+++ b/crates/docspec-test-utils/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "docspec-test-utils"
+version.workspace = true
+publish = false
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Internal test fixtures shared across the docspec workspace. Not published."
+
+[dependencies]
+zip = { version = "8", default-features = false, features = ["deflate"] }
+
+[lints]
+workspace = true

--- a/crates/docspec-test-utils/src/lib.rs
+++ b/crates/docspec-test-utils/src/lib.rs
@@ -1,0 +1,61 @@
+//! Internal test fixtures shared across the docspec workspace.
+//!
+//! This crate is not published. It exists solely to share fixture helpers
+//! between test modules of multiple workspace crates.
+
+// Reason: Helpers panic on internal ZIP write failure to keep test call sites
+// terse. Equivalent to the per-file allows used in workspace test modules.
+#![allow(clippy::expect_used)]
+
+use std::io::{Cursor, Write as _};
+
+pub use zip::CompressionMethod;
+use zip::{write::SimpleFileOptions, ZipWriter};
+
+/// Builds a minimal 2-entry DOCX archive (Deflated) from raw XML strings.
+///
+/// Entries:
+/// - `_rels/.rels` — the relationship file
+/// - `word/document.xml` — the main document
+///
+/// # Panics
+///
+/// Panics if the ZIP writer fails (should never happen for in-memory buffers).
+#[inline]
+#[must_use]
+pub fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
+    synth_docx_with_entries(&[
+        (
+            "_rels/.rels",
+            CompressionMethod::Deflated,
+            rels_xml.as_bytes(),
+        ),
+        (
+            "word/document.xml",
+            CompressionMethod::Deflated,
+            document_xml.as_bytes(),
+        ),
+    ])
+}
+
+/// Builds a DOCX archive with arbitrary entries.
+///
+/// Each entry is a tuple of `(name, compression_method, bytes)`.
+///
+/// # Panics
+///
+/// Panics if the ZIP writer fails (should never happen for in-memory buffers).
+#[inline]
+#[must_use]
+pub fn synth_docx_with_entries(entries: &[(&str, CompressionMethod, &[u8])]) -> Vec<u8> {
+    let buf = Cursor::new(Vec::new());
+    let mut writer = ZipWriter::new(buf);
+    for (name, method, data) in entries {
+        let options = SimpleFileOptions::default().compression_method(*method);
+        writer
+            .start_file(*name, options)
+            .expect("start_file failed");
+        writer.write_all(data).expect("write_all failed");
+    }
+    writer.finish().expect("finish failed").into_inner()
+}

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -52,7 +52,7 @@ docspec-pandoc-native-writer = { workspace = true, optional = true }
 [dev-dependencies]
 serde_json = "1"
 tempfile = "3"
-zip = { version = "8", default-features = false, features = ["deflate"] }
+docspec-test-utils = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/crates/docspec/tests/docx_color_to_blocknote.rs
+++ b/crates/docspec/tests/docx_color_to_blocknote.rs
@@ -18,28 +18,13 @@
     clippy::doc_paragraphs_missing_punctuation
 )]
 
-use std::io::{Cursor, Write as _};
-
-use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+use std::io::Cursor;
 
 use docspec::writers::BlockNoteWriter;
 use docspec::{AnyReader, EventSink as _, EventSource as _, InputFormat, StackTrackingSink};
+use docspec_test_utils::synth_docx;
 
 const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
-
-fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
-    let buf = Cursor::new(Vec::new());
-    let mut zip_writer = ZipWriter::new(buf);
-    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    zip_writer.start_file("_rels/.rels", opts).unwrap();
-    zip_writer.write_all(rels_xml.as_bytes()).unwrap();
-    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    zip_writer
-        .start_file("word/document.xml", opts_doc)
-        .unwrap();
-    zip_writer.write_all(document_xml.as_bytes()).unwrap();
-    zip_writer.finish().unwrap().into_inner()
-}
 
 /// End-to-end test: DOCX with color, highlight, and shading → BlockNote JSON.
 ///

--- a/crates/docspec/tests/readers_docx.rs
+++ b/crates/docspec/tests/readers_docx.rs
@@ -41,22 +41,11 @@ mod tests {
     }
 }
 
-use std::io::{Cursor, Write as _};
-use zip::{write::SimpleFileOptions, CompressionMethod, ZipWriter};
+use std::io::Cursor;
+
+use docspec_test_utils::synth_docx;
 
 const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
-
-fn synth_docx(rels_xml: &str, document_xml: &str) -> Vec<u8> {
-    let buf = Cursor::new(Vec::new());
-    let mut writer = ZipWriter::new(buf);
-    let opts = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    writer.start_file("_rels/.rels", opts).unwrap();
-    writer.write_all(rels_xml.as_bytes()).unwrap();
-    let opts_doc = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
-    writer.start_file("word/document.xml", opts_doc).unwrap();
-    writer.write_all(document_xml.as_bytes()).unwrap();
-    writer.finish().unwrap().into_inner()
-}
 
 #[test]
 fn any_reader_from_reader_docx_hello() {


### PR DESCRIPTION
Bootstraps a new internal `docspec-test-utils` crate (`publish = false`) and migrates 5 duplicate `synth_docx` impls (across `docspec-http`, `docspec`, `docspec-cli`, and the existing canonical in `docspec-docx-reader`) to a single source. Also drops 3 now-unused `zip` dev-dependencies.

First slice of the `docspec-test-utils` crate envisioned by the D bundle in the dedup audit; future PRs can add `event_builders`, reader/writer harnesses, and `FailingWriter`.