### PR TITLE
refactor(tests): share FailingWriter mock via docspec-test-utils

### DIFF
--- a/crates/docspec-blocknote-writer/Cargo.toml
+++ b/crates/docspec-blocknote-writer/Cargo.toml
@@ -18,7 +18,6 @@ docspec-json = { workspace = true }
 docspec-test-utils = { workspace = true }
 paste = "1"
 serde_json = "1"
-docspec-test-utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -17,34 +17,7 @@ mod tests {
         TextStyleKind,
     };
     use docspec_test_utils::builders::text;
-
-    struct FailingWriter {
-        fail_after: usize,
-        writes: usize,
-    }
-
-    impl FailingWriter {
-        fn new(fail_after: usize) -> Self {
-            Self {
-                fail_after,
-                writes: 0,
-            }
-        }
-    }
-
-    impl Write for FailingWriter {
-        fn flush(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-
-        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-            self.writes = self.writes.saturating_add(1);
-            if self.writes > self.fail_after {
-                return Err(std::io::Error::other("simulated write failure"));
-            }
-            Ok(buf.len())
-        }
-    }
+    use docspec_test_utils::FailingWriter;
 
     struct MockAssetProvider {
         assets: HashMap<String, (String, Vec<u8>)>,

--- a/crates/docspec-html-writer/tests/writer.rs
+++ b/crates/docspec-html-writer/tests/writer.rs
@@ -5,20 +5,9 @@
 use core::cell::Cell;
 use docspec_core::{Error, Event, EventSink as _, ImageSource, ListStyleType, TextStyleKind};
 use docspec_html_writer::HtmlWriter;
+use docspec_test_utils::FailingWriter;
 use std::io::{self, Write};
 use std::rc::Rc;
-
-struct FailingWriter;
-
-impl Write for FailingWriter {
-    fn flush(&mut self) -> io::Result<()> {
-        Err(io::Error::new(io::ErrorKind::BrokenPipe, "fail"))
-    }
-
-    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-        Err(io::Error::new(io::ErrorKind::BrokenPipe, "fail"))
-    }
-}
 
 struct FlushTrackingWriter {
     buf: Vec<u8>,
@@ -229,7 +218,8 @@ mod tests {
 
     #[test]
     fn write_failure_propagates_error() {
-        let mut writer = HtmlWriter::new(FailingWriter);
+        let mut writer =
+            HtmlWriter::new(FailingWriter::new(0).with_kind(io::ErrorKind::BrokenPipe));
         let result = writer.handle_event(Event::StartDocument {
             id: None,
             language: None,

--- a/crates/docspec-oxa-writer/Cargo.toml
+++ b/crates/docspec-oxa-writer/Cargo.toml
@@ -16,7 +16,6 @@ docspec-json = { workspace = true }
 [dev-dependencies]
 docspec-test-utils = { workspace = true }
 serde_json = "1"
-docspec-test-utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -4,20 +4,7 @@
 
 use docspec_core::Event;
 use docspec_pandoc_native_writer::PandocNativeWriter;
-use std::io::{self, Write};
-
-/// A writer that always fails on write.
-struct FailingWriter;
-
-impl Write for FailingWriter {
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-
-    fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
-        Err(io::Error::other("write failed"))
-    }
-}
+use docspec_test_utils::FailingWriter;
 
 #[cfg(test)]
 mod tests {
@@ -475,7 +462,7 @@ mod tests {
 
     #[test]
     fn write_error_propagates() {
-        let mut writer = PandocNativeWriter::new(FailingWriter);
+        let mut writer = PandocNativeWriter::new(FailingWriter::new(0));
         let result = writer.handle_event(start_document());
         assert!(result.is_err());
     }

--- a/crates/docspec-test-utils/Cargo.toml
+++ b/crates/docspec-test-utils/Cargo.toml
@@ -10,7 +10,6 @@ description = "Internal test fixtures shared across the docspec workspace. Not p
 [dependencies]
 docspec-core = { workspace = true }
 zip = { version = "8", default-features = false, features = ["deflate"] }
-docspec-core = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-test-utils/src/failing_writer.rs
+++ b/crates/docspec-test-utils/src/failing_writer.rs
@@ -1,0 +1,94 @@
+//! A configurable [`std::io::Write`] mock that fails after a threshold of
+//! successful writes.
+//!
+//! Used by writer integration tests to verify error propagation. Wraps the
+//! writer-under-test around a [`FailingWriter`] configured to fail on the Nth
+//! write, then assert that the error surfaces correctly through the writer's
+//! [`docspec_core::EventSink`] implementation.
+
+use std::io::{self, Write};
+
+/// A [`std::io::Write`] implementation that fails after a configurable number
+/// of successful writes.
+///
+/// Construct with [`FailingWriter::new`] to specify how many writes succeed
+/// before failures begin. Use [`FailingWriter::with_kind`] to override the
+/// [`io::ErrorKind`] returned on failure (defaults to [`io::ErrorKind::Other`]).
+///
+/// [`FailingWriter::flush`] always succeeds; only [`FailingWriter::write`]
+/// participates in the threshold counter. Failure responses always use the
+/// message `"simulated write failure"`.
+///
+/// # Examples
+///
+/// Fail immediately on the first write:
+///
+/// ```
+/// use docspec_test_utils::FailingWriter;
+/// use std::io::Write;
+///
+/// let mut writer = FailingWriter::new(0);
+/// assert!(writer.write(b"data").is_err());
+/// ```
+///
+/// Succeed once, then fail with a [`io::ErrorKind::BrokenPipe`] error:
+///
+/// ```
+/// use docspec_test_utils::FailingWriter;
+/// use std::io::{ErrorKind, Write};
+///
+/// let mut writer = FailingWriter::new(1).with_kind(ErrorKind::BrokenPipe);
+/// assert!(writer.write(b"first").is_ok());
+/// let err = writer.write(b"second").expect_err("second write must fail");
+/// assert_eq!(err.kind(), ErrorKind::BrokenPipe);
+/// ```
+#[derive(Debug)]
+pub struct FailingWriter {
+    fail_after: usize,
+    kind: io::ErrorKind,
+    writes: usize,
+}
+
+impl FailingWriter {
+    /// Constructs a [`FailingWriter`] that succeeds for the first `fail_after`
+    /// writes and fails on every write thereafter.
+    ///
+    /// Pass `0` to fail immediately on the first write. The default error kind
+    /// is [`io::ErrorKind::Other`]; use [`FailingWriter::with_kind`] to
+    /// override.
+    #[inline]
+    #[must_use]
+    pub fn new(fail_after: usize) -> Self {
+        Self {
+            fail_after,
+            kind: io::ErrorKind::Other,
+            writes: 0,
+        }
+    }
+
+    /// Overrides the [`io::ErrorKind`] returned by failing writes.
+    ///
+    /// Defaults to [`io::ErrorKind::Other`].
+    #[inline]
+    #[must_use]
+    pub fn with_kind(mut self, kind: io::ErrorKind) -> Self {
+        self.kind = kind;
+        self
+    }
+}
+
+impl Write for FailingWriter {
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+
+    #[inline]
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.writes = self.writes.saturating_add(1);
+        if self.writes > self.fail_after {
+            return Err(io::Error::new(self.kind, "simulated write failure"));
+        }
+        Ok(buf.len())
+    }
+}

--- a/crates/docspec-test-utils/src/lib.rs
+++ b/crates/docspec-test-utils/src/lib.rs
@@ -17,6 +17,9 @@ use zip::{write::SimpleFileOptions, ZipWriter};
 mod drive;
 pub use drive::{drive, try_drive};
 
+mod failing_writer;
+pub use failing_writer::FailingWriter;
+
 /// Builds a minimal 2-entry DOCX archive (Deflated) from raw XML strings.
 ///
 /// Entries:


### PR DESCRIPTION
Adds `FailingWriter` to `docspec-test-utils` — a configurable `std::io::Write` mock that fails after N successful writes. Replaces three duplicated impls in `docspec-blocknote-writer`, `docspec-html-writer`, and `docspec-pandoc-native-writer`.

API:
- `FailingWriter::new(fail_after)` — fails after N successful writes (0 = immediate)
- `.with_kind(io::ErrorKind)` — override default `Other` kind (used by html-writer’s `BrokenPipe` test)

Fourth slice of the D-bundle test-utils crate after #270 (synth_docx) and #273 (event builders).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored test infrastructure by consolidating shared test utilities into a dedicated, reusable crate within the workspace.
  * Centralized duplicate test helper implementations previously scattered across multiple crate test modules into a single shared utility module.
  * Updated all affected test suites to use the new centralized testing utilities for improved code maintainability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->