### PR TITLE
refactor(tests): share writer drive harness via docspec-test-utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,7 @@ dependencies = [
  "base64",
  "docspec-core",
  "docspec-json",
+ "docspec-test-utils",
  "paste",
  "serde_json",
 ]
@@ -544,6 +545,7 @@ name = "docspec-html-writer"
 version = "1.9.0"
 dependencies = [
  "docspec-core",
+ "docspec-test-utils",
  "html5ever",
 ]
 
@@ -595,6 +597,7 @@ version = "1.9.0"
 dependencies = [
  "docspec-core",
  "docspec-json",
+ "docspec-test-utils",
  "serde_json",
 ]
 
@@ -603,12 +606,14 @@ name = "docspec-pandoc-native-writer"
 version = "1.9.0"
 dependencies = [
  "docspec-core",
+ "docspec-test-utils",
 ]
 
 [[package]]
 name = "docspec-test-utils"
 version = "1.9.0"
 dependencies = [
+ "docspec-core",
  "zip",
 ]
 

--- a/crates/docspec-blocknote-writer/Cargo.toml
+++ b/crates/docspec-blocknote-writer/Cargo.toml
@@ -15,6 +15,7 @@ docspec-core = { workspace = true }
 docspec-json = { workspace = true }
 
 [dev-dependencies]
+docspec-test-utils = { workspace = true }
 paste = "1"
 serde_json = "1"
 

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -103,35 +103,22 @@ mod tests {
 
     fn run_events_with_assets(events: &[Event], provider: &dyn AssetProvider) -> String {
         let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut buf, provider));
-        for event in events {
-            writer
-                .handle_event(event.clone())
-                .expect("handle_event should accept fixture event");
-        }
-        writer.finish().expect("writer should finish fixture");
+        let writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut buf, provider));
+        docspec_test_utils::drive(writer, events.iter().cloned());
         String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8")
     }
 
     fn run_events(events: &[Event]) -> String {
         let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
-        for event in events {
-            writer
-                .handle_event(event.clone())
-                .expect("handle_event should accept fixture event");
-        }
-        writer.finish().expect("writer should finish fixture");
+        let writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+        docspec_test_utils::drive(writer, events.iter().cloned());
         String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8")
     }
 
     fn run_events_result(events: &[Event]) -> docspec_core::Result<String> {
         let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
-        for event in events {
-            writer.handle_event(event.clone())?;
-        }
-        writer.finish()?;
+        let writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+        docspec_test_utils::try_drive(writer, events.iter().cloned())?;
         String::from_utf8(buf).map_err(|err| docspec_core::Error::Other {
             message: format!("BlockNoteWriter output should be valid UTF-8: {err}"),
         })
@@ -139,13 +126,8 @@ mod tests {
 
     fn run_direct_writer_events(events: &[Event]) -> String {
         let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        for event in events {
-            writer
-                .handle_event(event.clone())
-                .expect("handle_event should accept fixture event");
-        }
-        writer.finish().expect("writer should finish fixture");
+        let writer = BlockNoteWriter::new(&mut buf);
+        docspec_test_utils::drive(writer, events.iter().cloned());
         String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8")
     }
 

--- a/crates/docspec-html-writer/Cargo.toml
+++ b/crates/docspec-html-writer/Cargo.toml
@@ -13,5 +13,8 @@ categories = ["encoding"]
 docspec-core = { workspace = true }
 html5ever = "0.39"
 
+[dev-dependencies]
+docspec-test-utils = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/docspec-html-writer/src/lib.rs
+++ b/crates/docspec-html-writer/src/lib.rs
@@ -109,11 +109,8 @@ mod tests {
 
     fn assert_output(events: impl IntoIterator<Item = Event>, expected: &str) {
         let mut buf: Vec<u8> = Vec::new();
-        let mut writer = HtmlWriter::new(&mut buf);
-        for e in events {
-            let _r = writer.handle_event(e);
-        }
-        let _r = writer.finish();
+        let writer = HtmlWriter::new(&mut buf);
+        let _r = docspec_test_utils::try_drive(writer, events);
         let output = String::from_utf8(buf).unwrap();
         assert_eq!(output, expected);
     }

--- a/crates/docspec-oxa-writer/Cargo.toml
+++ b/crates/docspec-oxa-writer/Cargo.toml
@@ -14,6 +14,7 @@ docspec-core = { workspace = true }
 docspec-json = { workspace = true }
 
 [dev-dependencies]
+docspec-test-utils = { workspace = true }
 serde_json = "1"
 
 [lints]

--- a/crates/docspec-oxa-writer/tests/writer.rs
+++ b/crates/docspec-oxa-writer/tests/writer.rs
@@ -4,7 +4,7 @@
 
 #[cfg(test)]
 mod tests {
-    use docspec_core::{Error, Event, EventSink as _, ImageSource, TextStyleKind};
+    use docspec_core::{Error, Event, ImageSource, TextStyleKind};
     use docspec_oxa_writer::OxaWriter;
     use serde_json::{json, Value};
 
@@ -15,21 +15,15 @@ mod tests {
 
     fn run_raw(events: Vec<Event>) -> String {
         let mut buf = Vec::new();
-        let mut w = OxaWriter::new(&mut buf);
-        for e in events {
-            w.handle_event(e).expect("handle_event");
-        }
-        w.finish().expect("finish");
+        let w = OxaWriter::new(&mut buf);
+        docspec_test_utils::drive(w, events);
         String::from_utf8(buf).expect("utf-8")
     }
 
     fn try_run(events: Vec<Event>) -> docspec_core::Result<String> {
         let mut buf = Vec::new();
-        let mut w = OxaWriter::new(&mut buf);
-        for e in events {
-            w.handle_event(e)?;
-        }
-        w.finish()?;
+        let w = OxaWriter::new(&mut buf);
+        docspec_test_utils::try_drive(w, events)?;
         String::from_utf8(buf).map_err(|err| Error::Other {
             message: err.to_string(),
         })

--- a/crates/docspec-pandoc-native-writer/Cargo.toml
+++ b/crates/docspec-pandoc-native-writer/Cargo.toml
@@ -12,5 +12,8 @@ categories = ["text-processing"]
 [dependencies]
 docspec-core = { workspace = true }
 
+[dev-dependencies]
+docspec-test-utils = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/docspec-pandoc-native-writer/tests/writer.rs
+++ b/crates/docspec-pandoc-native-writer/tests/writer.rs
@@ -28,21 +28,15 @@ mod tests {
 
     fn run(events: impl IntoIterator<Item = Event>) -> String {
         let mut buf: Vec<u8> = Vec::new();
-        let mut writer = PandocNativeWriter::new(&mut buf);
-        for event in events {
-            writer.handle_event(event).unwrap();
-        }
-        writer.finish().unwrap();
+        let writer = PandocNativeWriter::new(&mut buf);
+        docspec_test_utils::drive(writer, events);
         String::from_utf8(buf).unwrap()
     }
 
     fn try_run(events: impl IntoIterator<Item = Event>) -> docspec_core::Result<String> {
         let mut buf: Vec<u8> = Vec::new();
-        let mut writer = PandocNativeWriter::new(&mut buf);
-        for event in events {
-            writer.handle_event(event)?;
-        }
-        writer.finish()?;
+        let writer = PandocNativeWriter::new(&mut buf);
+        docspec_test_utils::try_drive(writer, events)?;
         Ok(String::from_utf8(buf).unwrap())
     }
 

--- a/crates/docspec-test-utils/Cargo.toml
+++ b/crates/docspec-test-utils/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "Internal test fixtures shared across the docspec workspace. Not published."
 
 [dependencies]
+docspec-core = { workspace = true }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 
 [lints]

--- a/crates/docspec-test-utils/src/drive.rs
+++ b/crates/docspec-test-utils/src/drive.rs
@@ -1,0 +1,41 @@
+//! Generic event-feeding harness for [`EventSink`] writers in tests.
+//!
+//! Replaces the per-writer `for event in events { sink.handle_event(...)?; }
+//! sink.finish()?;` boilerplate that integration tests across writer crates
+//! would otherwise re-implement.
+
+use docspec_core::{Event, EventSink, Result};
+
+/// Pushes every event in `events` to `sink`, then consumes `sink` by calling
+/// [`EventSink::finish`].
+///
+/// Use [`try_drive`] when the test needs to inspect the error rather than
+/// panic on it.
+///
+/// # Panics
+///
+/// Panics with the underlying error if [`EventSink::handle_event`] or
+/// [`EventSink::finish`] ever returns `Err`.
+#[inline]
+pub fn drive<W: EventSink, I: IntoIterator<Item = Event>>(sink: W, events: I) {
+    try_drive(sink, events).expect("event sink returned an error");
+}
+
+/// Pushes every event in `events` to `sink`, then consumes `sink` by calling
+/// [`EventSink::finish`], propagating the first error to the caller.
+///
+/// # Errors
+///
+/// Returns the first error produced by [`EventSink::handle_event`] or
+/// [`EventSink::finish`].
+#[inline]
+pub fn try_drive<W: EventSink, I: IntoIterator<Item = Event>>(
+    mut sink: W,
+    events: I,
+) -> Result<()> {
+    for event in events {
+        sink.handle_event(event)?;
+    }
+    sink.finish()?;
+    Ok(())
+}

--- a/crates/docspec-test-utils/src/lib.rs
+++ b/crates/docspec-test-utils/src/lib.rs
@@ -12,6 +12,9 @@ use std::io::{Cursor, Write as _};
 pub use zip::CompressionMethod;
 use zip::{write::SimpleFileOptions, ZipWriter};
 
+mod drive;
+pub use drive::{drive, try_drive};
+
 /// Builds a minimal 2-entry DOCX archive (Deflated) from raw XML strings.
 ///
 /// Entries:


### PR DESCRIPTION
Adds `drive` and `try_drive` to `docspec-test-utils` — generic over `EventSink`. Replaces the per-writer `for event in events { sink.handle_event(...)?; } sink.finish()?;` loop body in 9 helpers across blocknote, oxa, pandoc-native, and html writer tests.

Local `run` / `try_run` / `run_events` / `assert_output` wrappers are preserved as thin delegations — all call sites stay unchanged.

Completes the D-bundle test-utils crate after #270, #273, #274, and #275.