### PR TITLE
refactor(tests): share collect_events harness via docspec-test-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -537,6 +537,7 @@ name = "docspec-html-reader"
 version = "1.9.0"
 dependencies = [
  "docspec-core",
+ "docspec-test-utils",
  "html5gum",
 ]
 

--- a/crates/docspec-blocknote-writer/Cargo.toml
+++ b/crates/docspec-blocknote-writer/Cargo.toml
@@ -18,7 +18,6 @@ docspec-json = { workspace = true }
 docspec-test-utils = { workspace = true }
 paste = "1"
 serde_json = "1"
-docspec-test-utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-docx-reader/tests/qa_final.rs
+++ b/crates/docspec-docx-reader/tests/qa_final.rs
@@ -14,7 +14,7 @@ mod fixture;
 
 use std::io::Cursor;
 
-use docspec_core::{Event, EventSource as _, TextStyleKind};
+use docspec_core::{Event, TextStyleKind};
 use docspec_docx_reader::DocxReader;
 
 const ROOT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -57,11 +57,7 @@ fn synth_docx_with_styles(document_xml: &str, styles_xml: &str) -> Vec<u8> {
 }
 
 fn drive(reader: &mut DocxReader) -> Vec<Event> {
-    let mut events = Vec::new();
-    while let Some(event) = reader.next_event().expect("next_event") {
-        events.push(event);
-    }
-    events
+    docspec_test_utils::collect_events(reader)
 }
 
 #[test]

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -37,18 +37,9 @@ fn synth_docx_roundtrips_through_zip_archive() {
 }
 
 fn collect_events(bytes: Vec<u8>) -> Vec<docspec_core::Event> {
-    use docspec_core::EventSource as _;
     let mut reader =
         docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes)).unwrap();
-    let mut events = Vec::new();
-    loop {
-        match reader.next_event() {
-            Ok(Some(event)) => events.push(event),
-            Ok(None) => break,
-            Err(err) => panic!("unexpected error: {err:?}"),
-        }
-    }
-    events
+    docspec_test_utils::collect_events(&mut reader)
 }
 
 mod constructor {
@@ -529,11 +520,7 @@ mod events {
     }
 
     fn drive(reader: &mut DocxReader) -> Vec<Event> {
-        let mut events = Vec::new();
-        while let Some(event) = reader.next_event().expect("next_event") {
-            events.push(event);
-        }
-        events
+        docspec_test_utils::collect_events(reader)
     }
 
     fn collect_events(content: &str) -> Vec<Event> {

--- a/crates/docspec-html-reader/Cargo.toml
+++ b/crates/docspec-html-reader/Cargo.toml
@@ -13,5 +13,8 @@ categories = ["parsing"]
 docspec-core = { workspace = true }
 html5gum = "0.8"
 
+[dev-dependencies]
+docspec-test-utils = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/docspec-html-reader/tests/reader.rs
+++ b/crates/docspec-html-reader/tests/reader.rs
@@ -9,22 +9,12 @@ mod tests {
 
     fn collect_events(input: &str) -> Vec<Event> {
         let mut reader = HtmlReader::from_str(input);
-        let mut events = Vec::new();
-        while let Some(ev) = reader.next_event().expect("unexpected parse error") {
-            events.push(ev);
-        }
-        events
+        docspec_test_utils::collect_events(&mut reader)
     }
 
     fn collect_events_result(input: &str) -> Result<Vec<Event>> {
         let mut reader = HtmlReader::from_str(input);
-        let mut events = Vec::new();
-        loop {
-            match reader.next_event()? {
-                Some(ev) => events.push(ev),
-                None => return Ok(events),
-            }
-        }
+        docspec_test_utils::try_collect_events(&mut reader)
     }
 
     #[test]

--- a/crates/docspec-markdown-reader/tests/reader.rs
+++ b/crates/docspec-markdown-reader/tests/reader.rs
@@ -117,16 +117,7 @@ mod tests {
     use std::io::Cursor;
 
     fn collect_events(reader: &mut MarkdownReader) -> Vec<Event> {
-        let mut events = Vec::new();
-        loop {
-            let result = reader.next_event();
-            assert!(result.is_ok(), "next_event failed: {:?}", result.err());
-            match result {
-                Ok(Some(event)) => events.push(event),
-                Ok(None) | Err(_) => break,
-            }
-        }
-        events
+        docspec_test_utils::collect_events(reader)
     }
 
     fn collect_markdown(markdown: &str) -> Vec<Event> {

--- a/crates/docspec-oxa-writer/Cargo.toml
+++ b/crates/docspec-oxa-writer/Cargo.toml
@@ -16,7 +16,6 @@ docspec-json = { workspace = true }
 [dev-dependencies]
 docspec-test-utils = { workspace = true }
 serde_json = "1"
-docspec-test-utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-test-utils/Cargo.toml
+++ b/crates/docspec-test-utils/Cargo.toml
@@ -10,7 +10,6 @@ description = "Internal test fixtures shared across the docspec workspace. Not p
 [dependencies]
 docspec-core = { workspace = true }
 zip = { version = "8", default-features = false, features = ["deflate"] }
-docspec-core = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/docspec-test-utils/src/collect.rs
+++ b/crates/docspec-test-utils/src/collect.rs
@@ -1,0 +1,35 @@
+//! Generic event-collection harness for [`EventSource`] readers in tests.
+//!
+//! Replaces the per-reader `collect_events` / `drive` boilerplate that
+//! integration tests across reader crates would otherwise re-implement.
+
+use docspec_core::{Event, EventSource, Result};
+
+/// Drains an [`EventSource`] to completion, returning all emitted events.
+///
+/// Use [`try_collect_events`] when the test needs to inspect the error
+/// rather than panic on it.
+///
+/// # Panics
+///
+/// Panics with the underlying error if [`EventSource::next_event`] ever
+/// returns `Err`.
+#[inline]
+pub fn collect_events<R: EventSource>(reader: &mut R) -> Vec<Event> {
+    try_collect_events(reader).expect("event source returned an error")
+}
+
+/// Drains an [`EventSource`] to completion, propagating any error to the
+/// caller.
+///
+/// # Errors
+///
+/// Returns the first error produced by [`EventSource::next_event`].
+#[inline]
+pub fn try_collect_events<R: EventSource>(reader: &mut R) -> Result<Vec<Event>> {
+    let mut events = Vec::new();
+    while let Some(event) = reader.next_event()? {
+        events.push(event);
+    }
+    Ok(events)
+}

--- a/crates/docspec-test-utils/src/lib.rs
+++ b/crates/docspec-test-utils/src/lib.rs
@@ -14,7 +14,9 @@ use std::io::{Cursor, Write as _};
 pub use zip::CompressionMethod;
 use zip::{write::SimpleFileOptions, ZipWriter};
 
+mod collect;
 mod drive;
+pub use collect::{collect_events, try_collect_events};
 pub use drive::{drive, try_drive};
 
 /// Builds a minimal 2-entry DOCX archive (Deflated) from raw XML strings.


### PR DESCRIPTION
Adds `collect_events` and `try_collect_events` to `docspec-test-utils` — generic over `EventSource`. Replaces the per-reader event-collection loop body in 6 helpers across docx, markdown, and html reader integration tests.

Local `collect_events` / `drive` wrappers in each crate are preserved as thin one-line delegations — all ~270 call sites stay unchanged.

Final slice of the D-bundle test-utils crate after #270, #273, and #274.