### PR TITLE
DOCX: image support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,10 +525,12 @@ dependencies = [
 name = "docspec-docx-reader"
 version = "1.9.0"
 dependencies = [
+ "docspec-blocknote-writer",
  "docspec-core",
  "docspec-test-utils",
  "flate2",
  "quick-xml",
+ "serde_json",
  "tempfile",
  "zip",
 ]

--- a/crates/docspec-docx-reader/Cargo.toml
+++ b/crates/docspec-docx-reader/Cargo.toml
@@ -16,6 +16,8 @@ zip = { version = "8", default-features = false, features = ["deflate"] }
 flate2 = "1"
 
 [dev-dependencies]
+docspec-blocknote-writer = { workspace = true }
+serde_json = "1"
 zip = { version = "8", default-features = false, features = [
   "deflate",
   "bzip2",

--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -23,8 +23,8 @@ architecture, and the event protocol.
 - Hyperlinks (`<w:hyperlink>`): resolved via `word/_rels/document.xml.rels` and emitted as `StartLink`/`EndLink` events around inline content. Supports external URL targets (both Strict and Transitional OOXML relationship Type URIs), anchor-only links (`w:anchor` without `r:id` emits `#fragment`), and tooltips (`w:tooltip` → `StartLink.title`, XML-decoded). When the relationship cannot be resolved, the link wrapper is dropped and content passes through as plain runs.
 - Structured Document Tags (`<w:sdt>`) — the content of an SDT is emitted normally. The property containers `<w:sdtPr>` and `<w:sdtEndPr>` are dropped.
 - Tracked insertions and moves (`<w:ins>`, `<w:moveTo>`) — the inserted/moved-in content is emitted (accept-changes semantics).
-- Hyperlinks (`<w:hyperlink>`): resolved via `word/_rels/document.xml.rels` and emitted as `StartLink`/`EndLink` events around inline content. Supports external URL targets (both Strict and Transitional OOXML relationship Type URIs), anchor-only links (`w:anchor` without `r:id` emits `#fragment`), and tooltips (`w:tooltip` → `StartLink.title`, XML-decoded). When the relationship cannot be resolved, the link wrapper is dropped and content passes through as plain runs.
-- Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`, `EndTableRow`, `EndTable`, `StartLink`, `EndLink`, `StartOrderedListItem`, `EndOrderedListItem`, `StartUnorderedListItem`, `EndUnorderedListItem`, `EndDocument`
+- DrawingML images (`<w:drawing>`) — emitted as `Event::Image`. See [Image Support](#image-support) below.
+- Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`, `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`, `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`, `EndTableRow`, `EndTable`, `StartLink`, `EndLink`, `StartOrderedListItem`, `EndOrderedListItem`, `StartUnorderedListItem`, `EndUnorderedListItem`, `Image`, `EndDocument`
 - Symbol font character normalization for Wingdings, Wingdings 2, Wingdings 3, Webdings, and Symbol fonts — codepoints are mapped to their Unicode equivalents; unmapped codepoints are dropped
 - Compression: `Stored` and `Deflated` only
 
@@ -54,7 +54,7 @@ The XML elements listed below are the reader's denylist — their entire subtree
 - Header rows in nested tables — only the outermost table honors `<w:tblHeader>`
 - Table-level property exceptions (`<w:tblPrEx>`) — silently ignored (consistent with `<w:tblPr>`)
 - Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual fields, `<w:tcPr>` visual fields, `<w:tblGrid>`) — silently dropped
-- Drawings and images (`<w:drawing>`, `<w:pict>`)
+- VML images (`<w:pict>`) — deferred to follow-up; subtree silently dropped
 - Comments, footnotes, headers, footers
 - Document metadata
 - Tracked deletions and moves-from (`<w:del>`, `<w:moveFrom>`) — silently dropped (accept-changes semantics). Their text content uses `<w:delText>` which is not part of the reader's text-matching set.
@@ -72,6 +72,48 @@ The following list features are intentionally out of scope for V1:
 - No per-level marker text (`<w:lvlText>`) — not parsed
 - No level-specific font, color, or indent
 - No per-level resolution for synthesised phantom levels — when the first authored item appears at `ilvl > 0`, intermediate levels inherit the target item's ordered/unordered classification and use `Decimal`/`Disc` defaults instead of resolving each phantom level's own `numFmt`
+
+## Image Support
+
+`<w:drawing>` elements are parsed and emit `Event::Image`. The `source` field is one of two variants:
+
+- **Embedded image** (`r:embed`): `ImageSource::Asset { asset_id: "zip://word/media/image1.png" }`. The `asset_id` is the resolved ZIP entry path with a `zip://` scheme prefix. Use [`DocxAssetProvider`] to stream the raw bytes.
+- **External image** (`r:link`): `ImageSource::Uri { uri: "<url>" }`. The URL is passed through verbatim from the relationship target.
+
+When both `r:embed` and `r:link` appear on the same blip, `r:embed` wins.
+
+A relationship marked `TargetMode="External"` is honored even when referenced via `r:embed` — the reader emits `ImageSource::Uri` in that case, matching Word and LibreOffice behavior.
+
+If the relationship ID cannot be resolved (missing or malformed rels), the reader emits `ImageSource::Asset { asset_id: "<rId>" }` using the raw relationship ID with no `zip://` prefix. Writers should apply their own missing-asset policy.
+
+`wp:docPr/@descr` maps to `Event::Image.alt`. The `title` field is always `None` in this release.
+
+VML images (`<w:pict>`) are not supported in this release — their subtree is silently dropped.
+
+### DocxAssetProvider
+
+[`DocxAssetProvider`] implements the `AssetProvider` trait and streams asset bytes from the DOCX ZIP archive on demand. Open it independently from [`DocxReader`] using the same file path or an in-memory buffer.
+
+```rust,no_run
+use docspec_docx_reader::{DocxReader, DocxAssetProvider, EventSource};
+use docspec_core::{AssetProvider, Event, ImageSource};
+
+let mut reader = DocxReader::from_path("document.docx")?;
+let provider = DocxAssetProvider::from_path("document.docx")?;
+
+while let Some(event) = reader.next_event()? {
+    if let Event::Image { source: ImageSource::Asset { asset_id }, .. } = &event {
+        let mut buf = Vec::new();
+        if let Some(result) = provider.stream_to(asset_id, &mut buf) {
+            result?;
+        }
+        // buf now contains the raw image bytes (or is empty if the asset was missing)
+    }
+}
+# Ok::<(), docspec_core::Error>(())
+```
+
+For in-memory DOCX data, use `DocxAssetProvider::from_reader` with a `Cursor<Vec<u8>>`.
 
 ## Streaming Guarantee
 

--- a/crates/docspec-docx-reader/src/asset_provider.rs
+++ b/crates/docspec-docx-reader/src/asset_provider.rs
@@ -1,0 +1,240 @@
+//! DOCX ZIP archive asset provider.
+
+use std::borrow::Cow;
+use std::io::{self, Read, Seek, Write};
+use std::path::Path;
+use std::sync::Mutex;
+
+use docspec_core::{AssetProvider, Error, Result};
+use zip::result::ZipError;
+use zip::ZipArchive;
+
+use crate::content_types::{self, ContentTypes};
+
+/// Object-safe alias combining [`Read`], [`Seek`], and [`Send`] for use in trait objects.
+trait ReadSeek: Read + Seek + Send {}
+impl<T: Read + Seek + Send> ReadSeek for T {}
+
+/// Provides streaming access to binary assets stored inside a DOCX ZIP archive.
+///
+/// Holds the docx ZIP file open until dropped. Uses internal Mutex to serialize
+/// concurrent ZIP reads. Not Clone — use `Arc<DocxAssetProvider>` to share.
+pub struct DocxAssetProvider {
+    archive: Mutex<ZipArchive<Box<dyn ReadSeek + 'static>>>,
+    content_types: ContentTypes,
+}
+
+impl DocxAssetProvider {
+    /// Creates a `DocxAssetProvider` from a file path.
+    ///
+    /// Opens the DOCX ZIP file and reads `[Content_Types].xml` to build the
+    /// content type lookup table.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Io`] if the file cannot be opened, or [`Error::Parse`]
+    /// if the file is not a valid ZIP archive.
+    #[inline]
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let file = std::fs::File::open(path.as_ref()).map_err(Error::from)?;
+        Self::from_reader(file)
+    }
+
+    /// Creates a `DocxAssetProvider` from any [`Read`] + [`Seek`] + [`Send`] source.
+    ///
+    /// The source must be positioned at the start of a valid DOCX (ZIP) archive.
+    /// Reads `[Content_Types].xml` to build the content type lookup table.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Parse`] if the input is not a valid ZIP archive, or
+    /// [`Error::Io`] for I/O failures when reading `[Content_Types].xml`.
+    #[inline]
+    pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
+        let boxed: Box<dyn ReadSeek + 'static> = Box::new(reader);
+        let mut archive = ZipArchive::new(boxed).map_err(|err| match err {
+            ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
+                message: "not a valid ZIP archive".to_string(),
+                position: None,
+            },
+            ZipError::Io(source) => Error::Io { source },
+            ZipError::FileNotFound
+            | ZipError::InvalidPassword
+            | ZipError::CompressionMethodNotSupported(_)
+            | _ => Error::Parse {
+                message: format!("not a valid ZIP archive: {err}"),
+                position: None,
+            },
+        })?;
+
+        let ct_bytes = match archive.by_name("[Content_Types].xml") {
+            Ok(mut entry) => {
+                let mut bytes: Vec<u8> = Vec::new();
+                io::copy(&mut entry, &mut bytes).map_err(Error::from)?;
+                bytes
+            }
+            Err(_) => Vec::new(),
+        };
+
+        let content_types = content_types::parse(&ct_bytes)?;
+
+        Ok(Self {
+            archive: Mutex::new(archive),
+            content_types,
+        })
+    }
+}
+
+impl AssetProvider for DocxAssetProvider {
+    /// Returns the MIME content type for an asset ID with a `zip://` scheme prefix.
+    ///
+    /// Strips the `zip://` prefix and looks up the path in `[Content_Types].xml`.
+    /// Returns `None` if the scheme is not `zip://` or if no content type is registered
+    /// for the path.
+    #[inline]
+    fn content_type(&self, asset_id: &str) -> Option<Cow<'_, str>> {
+        asset_id
+            .strip_prefix("zip://")
+            .and_then(|p| self.content_types.lookup(p))
+            .map(Cow::Borrowed)
+    }
+
+    /// Streams the asset bytes at `asset_id` to `writer`.
+    ///
+    /// Strips the `zip://` prefix, acquires the archive mutex, locates the ZIP entry,
+    /// and copies bytes via [`io::copy`] — never buffers the full asset. Returns:
+    ///
+    /// - `None` if `asset_id` does not start with `zip://`
+    /// - `None` if the mutex is poisoned
+    /// - `None` if the entry is not found in the archive
+    /// - `Some(Ok(n))` on success with `n` bytes written
+    /// - `Some(Err(_))` on I/O error during copy
+    #[inline]
+    fn stream_to(&self, asset_id: &str, writer: &mut dyn Write) -> Option<io::Result<u64>> {
+        let path = asset_id.strip_prefix("zip://")?;
+        let mut archive = self.archive.lock().ok()?;
+        let mut entry = archive.by_name(path).ok()?;
+        Some(io::copy(&mut entry, writer))
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(coverage))]
+mod tests {
+    #![allow(
+        clippy::unwrap_used,
+        clippy::expect_used,
+        clippy::separated_literal_suffix,
+        clippy::unseparated_literal_suffix
+    )]
+    use std::borrow::Cow;
+    use std::io::{Cursor, Write as _};
+    use zip::write::SimpleFileOptions;
+    use zip::CompressionMethod;
+
+    use super::DocxAssetProvider;
+    use docspec_core::AssetProvider as _;
+
+    fn synth_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
+        let buf = Cursor::new(Vec::new());
+        let mut writer = zip::ZipWriter::new(buf);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+        for (name, data) in entries {
+            writer.start_file(*name, options).unwrap();
+            writer.write_all(data).unwrap();
+        }
+        writer.finish().unwrap().into_inner()
+    }
+
+    fn content_types_png_xml() -> &'static [u8] {
+        br#"<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="png" ContentType="image/png"/>
+</Types>"#
+    }
+
+    fn synth_png_docx() -> Vec<u8> {
+        synth_zip(&[
+            ("[Content_Types].xml", content_types_png_xml()),
+            ("word/media/image1.png", &[0x89, 0x50, 0x4E, 0x47]),
+        ])
+    }
+
+    #[test]
+    fn is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<DocxAssetProvider>();
+    }
+
+    #[test]
+    fn stream_to_exact_bytes() {
+        let zip_bytes = synth_png_docx();
+        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
+        let mut buf = Vec::new();
+        let result = provider.stream_to("zip://word/media/image1.png", &mut buf);
+        assert_eq!(
+            result.expect("should return Some").expect("should be Ok"),
+            4u64
+        );
+        assert_eq!(buf, &[0x89, 0x50, 0x4E, 0x47]);
+    }
+
+    #[test]
+    fn content_type_from_default() {
+        let zip_bytes = synth_png_docx();
+        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
+        let ct = provider.content_type("zip://word/media/image1.png");
+        assert_eq!(ct, Some(Cow::Borrowed("image/png")));
+    }
+
+    #[test]
+    fn non_zip_scheme_returns_none() {
+        let zip_bytes = synth_png_docx();
+        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
+        assert_eq!(provider.content_type("rId99"), None);
+        let mut buf = Vec::new();
+        assert!(provider.stream_to("rId99", &mut buf).is_none());
+    }
+
+    #[test]
+    fn missing_asset_stream_returns_none() {
+        let zip_bytes = synth_png_docx();
+        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
+        let mut buf = Vec::new();
+        assert!(provider
+            .stream_to("zip://word/media/noexist.png", &mut buf)
+            .is_none());
+    }
+
+    #[test]
+    fn content_type_returns_none_for_unregistered_extension() {
+        let zip_bytes = synth_png_docx();
+        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
+        assert_eq!(provider.content_type("zip://word/document.xml"), None);
+    }
+
+    #[test]
+    fn from_path_opens_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("test.docx");
+        let zip_bytes = synth_png_docx();
+        std::fs::write(&path, &zip_bytes).expect("write file");
+        let provider = DocxAssetProvider::from_path(&path).expect("should open");
+        let ct = provider.content_type("zip://word/media/image1.png");
+        assert_eq!(ct, Some(Cow::Borrowed("image/png")));
+    }
+
+    #[test]
+    fn missing_content_types_yields_empty_lookup() {
+        let zip_bytes = synth_zip(&[("word/media/image1.png", &[0x89, 0x50, 0x4E, 0x47])]);
+        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
+        assert_eq!(provider.content_type("zip://word/media/image1.png"), None);
+        let mut buf = Vec::new();
+        let result = provider.stream_to("zip://word/media/image1.png", &mut buf);
+        assert_eq!(
+            result.expect("should return Some").expect("should be Ok"),
+            4u64
+        );
+        assert_eq!(buf, &[0x89, 0x50, 0x4E, 0x47]);
+    }
+}

--- a/crates/docspec-docx-reader/src/content_types.rs
+++ b/crates/docspec-docx-reader/src/content_types.rs
@@ -1,0 +1,286 @@
+//! Content type mapping from `[Content_Types].xml`.
+
+use std::collections::HashMap;
+use std::io::Read;
+
+use docspec_core::Error;
+use quick_xml::events::Event;
+use quick_xml::XmlVersion;
+
+/// Content type lookup for DOCX package parts.
+///
+/// Parsed from `[Content_Types].xml` via [`parse`]. [`lookup`][ContentTypes::lookup]
+/// resolves a ZIP entry path to its MIME type following ECMA-376 §10.1.2:
+/// override entries (matched by exact part path) take precedence over
+/// default entries (matched by file extension).
+pub(crate) struct ContentTypes {
+    /// Maps lowercase file extension → MIME type (from `<Default>` elements).
+    defaults: HashMap<String, String>,
+    /// Maps stripped part path (no leading `/`) → MIME type (from `<Override>` elements).
+    overrides: HashMap<String, String>,
+}
+
+impl Default for ContentTypes {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            defaults: HashMap::new(),
+            overrides: HashMap::new(),
+        }
+    }
+}
+
+/// Parses `[Content_Types].xml` bytes into a [`ContentTypes`] lookup table.
+///
+/// Empty input (`xml = &[]`) represents a missing `[Content_Types].xml` and returns
+/// `Ok(ContentTypes::default())` rather than an error.
+///
+/// # Errors
+///
+/// Returns [`docspec_core::Error::Parse`] for malformed XML.
+pub(crate) fn parse(xml: &[u8]) -> docspec_core::Result<ContentTypes> {
+    if xml.is_empty() {
+        return Ok(ContentTypes::default());
+    }
+
+    let mut xml_reader = quick_xml::Reader::from_reader(xml);
+    let mut buf = Vec::new();
+    let mut element_depth: usize = 0;
+    let mut ct = ContentTypes::default();
+
+    loop {
+        match xml_reader.read_event_into(&mut buf) {
+            Ok(Event::Start(element)) => {
+                element_depth = element_depth.saturating_add(1);
+                process_element(&xml_reader, &element, &mut ct)?;
+            }
+            Ok(Event::Empty(element)) => {
+                process_element(&xml_reader, &element, &mut ct)?;
+            }
+            Ok(Event::End(_)) => {
+                let Some(next_depth) = element_depth.checked_sub(1) else {
+                    return Err(parse_error("malformed [Content_Types].xml".to_string()));
+                };
+                element_depth = next_depth;
+            }
+            Ok(Event::Eof) => {
+                if element_depth != 0 {
+                    return Err(parse_error("malformed [Content_Types].xml".to_string()));
+                }
+                return Ok(ct);
+            }
+            Err(err) => {
+                return Err(parse_error(format!("malformed [Content_Types].xml: {err}")));
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+}
+
+impl ContentTypes {
+    /// Resolves a ZIP entry path to its MIME content type.
+    ///
+    /// Checks `Override` entries (exact part path match, leading `/` already stripped
+    /// at parse time) first, then falls back to `Default` entries matched by the
+    /// lowercase file extension of `part_path`.
+    ///
+    /// The extension is the substring after the last `.` in the final path segment
+    /// (i.e. after the last `/`). Part paths without a `.` in the final segment have
+    /// no extension and never match a `Default` entry, even when a `Default` exists
+    /// whose `Extension` happens to equal the whole part path.
+    ///
+    /// Returns `None` if neither an override nor a default entry matches.
+    #[inline]
+    #[must_use]
+    pub(crate) fn lookup<'a>(&'a self, part_path: &str) -> Option<&'a str> {
+        if let Some(ct) = self.overrides.get(part_path) {
+            return Some(ct.as_str());
+        }
+        let file_name = part_path.rsplit('/').next().unwrap_or(part_path);
+        let (_, ext) = file_name.rsplit_once('.')?;
+        if ext.is_empty() {
+            return None;
+        }
+        self.defaults
+            .get(&ext.to_ascii_lowercase())
+            .map(String::as_str)
+    }
+}
+
+fn process_element<R: Read>(
+    reader: &quick_xml::Reader<R>,
+    element: &quick_xml::events::BytesStart<'_>,
+    ct: &mut ContentTypes,
+) -> docspec_core::Result<()> {
+    match element.local_name().as_ref() {
+        b"Default" => {
+            let ext = attr_string(reader, element, b"Extension")?;
+            let content_type = attr_string(reader, element, b"ContentType")?;
+            if let (Some(ext_val), Some(ct_val)) = (ext, content_type) {
+                ct.defaults.insert(ext_val.to_ascii_lowercase(), ct_val);
+            }
+        }
+        b"Override" => {
+            let part_name = attr_string(reader, element, b"PartName")?;
+            let content_type = attr_string(reader, element, b"ContentType")?;
+            if let (Some(part), Some(ct_val)) = (part_name, content_type) {
+                let key = part.strip_prefix('/').unwrap_or(&part).to_string();
+                ct.overrides.insert(key, ct_val);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn attr_string<R: Read>(
+    reader: &quick_xml::Reader<R>,
+    element: &quick_xml::events::BytesStart<'_>,
+    name: &[u8],
+) -> docspec_core::Result<Option<String>> {
+    for attribute_result in element.attributes() {
+        let attribute = attribute_result
+            .map_err(|err| parse_error(format!("malformed [Content_Types].xml: {err}")))?;
+        if attribute.key.local_name().as_ref() == name {
+            return attribute
+                .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
+                .map(|value| Some(value.into_owned()))
+                .map_err(|err| parse_error(format!("malformed [Content_Types].xml: {err}")));
+        }
+    }
+    Ok(None)
+}
+
+fn parse_error(message: String) -> Error {
+    Error::Parse {
+        message,
+        position: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+    use super::*;
+
+    #[test]
+    fn default_extension_lookup() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("word/media/image1.png"), Some("image/png"));
+    }
+
+    #[test]
+    fn override_beats_default() {
+        let xml = br#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(
+            ct.lookup("word/document.xml"),
+            Some(
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"
+            )
+        );
+    }
+
+    #[test]
+    fn default_when_empty() {
+        let ct = parse(&[]).expect("parse of empty input should succeed");
+        assert_eq!(ct.lookup("word/media/image1.png"), None);
+        assert_eq!(ct.lookup("word/document.xml"), None);
+    }
+
+    #[test]
+    fn extension_lookup_is_case_insensitive() {
+        let xml = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="PNG" ContentType="image/png"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("word/media/photo.png"), Some("image/png"));
+        assert_eq!(ct.lookup("word/media/photo.PNG"), Some("image/png"));
+    }
+
+    #[test]
+    fn lookup_returns_none_for_unknown_extension() {
+        let xml = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="png" ContentType="image/png"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("word/media/file.docx"), None);
+    }
+
+    #[test]
+    fn override_strips_leading_slash_from_part_name() {
+        let xml = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Override PartName="/word/document.xml" ContentType="application/vnd.docx"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("word/document.xml"), Some("application/vnd.docx"));
+        assert_eq!(ct.lookup("/word/document.xml"), None);
+    }
+
+    #[test]
+    fn non_self_closing_elements_are_parsed() {
+        let xml = br#"<?xml version="1.0"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="png" ContentType="image/png"></Default>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.docx"></Override>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("word/media/image1.png"), Some("image/png"));
+        assert_eq!(ct.lookup("word/document.xml"), Some("application/vnd.docx"));
+    }
+
+    #[test]
+    fn malformed_xml_returns_error() {
+        let result = parse(b"<Types><broken>");
+        assert!(matches!(result, Err(docspec_core::Error::Parse { .. })));
+    }
+
+    #[test]
+    fn multiple_defaults_and_overrides() {
+        let xml = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.rels"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Default Extension="jpeg" ContentType="image/jpeg"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.docx"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.styles"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("word/media/image1.png"), Some("image/png"));
+        assert_eq!(ct.lookup("word/media/photo.jpeg"), Some("image/jpeg"));
+        assert_eq!(ct.lookup("word/document.xml"), Some("application/vnd.docx"));
+        assert_eq!(ct.lookup("word/styles.xml"), Some("application/vnd.styles"));
+        assert_eq!(ct.lookup("word/theme/theme1.xml"), Some("application/xml"));
+    }
+
+    #[test]
+    fn lookup_no_extension_returns_none() {
+        let xml = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="xml" ContentType="application/xml"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("noextension"), None);
+    }
+
+    #[test]
+    fn lookup_extensionless_part_does_not_match_default_with_same_name() {
+        let xml = br#"<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="png" ContentType="image/png"/>
+</Types>"#;
+        let ct = parse(xml).expect("parse should succeed");
+        assert_eq!(ct.lookup("png"), None);
+        assert_eq!(ct.lookup("media/png"), None);
+        assert_eq!(ct.lookup("dotted.dir/noext"), None);
+        assert_eq!(ct.lookup("trailing."), None);
+    }
+}

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -4,11 +4,13 @@ use alloc::collections::VecDeque;
 use core::fmt;
 use std::io::{BufReader, Read};
 
-use docspec_core::{Color, Error, Event, Result, TableHeaderScope, TextAlignment, TextStyleKind};
+use docspec_core::{
+    Color, Error, Event, ImageSource, Result, TableHeaderScope, TextAlignment, TextStyleKind,
+};
 use quick_xml::events::{BytesCData, BytesRef, BytesStart, BytesText};
 
 use crate::properties;
-use crate::rels::HyperlinkMap;
+use crate::rels::{HyperlinkMap, ImageMap};
 use crate::styles::StyleList;
 
 const MAX_LIST_LEVEL: u32 = 8;
@@ -64,6 +66,15 @@ struct ListStackEntry {
     is_ordered: bool,
 }
 
+#[derive(Default)]
+struct DrawingScanState {
+    pending_alt: Option<String>,
+    current_pic_alt: Option<String>,
+    pic_depth: u32,
+    blip_fill_depth: u32,
+    emitted_for_current_pic: bool,
+}
+
 /// Bundle of package-level data the document reader consults during streaming.
 ///
 /// Forward-compatible: additional package parts (theme, settings)
@@ -75,6 +86,8 @@ pub struct DocxData {
     pub hyperlink_map: HyperlinkMap,
     /// Numbering definitions loaded from the numbering part, used to resolve list styles.
     pub numbering: crate::numbering::MinimalNumbering,
+    /// Map of relationship Id → [`crate::rels::ImageRel`] for every image relationship in the document part. Resolved from word/_rels/document.xml.rels at package-open time; empty if absent.
+    pub image_map: ImageMap,
 }
 
 /// Deferred-emission state for an open <w:hyperlink>.
@@ -99,8 +112,7 @@ pub(crate) struct PendingLink {
 #[non_exhaustive]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum DeniedKind {
-    // 10 doc-level denied containers.
-    Drawing,
+    // 9 doc-level denied containers.
     Pict,
     Object,
     Del,
@@ -306,6 +318,7 @@ impl DocumentReader {
             style_list,
             hyperlink_map,
             numbering,
+            image_map,
         } = data;
         Self {
             buf: Vec::with_capacity(4096),
@@ -336,6 +349,7 @@ impl DocumentReader {
                 style_list,
                 hyperlink_map: HyperlinkMap::default(),
                 numbering,
+                image_map,
             },
             hyperlink_map,
             in_tcpr: false,
@@ -910,20 +924,24 @@ impl DocumentReader {
         Ok(())
     }
 
-    fn handle_start(&mut self, tag: &BytesStart<'_>) {
+    fn handle_start(&mut self, tag: &BytesStart<'_>) -> Result<()> {
         let local_name = tag.local_name();
         let local = local_name.as_ref();
         if !self.denied_stack.is_empty() {
             if let Some(kind) = is_denied_container(local) {
                 self.denied_stack.push(kind);
             }
-            return;
+            return Ok(());
+        }
+        if local == b"drawing" {
+            self.handle_drawing_start()?;
+            return Ok(());
         }
         if self.handle_table_start(local, tag) {
-            return;
+            return Ok(());
         }
         if self.handle_rpr_property(local, tag) {
-            return;
+            return Ok(());
         }
 
         let denied_container = is_denied_container(local);
@@ -997,6 +1015,148 @@ impl DocumentReader {
             }
             (b"hyperlink", _) => self.handle_hyperlink_start(tag),
             _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_drawing_start(&mut self) -> Result<()> {
+        if self.in_paragraph {
+            self.ensure_cell_started();
+            self.ensure_paragraph_started();
+            self.flush_pending_text();
+            self.flush_pending_link_start();
+        }
+        self.run_content_emitted = true;
+        self.parse_drawing_subtree()
+    }
+
+    fn parse_drawing_subtree(&mut self) -> Result<()> {
+        let mut state = DrawingScanState::default();
+        let mut drawing_depth: u32 = 1;
+
+        while drawing_depth > 0 {
+            let event = self
+                .xml
+                .read_event_into(&mut self.buf)
+                .map_err(map_quick_xml_error)?
+                .into_owned();
+
+            match event {
+                quick_xml::events::Event::Start(tag) => {
+                    self.handle_drawing_child_start(&mut state, &tag);
+                    drawing_depth = drawing_depth.saturating_add(1);
+                }
+                quick_xml::events::Event::Empty(tag) => {
+                    self.handle_drawing_child_empty(&mut state, &tag);
+                }
+                quick_xml::events::Event::End(tag) => {
+                    if tag.local_name().as_ref() == b"drawing" && drawing_depth == 1 {
+                        drawing_depth = drawing_depth.saturating_sub(1);
+                    } else {
+                        Self::handle_drawing_child_end(&mut state, tag.local_name().as_ref());
+                        drawing_depth = drawing_depth.saturating_sub(1);
+                    }
+                }
+                quick_xml::events::Event::Eof => {
+                    self.handle_eof();
+                    drawing_depth = 0;
+                }
+                quick_xml::events::Event::Text(_)
+                | quick_xml::events::Event::GeneralRef(_)
+                | quick_xml::events::Event::CData(_)
+                | quick_xml::events::Event::Comment(_)
+                | quick_xml::events::Event::Decl(_)
+                | quick_xml::events::Event::PI(_)
+                | quick_xml::events::Event::DocType(_) => {}
+            }
+            self.buf.clear();
+        }
+
+        Ok(())
+    }
+
+    fn handle_drawing_child_start(&mut self, state: &mut DrawingScanState, tag: &BytesStart<'_>) {
+        let local_name = tag.local_name();
+        let local = local_name.as_ref();
+        match local {
+            b"docPr" => {
+                state.pending_alt = read_decoded_attribute(tag, b"descr");
+            }
+            b"pic" => {
+                state.pic_depth = state.pic_depth.saturating_add(1);
+                if state.pic_depth == 1 {
+                    state.current_pic_alt = state.pending_alt.take();
+                    state.emitted_for_current_pic = false;
+                }
+            }
+            b"blipFill" if state.pic_depth > 0 => {
+                state.blip_fill_depth = state.blip_fill_depth.saturating_add(1);
+            }
+            b"blip" => self.maybe_emit_drawing_blip(state, tag),
+            _ => {}
+        }
+    }
+
+    fn handle_drawing_child_empty(&mut self, state: &mut DrawingScanState, tag: &BytesStart<'_>) {
+        let local_name = tag.local_name();
+        let local = local_name.as_ref();
+        match local {
+            b"docPr" => {
+                state.pending_alt = read_decoded_attribute(tag, b"descr");
+            }
+            b"blip" => self.maybe_emit_drawing_blip(state, tag),
+            _ => {}
+        }
+    }
+
+    fn handle_drawing_child_end(state: &mut DrawingScanState, local: &[u8]) {
+        match local {
+            b"blipFill" if state.blip_fill_depth > 0 => {
+                state.blip_fill_depth = state.blip_fill_depth.saturating_sub(1);
+            }
+            b"pic" if state.pic_depth > 0 => {
+                state.pic_depth = state.pic_depth.saturating_sub(1);
+                if state.pic_depth == 0 {
+                    state.current_pic_alt = None;
+                    state.emitted_for_current_pic = false;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn maybe_emit_drawing_blip(&mut self, state: &mut DrawingScanState, tag: &BytesStart<'_>) {
+        if state.pic_depth == 0 || state.blip_fill_depth == 0 || state.emitted_for_current_pic {
+            return;
+        }
+
+        let embed = read_attribute(tag, b"r:embed");
+        let link = read_attribute(tag, b"r:link");
+        let Some(rid) = embed.or(link) else {
+            return;
+        };
+
+        state.emitted_for_current_pic = true;
+        self.queue.push_back(Event::Image {
+            alt: state.current_pic_alt.clone(),
+            decorative: false,
+            id: None,
+            source: self.image_source_for_rid(&rid),
+            title: None,
+        });
+    }
+
+    fn image_source_for_rid(&self, rid: &str) -> ImageSource {
+        match self.data.image_map.get(rid) {
+            Some(rel) if rel.is_external => ImageSource::Uri {
+                uri: rel.target.clone(),
+            },
+            Some(rel) => ImageSource::Asset {
+                asset_id: format!("zip://{}", rel.target),
+            },
+            None => ImageSource::Asset {
+                asset_id: rid.to_string(),
+            },
         }
     }
 
@@ -1129,7 +1289,7 @@ impl DocumentReader {
             .into_owned();
 
         match event {
-            quick_xml::events::Event::Start(tag) => self.handle_start(&tag),
+            quick_xml::events::Event::Start(tag) => self.handle_start(&tag)?,
             quick_xml::events::Event::End(tag) => self.handle_end(tag.local_name().as_ref()),
             quick_xml::events::Event::Empty(tag) => self.handle_empty(&tag),
             quick_xml::events::Event::Text(text) => {
@@ -1375,7 +1535,6 @@ impl DocumentReader {
 /// markers (PPr/RPr/TrPr/TcPr).
 fn is_denied_container(local: &[u8]) -> Option<DeniedKind> {
     match local {
-        b"drawing" => Some(DeniedKind::Drawing),
         b"pict" => Some(DeniedKind::Pict),
         b"object" => Some(DeniedKind::Object),
         b"del" => Some(DeniedKind::Del),
@@ -1393,7 +1552,6 @@ fn is_denied_container(local: &[u8]) -> Option<DeniedKind> {
 /// Superset of `is_denied_container`: adds PPr/RPr/TrPr/TcPr.
 fn denied_kind_for(local: &[u8]) -> Option<DeniedKind> {
     match local {
-        b"drawing" => Some(DeniedKind::Drawing),
         b"pict" => Some(DeniedKind::Pict),
         b"object" => Some(DeniedKind::Object),
         b"del" => Some(DeniedKind::Del),
@@ -1425,6 +1583,13 @@ fn read_attribute(tag: &BytesStart<'_>, name: &[u8]) -> Option<String> {
         .map(str::to_owned)
 }
 
+fn read_decoded_attribute(tag: &BytesStart<'_>, name: &[u8]) -> Option<String> {
+    let value = read_attribute(tag, name)?;
+    quick_xml::escape::unescape(&value)
+        .ok()
+        .map(std::borrow::Cow::into_owned)
+}
+
 fn read_rfonts_symbol(tag: &BytesStart<'_>) -> Option<crate::symbol_fonts::SymbolFont> {
     for attr_name in [b"w:ascii".as_ref(), b"w:hAnsi".as_ref(), b"w:cs".as_ref()] {
         if let Some(name) = read_attribute(tag, attr_name) {
@@ -1448,6 +1613,18 @@ fn parse_error(message: String) -> Error {
     }
 }
 
+fn map_quick_xml_error(err: quick_xml::Error) -> Error {
+    match err {
+        quick_xml::Error::Io(source) => Error::Io {
+            source: std::io::Error::new(source.kind(), source.to_string()),
+        },
+        other => Error::Parse {
+            message: format!("malformed document.xml: {other}"),
+            position: None,
+        },
+    }
+}
+
 #[cfg(test)]
 #[cfg(not(coverage))]
 mod tests {
@@ -1460,7 +1637,7 @@ mod tests {
     use core::fmt::Write as _;
     use std::io::{Cursor, Read};
 
-    use docspec_core::ListStyleType;
+    use docspec_core::{ImageSource, ListStyleType};
 
     use super::*;
 
@@ -1481,6 +1658,7 @@ mod tests {
             style_list,
             hyperlink_map: HyperlinkMap::default(),
             numbering: crate::numbering::MinimalNumbering::new(),
+            image_map: crate::rels::ImageMap::default(),
         }
     }
 
@@ -1515,6 +1693,7 @@ mod tests {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map: HyperlinkMap::default(),
             numbering,
+            image_map: crate::rels::ImageMap::default(),
         };
         DocumentReader::from_xml_reader(xml, data)
     }
@@ -1570,8 +1749,328 @@ mod tests {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map: HyperlinkMap::default(),
             numbering: crate::numbering::MinimalNumbering::new(),
+            image_map: crate::rels::ImageMap::default(),
         };
         DocumentReader::from_xml_reader(xml, data)
+    }
+
+    fn make_reader_with_images(
+        document_xml: &str,
+        image_map: crate::rels::ImageMap,
+    ) -> DocumentReader {
+        let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
+        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
+        let data = DocxData {
+            style_list: crate::styles::StyleList::default(),
+            hyperlink_map: HyperlinkMap::default(),
+            numbering: crate::numbering::MinimalNumbering::new(),
+            image_map,
+        };
+        DocumentReader::from_xml_reader(xml, data)
+    }
+
+    fn image_rel(target: &str, is_external: bool) -> crate::rels::ImageRel {
+        crate::rels::ImageRel {
+            target: target.to_string(),
+            is_external,
+        }
+    }
+
+    fn image_event(source: ImageSource, alt: Option<&str>) -> Event {
+        Event::Image {
+            alt: alt.map(str::to_string),
+            decorative: false,
+            id: None,
+            source,
+            title: None,
+        }
+    }
+
+    fn drawing_document(drawing_inner: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+    xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+    xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body><w:p><w:r><w:drawing>{drawing_inner}</w:drawing></w:r></w:p></w:body>
+</w:document>"#
+        )
+    }
+
+    fn picture_with_blip(doc_pr_attrs: &str, blip: &str) -> String {
+        format!(
+            "<wp:inline>
+  <wp:docPr {doc_pr_attrs}/>
+  <a:graphic><a:graphicData><pic:pic><pic:blipFill>{blip}</pic:blipFill></pic:pic></a:graphicData></a:graphic>
+</wp:inline>"
+        )
+    }
+
+    fn start_doc() -> Event {
+        Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        }
+    }
+
+    fn start_para() -> Event {
+        Event::StartParagraph {
+            alignment: None,
+            id: None,
+        }
+    }
+
+    #[test]
+    fn drawing_embedded_internal_png_emits_zip_asset_with_alt_text() {
+        let mut image_map = crate::rels::ImageMap::default();
+        image_map.insert(
+            "rId1".to_string(),
+            image_rel("word/media/image1.png", false),
+        );
+        let doc = drawing_document(&picture_with_blip(
+            r#"descr="alt text" name="ignored title""#,
+            r#"<a:blip r:embed="rId1"/>"#,
+        ));
+        let mut reader = make_reader_with_images(&doc, image_map);
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                image_event(
+                    ImageSource::Asset {
+                        asset_id: "zip://word/media/image1.png".to_string(),
+                    },
+                    Some("alt text"),
+                ),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_external_link_emits_uri_without_alt() {
+        let mut image_map = crate::rels::ImageMap::default();
+        image_map.insert(
+            "rId2".to_string(),
+            image_rel("https://example.com/img.png", true),
+        );
+        let doc = drawing_document(&picture_with_blip("", r#"<a:blip r:link="rId2"/>"#));
+        let mut reader = make_reader_with_images(&doc, image_map);
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                image_event(
+                    ImageSource::Uri {
+                        uri: "https://example.com/img.png".to_string(),
+                    },
+                    None,
+                ),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_missing_rid_emits_raw_asset_id() {
+        let doc = drawing_document(&picture_with_blip(
+            r#"descr="missing rel""#,
+            r#"<a:blip r:embed="rId99"/>"#,
+        ));
+        let mut reader = make_reader_with_images(&doc, crate::rels::ImageMap::default());
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                image_event(
+                    ImageSource::Asset {
+                        asset_id: "rId99".to_string(),
+                    },
+                    Some("missing rel"),
+                ),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_empty_or_blip_without_ids_emits_no_image() {
+        let doc = drawing_document(&picture_with_blip(r#"descr="ignored""#, "<a:blip/>"));
+        let mut reader = make_reader_with_images(&doc, crate::rels::ImageMap::default());
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_with_embed_and_link_prefers_embed() {
+        let mut image_map = crate::rels::ImageMap::default();
+        image_map.insert(
+            "rIdEmbed".to_string(),
+            image_rel("word/media/embed.png", false),
+        );
+        image_map.insert(
+            "rIdLink".to_string(),
+            image_rel("https://example.com/link.png", true),
+        );
+        let doc = drawing_document(&picture_with_blip(
+            r#"descr="embed wins""#,
+            r#"<a:blip r:embed="rIdEmbed" r:link="rIdLink"/>"#,
+        ));
+        let mut reader = make_reader_with_images(&doc, image_map);
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                image_event(
+                    ImageSource::Asset {
+                        asset_id: "zip://word/media/embed.png".to_string(),
+                    },
+                    Some("embed wins"),
+                ),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_embed_with_external_target_mode_emits_uri() {
+        let mut image_map = crate::rels::ImageMap::default();
+        image_map.insert(
+            "rIdExternalEmbed".to_string(),
+            image_rel("https://cdn.example.com/embed.png", true),
+        );
+        let doc = drawing_document(&picture_with_blip(
+            r#"descr="external embed""#,
+            r#"<a:blip r:embed="rIdExternalEmbed"/>"#,
+        ));
+        let mut reader = make_reader_with_images(&doc, image_map);
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                image_event(
+                    ImageSource::Uri {
+                        uri: "https://cdn.example.com/embed.png".to_string(),
+                    },
+                    Some("external embed"),
+                ),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_ignores_smart_art_blip_outside_picture_blip_fill() {
+        let mut image_map = crate::rels::ImageMap::default();
+        image_map.insert(
+            "rIdSmart".to_string(),
+            image_rel("word/media/smart.png", false),
+        );
+        let doc = drawing_document(
+            r#"<wp:inline><wp:docPr descr="ignored"/><a:graphic><a:graphicData><a:blip r:embed="rIdSmart"/></a:graphicData></a:graphic></wp:inline>"#,
+        );
+        let mut reader = make_reader_with_images(&doc, image_map);
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                Event::EndParagraph,
+                Event::EndDocument
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_two_pictures_emit_two_images_in_source_order() {
+        let mut image_map = crate::rels::ImageMap::default();
+        image_map.insert("rId1".to_string(), image_rel("word/media/one.png", false));
+        image_map.insert("rId2".to_string(), image_rel("word/media/two.png", false));
+        let doc = drawing_document(&format!(
+            "{}{}",
+            picture_with_blip(r#"descr="one""#, r#"<a:blip r:embed="rId1"/>"#),
+            picture_with_blip(r#"descr="two""#, r#"<a:blip r:embed="rId2"/>"#),
+        ));
+        let mut reader = make_reader_with_images(&doc, image_map);
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                image_event(
+                    ImageSource::Asset {
+                        asset_id: "zip://word/media/one.png".to_string(),
+                    },
+                    Some("one"),
+                ),
+                image_event(
+                    ImageSource::Asset {
+                        asset_id: "zip://word/media/two.png".to_string(),
+                    },
+                    Some("two"),
+                ),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
+    }
+
+    #[test]
+    fn drawing_non_empty_blip_element_emits_like_self_closing_blip() {
+        let mut image_map = crate::rels::ImageMap::default();
+        image_map.insert(
+            "rId1".to_string(),
+            image_rel("word/media/image1.png", false),
+        );
+        let doc = drawing_document(&picture_with_blip(
+            r#"descr="start tag""#,
+            r#"<a:blip r:embed="rId1"><a:alphaModFix/></a:blip>"#,
+        ));
+        let mut reader = make_reader_with_images(&doc, image_map);
+
+        assert_eq!(
+            collect_events(&mut reader),
+            vec![
+                start_doc(),
+                start_para(),
+                image_event(
+                    ImageSource::Asset {
+                        asset_id: "zip://word/media/image1.png".to_string(),
+                    },
+                    Some("start tag"),
+                ),
+                Event::EndParagraph,
+                Event::EndDocument,
+            ]
+        );
     }
 
     fn make_reader_with_hyperlinks(
@@ -1584,6 +2083,7 @@ mod tests {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map,
             numbering: crate::numbering::MinimalNumbering::new(),
+            image_map: crate::rels::ImageMap::default(),
         };
         DocumentReader::from_xml_reader(xml, data)
     }
@@ -2807,6 +3307,7 @@ mod tests {
             style_list,
             hyperlink_map: HyperlinkMap::default(),
             numbering,
+            image_map: crate::rels::ImageMap::default(),
         };
         DocumentReader::from_xml_reader(xml, data)
     }

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -16,14 +16,16 @@
 //! hyperlinks (`<w:hyperlink>` — resolved via `word/_rels/document.xml.rels`
 //! and emitted as `StartLink`/`EndLink` events around inline content),
 //! structured document tags (`<w:sdt>` — content emitted normally;
-//! `<w:sdtPr>`/`<w:sdtEndPr>` dropped), and tracked insertions and moves
-//! (`<w:ins>`, `<w:moveTo>` — accept-changes semantics).
+//! `<w:sdtPr>`/`<w:sdtEndPr>` dropped), tracked insertions and moves
+//! (`<w:ins>`, `<w:moveTo>` — accept-changes semantics), and `DrawingML` images
+//! (`<w:drawing>` — emitted as `Image` events; see the crate README for
+//! `ImageSource` variants and `DocxAssetProvider` usage).
 //! Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`,
 //! `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`,
 //! `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`,
 //! `EndTableRow`, `EndTable`, `StartLink`, `EndLink`, `StartOrderedListItem`,
 //! `EndOrderedListItem`, `StartUnorderedListItem`, `EndUnorderedListItem`,
-//! `EndDocument`.
+//! `Image`, `EndDocument`.
 //!
 //! The elements listed under "Out of scope" are the reader's denylist — their
 //! entire subtree is silently dropped. Every other element (known or unknown)
@@ -39,7 +41,7 @@
 //! - Table-level property exceptions (`<w:tblPrEx>`) — silently ignored
 //! - Table, row, and cell visual properties (`<w:tblPr>`, `<w:trPr>` visual
 //!   fields, `<w:tcPr>` visual fields, `<w:tblGrid>`)
-//! - Drawings and images (`<w:drawing>`, `<w:pict>`)
+//! - VML images (`<w:pict>`) — deferred to follow-up; subtree silently dropped
 //! - Comments, footnotes, headers, footers
 //! - Document metadata
 //! - Tracked deletions (`<w:del>`, `<w:moveFrom>`) — accept-changes semantics
@@ -76,6 +78,8 @@
 
 extern crate alloc;
 
+mod asset_provider;
+mod content_types;
 mod document;
 mod numbering;
 mod package;
@@ -88,14 +92,55 @@ use std::io::{BufReader, Read, Seek};
 use std::path::Path;
 
 pub use docspec_core::EventSource;
+
+/// Provides streaming access to binary assets stored inside a DOCX ZIP archive.
+///
+/// Use this alongside [`DocxReader`] when you need to resolve embedded images.
+/// [`DocxReader`] emits `Event::Image` with an `asset_id` of the form
+/// `zip://word/media/image1.png`; pass that `asset_id` to
+/// [`DocxAssetProvider`] to stream the raw bytes.
+///
+/// # Example
+///
+/// ```no_run
+/// use docspec_docx_reader::DocxAssetProvider;
+/// use docspec_core::AssetProvider;
+///
+/// let provider = DocxAssetProvider::from_path("document.docx")?;
+/// let mut buf = Vec::new();
+/// if let Some(result) = provider.stream_to("zip://word/media/image1.png", &mut buf) {
+///     result?;
+/// }
+/// # Ok::<(), docspec_core::Error>(())
+/// ```
+pub use asset_provider::DocxAssetProvider;
 use docspec_core::{Error, Result};
+
+const _: for<'a> fn(&'a content_types::ContentTypes, &str) -> Option<&'a str> =
+    content_types::ContentTypes::lookup;
+fn _image_rel_fields(r: &rels::ImageRel) -> (&str, bool) {
+    (&r.target, r.is_external)
+}
+const _: for<'a> fn(&'a rels::ImageRel) -> (&'a str, bool) = _image_rel_fields;
+fn _use_docx_asset_provider_from_path(p: &Path) -> Result<asset_provider::DocxAssetProvider> {
+    asset_provider::DocxAssetProvider::from_path(p)
+}
+const _: fn(&Path) -> Result<asset_provider::DocxAssetProvider> =
+    _use_docx_asset_provider_from_path;
+fn _use_docx_asset_provider_from_reader(
+    r: std::io::Cursor<Vec<u8>>,
+) -> Result<asset_provider::DocxAssetProvider> {
+    asset_provider::DocxAssetProvider::from_reader(r)
+}
+const _: fn(std::io::Cursor<Vec<u8>>) -> Result<asset_provider::DocxAssetProvider> =
+    _use_docx_asset_provider_from_reader;
 
 /// A streaming DOCX reader that implements [`EventSource`].
 ///
 /// `DocxReader` parses a DOCX archive and emits `DocSpec` events one at a time.
-/// `<w:p>` paragraphs, `<w:t>` text, `<w:br>` line breaks, `<w:tab>` tabs, and
-/// table elements (`<w:tbl>`, `<w:tr>`, `<w:tc>`) are recognized; all other
-/// elements are silently ignored.
+/// `<w:p>` paragraphs, `<w:t>` text, `<w:br>` line breaks, `<w:tab>` tabs,
+/// table elements (`<w:tbl>`, `<w:tr>`, `<w:tc>`), and `DrawingML` images
+/// (`<w:drawing>`) are recognized; all other elements are silently ignored.
 ///
 /// # Streaming
 ///
@@ -137,12 +182,14 @@ impl DocxReader {
     /// cannot be opened. Returns [`Error::Io`] for I/O failures.
     #[inline]
     pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
-        let (style_list, numbering, hyperlink_map, stream) = package::open_package(reader)?;
+        let (style_list, numbering, hyperlink_map, image_map, _content_types, stream) =
+            package::open_package(reader)?;
         let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
         let data = document::DocxData {
             style_list,
             hyperlink_map,
             numbering,
+            image_map,
         };
         Ok(Self {
             inner: document::DocumentReader::from_xml_reader(xml, data),

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -5,23 +5,26 @@ use std::io::{Read, Seek};
 use docspec_core::{Error, Result};
 use zip::result::ZipError;
 
+use crate::content_types;
+use crate::content_types::ContentTypes;
 use crate::rels;
-use crate::rels::HyperlinkMap;
+use crate::rels::{HyperlinkMap, ImageMap};
 use crate::styles::StyleList;
 
-/// Opens a DOCX ZIP archive, loads `styles.xml` and `numbering.xml` from the package
-/// relationships, locates `document.xml`, and returns a streaming reader for it.
-///
-/// Returns the loaded [`StyleList`], the loaded [`crate::numbering::MinimalNumbering`],
-/// the [`HyperlinkMap`], and a byte stream positioned at the start of `document.xml` data.
-pub fn open_package<R: Read + Seek + Send + 'static>(
-    mut reader: R,
-) -> Result<(
+type PackageContents = (
     StyleList,
     crate::numbering::MinimalNumbering,
     HyperlinkMap,
+    ImageMap,
+    ContentTypes,
     Box<dyn Read + Send>,
-)> {
+);
+
+/// Opens a DOCX ZIP archive, loads `styles.xml` and `numbering.xml` from the package
+/// relationships, locates `document.xml`, reads `[Content_Types].xml`, and returns
+/// a [`PackageContents`] tuple with all parsed data and a streaming reader for the
+/// main document part.
+pub fn open_package<R: Read + Seek + Send + 'static>(mut reader: R) -> Result<PackageContents> {
     let mut archive = zip::ZipArchive::new(&mut reader).map_err(|err| match err {
         ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
             message: "not a valid ZIP archive".to_string(),
@@ -51,9 +54,14 @@ pub fn open_package<R: Read + Seek + Send + 'static>(
     };
 
     let document_path = rels::find_document_target(std::io::Cursor::new(rels_bytes))?;
-    let (style_list, hyperlink_map) =
+    let (style_list, hyperlink_map, image_map) =
         load_style_list_and_hyperlink_map(&mut archive, &document_path)?;
     let numbering = load_numbering(&mut archive, &document_path)?;
+
+    let content_types = match read_optional_entry(&mut archive, "[Content_Types].xml")? {
+        Some(bytes) => content_types::parse(&bytes)?,
+        None => ContentTypes::default(),
+    };
 
     let (data_start, compressed_size, method) = {
         let entry = archive
@@ -86,13 +94,20 @@ pub fn open_package<R: Read + Seek + Send + 'static>(
         });
     };
 
-    Ok((style_list, numbering, hyperlink_map, stream))
+    Ok((
+        style_list,
+        numbering,
+        hyperlink_map,
+        image_map,
+        content_types,
+        stream,
+    ))
 }
 
 fn load_style_list_and_hyperlink_map<R: Read + Seek>(
     archive: &mut zip::ZipArchive<&mut R>,
     document_path: &str,
-) -> Result<(StyleList, HyperlinkMap)> {
+) -> Result<(StyleList, HyperlinkMap, ImageMap)> {
     let doc_rels_path = rels::derive_part_rels_path(document_path);
     let maybe_doc_rels_bytes = if doc_rels_path == "word/_rels/document.xml.rels" {
         match archive.by_name("word/_rels/document.xml.rels") {
@@ -108,16 +123,21 @@ fn load_style_list_and_hyperlink_map<R: Read + Seek>(
         read_optional_entry(archive, &doc_rels_path)?
     };
     let Some(doc_rels_bytes) = maybe_doc_rels_bytes else {
-        return Ok((StyleList::default(), HyperlinkMap::default()));
+        return Ok((
+            StyleList::default(),
+            HyperlinkMap::default(),
+            ImageMap::default(),
+        ));
     };
 
     let hyperlink_map =
         rels::collect_hyperlink_map(std::io::Cursor::new(doc_rels_bytes.as_slice()))?;
+    let image_map = rels::collect_image_map(doc_rels_bytes.as_slice(), document_path)?;
 
     let Some(styles_target) =
         rels::find_styles_target(std::io::Cursor::new(doc_rels_bytes.as_slice()))?
     else {
-        return Ok((StyleList::default(), hyperlink_map));
+        return Ok((StyleList::default(), hyperlink_map, image_map));
     };
 
     let styles_path = rels::resolve_relative_target(document_path, &styles_target);
@@ -127,12 +147,12 @@ fn load_style_list_and_hyperlink_map<R: Read + Seek>(
             entry.read_to_end(&mut bytes).map_err(Error::from)?;
             bytes
         }
-        Err(ZipError::FileNotFound) => return Ok((StyleList::default(), hyperlink_map)),
+        Err(ZipError::FileNotFound) => return Ok((StyleList::default(), hyperlink_map, image_map)),
         Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
     };
 
     let style_list = StyleList::parse(std::io::Cursor::new(styles_bytes))?;
-    Ok((style_list, hyperlink_map))
+    Ok((style_list, hyperlink_map, image_map))
 }
 
 fn read_optional_entry<R: Read + Seek>(
@@ -194,7 +214,7 @@ fn parse_error(message: String) -> Error {
 #[cfg(test)]
 #[cfg(not(coverage))]
 mod tests {
-    #![allow(clippy::unwrap_used)]
+    #![allow(clippy::unwrap_used, clippy::indexing_slicing)]
     use core::fmt::Write as _;
     use std::collections::HashMap;
     use std::io::{Cursor, Read as _, Write as _};
@@ -289,6 +309,23 @@ mod tests {
         xml
     }
 
+    fn image_doc_rels_xml(entries: &[(&str, &str)]) -> String {
+        let mut xml = String::from(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">"#,
+        );
+        for (id, target) in entries {
+            write!(
+                xml,
+                r#"
+  <Relationship Id="{id}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="{target}"/>"#
+            )
+            .unwrap();
+        }
+        xml.push_str("\n</Relationships>");
+        xml
+    }
+
     fn load_package_data(
         entries: &[(&str, &[u8])],
     ) -> core::result::Result<(StyleList, HashMap<String, String>), zip::result::ZipError> {
@@ -296,6 +333,7 @@ mod tests {
         let mut reader = Cursor::new(zip_bytes);
         let mut archive = zip::ZipArchive::new(&mut reader)?;
         load_style_list_and_hyperlink_map(&mut archive, "word/document.xml")
+            .map(|(style_list, hyperlink_map, _image_map)| (style_list, hyperlink_map))
             .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
     }
 
@@ -459,7 +497,14 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _numbering, _hyperlink_map, mut stream)) => {
+            Ok((
+                style_list,
+                _numbering,
+                _hyperlink_map,
+                _image_map,
+                _content_types,
+                mut stream,
+            )) => {
                 assert!(style_list.get_by_id("Normal").is_some());
                 let mut document = String::new();
                 let read_result = stream.read_to_string(&mut document);
@@ -484,7 +529,7 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _numbering, _hyperlink_map, _stream)) => {
+            Ok((style_list, _numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
                 assert_eq!(style_list, StyleList::default());
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
@@ -507,7 +552,7 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _numbering, _hyperlink_map, _stream)) => {
+            Ok((style_list, _numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
                 assert_eq!(style_list, StyleList::default());
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
@@ -565,7 +610,7 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, numbering, _hyperlink_map, _stream)) => {
+            Ok((_style_list, numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
                 assert!(numbering.resolve(1, 0).is_list);
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected numbering and document stream"),
@@ -586,7 +631,7 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, numbering, _hyperlink_map, _stream)) => {
+            Ok((_style_list, numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
                 assert!(!numbering.resolve(1, 0).is_list);
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected empty numbering"),
@@ -610,7 +655,7 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, numbering, _hyperlink_map, _stream)) => {
+            Ok((_style_list, numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
                 assert!(!numbering.resolve(1, 0).is_list);
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected empty numbering"),
@@ -640,6 +685,91 @@ mod tests {
                 "opened without error",
                 "expected parse error for malformed numbering.xml",
             ),
+        }
+    }
+
+    #[test]
+    fn open_package_with_images() {
+        let root_rels = root_rels_xml("word/document.xml");
+        let doc_rels = image_doc_rels_xml(&[("rId5", "media/image1.png")]);
+        let bytes = synth_zip(&[
+            ("_rels/.rels", root_rels.as_bytes()),
+            ("word/_rels/document.xml.rels", doc_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+            ("word/media/image1.png", b"\x89PNG\r\n\x1a\n"),
+        ]);
+
+        let result = bytes.and_then(|zip_bytes| {
+            open_package(Cursor::new(zip_bytes))
+                .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+        });
+
+        match result {
+            Ok((_style_list, _numbering, _hyperlink_map, image_map, _content_types, _stream)) => {
+                assert_eq!(image_map.len(), 1);
+                let rel = &image_map["rId5"];
+                assert_eq!(rel.target, "word/media/image1.png");
+                assert!(!rel.is_external);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected image map with one entry"),
+        }
+    }
+
+    #[test]
+    fn open_package_without_content_types() {
+        let root_rels = root_rels_xml("word/document.xml");
+        let bytes = synth_zip(&[
+            ("_rels/.rels", root_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+        ]);
+
+        let result = bytes.and_then(|zip_bytes| {
+            open_package(Cursor::new(zip_bytes))
+                .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+        });
+
+        match result {
+            Ok((_style_list, _numbering, _hyperlink_map, _image_map, content_types, _stream)) => {
+                assert_eq!(content_types.lookup("word/document.xml"), None);
+                assert_eq!(content_types.lookup("word/media/image1.png"), None);
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected default content types"),
+        }
+    }
+
+    #[test]
+    fn content_types_lookup_works() {
+        let root_rels = root_rels_xml("word/document.xml");
+        let content_types_xml = br#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#;
+        let bytes = synth_zip(&[
+            ("_rels/.rels", root_rels.as_bytes()),
+            ("word/document.xml", minimal_document_xml().as_bytes()),
+            ("[Content_Types].xml", content_types_xml),
+        ]);
+
+        let result = bytes.and_then(|zip_bytes| {
+            open_package(Cursor::new(zip_bytes))
+                .map_err(|err| zip::result::ZipError::Io(std::io::Error::other(format!("{err:?}"))))
+        });
+
+        match result {
+            Ok((_style_list, _numbering, _hyperlink_map, _image_map, content_types, _stream)) => {
+                assert_eq!(
+                    content_types.lookup("word/media/image1.png"),
+                    Some("image/png")
+                );
+                assert_eq!(
+                    content_types.lookup("word/document.xml"),
+                    Some(
+                        "application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"
+                    )
+                );
+            }
+            Err(err) => assert_eq!(format!("{err:?}"), "expected content types lookup to work"),
         }
     }
 }

--- a/crates/docspec-docx-reader/src/rels.rs
+++ b/crates/docspec-docx-reader/src/rels.rs
@@ -8,6 +8,22 @@ use quick_xml::XmlVersion;
 /// Maps relationship Id (e.g., "rId7") to Target URL/path for every <Relationship> entry whose Type ends with "/hyperlink".
 pub(crate) type HyperlinkMap = HashMap<String, String>;
 
+const REL_TYPE_IMAGE: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+
+/// Represents an image relationship in a DOCX package.
+#[derive(Debug)]
+pub(crate) struct ImageRel {
+    /// Resolved package path for internal images, or raw URL for external ones.
+    pub target: String,
+    /// `true` when `TargetMode="External"`.
+    pub is_external: bool,
+}
+
+/// Maps relationship Id (e.g., "rId5") to [`ImageRel`] for every `<Relationship>` entry
+/// whose Type ends with "/image".
+pub(crate) type ImageMap = HashMap<String, ImageRel>;
+
 pub fn find_document_target<R: Read>(reader: R) -> docspec_core::Result<String> {
     let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
     let mut buf = Vec::new();
@@ -134,6 +150,55 @@ pub(crate) fn collect_hyperlink_map<R: Read>(reader: R) -> Result<HyperlinkMap, 
                     return Err(parse_error("malformed _rels/.rels".to_string()));
                 }
                 return Ok(hyperlinks);
+            }
+            Err(_err) => {
+                return Err(parse_error("malformed _rels/.rels".to_string()));
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+}
+
+/// Parses a DOCX part relationships XML and returns every image relationship.
+///
+/// For internal images, resolves the target path relative to `document_path` and
+/// validates it contains no `..` traversal segments. For external images
+/// (`TargetMode="External"`), stores the raw URL without path resolution.
+///
+/// Returns `Err` if the XML is malformed or an internal target contains a `..` segment.
+pub(crate) fn collect_image_map(rels_xml: &[u8], document_path: &str) -> Result<ImageMap, Error> {
+    let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(rels_xml));
+    let mut buf = Vec::new();
+    let mut element_depth: usize = 0;
+    let mut images = HashMap::new();
+
+    loop {
+        match xml_reader.read_event_into(&mut buf) {
+            Ok(Event::Start(element)) => {
+                element_depth = element_depth.saturating_add(1);
+                if element.local_name().as_ref() == b"Relationship" {
+                    if let Some((id, rel)) = image_entry(&xml_reader, &element, document_path)? {
+                        images.insert(id, rel);
+                    }
+                }
+            }
+            Ok(Event::Empty(element)) if element.local_name().as_ref() == b"Relationship" => {
+                if let Some((id, rel)) = image_entry(&xml_reader, &element, document_path)? {
+                    images.insert(id, rel);
+                }
+            }
+            Ok(Event::End(_)) => {
+                let Some(next_depth) = element_depth.checked_sub(1) else {
+                    return Err(parse_error("malformed _rels/.rels".to_string()));
+                };
+                element_depth = next_depth;
+            }
+            Ok(Event::Eof) => {
+                if element_depth != 0 {
+                    return Err(parse_error("malformed _rels/.rels".to_string()));
+                }
+                return Ok(images);
             }
             Err(_err) => {
                 return Err(parse_error("malformed _rels/.rels".to_string()));
@@ -327,6 +392,66 @@ fn hyperlink_entry<R: Read>(
     })
 }
 
+fn image_entry<R: Read>(
+    reader: &quick_xml::Reader<R>,
+    element: &quick_xml::events::BytesStart<'_>,
+    document_path: &str,
+) -> Result<Option<(String, ImageRel)>, Error> {
+    let mut id = None;
+    let mut rel_type = None;
+    let mut target = None;
+    let mut target_mode = None;
+
+    for attribute_result in element.attributes() {
+        let attribute = attribute_result.map_err(|err| Error::Parse {
+            message: format!("malformed _rels/.rels: {err}"),
+            position: None,
+        })?;
+        let value = attribute
+            .decoded_and_normalized_value(XmlVersion::Implicit1_0, reader.decoder())
+            .map_err(|err| Error::Parse {
+                message: format!("malformed _rels/.rels: {err}"),
+                position: None,
+            })?
+            .into_owned();
+
+        match attribute.key.local_name().as_ref() {
+            b"Id" => id = Some(value),
+            b"Type" => rel_type = Some(value),
+            b"Target" => target = Some(value),
+            b"TargetMode" => target_mode = Some(value),
+            _ => {}
+        }
+    }
+
+    match (id, rel_type, target) {
+        (Some(found_id), Some(found_type), Some(found_target))
+            if found_type == REL_TYPE_IMAGE || found_type.ends_with("/image") =>
+        {
+            let is_external = target_mode.as_deref() == Some("External");
+            if is_external {
+                Ok(Some((
+                    found_id,
+                    ImageRel {
+                        target: found_target,
+                        is_external: true,
+                    },
+                )))
+            } else {
+                let validated = normalize_relative_target(document_path, &found_target)?;
+                Ok(Some((
+                    found_id,
+                    ImageRel {
+                        target: validated,
+                        is_external: false,
+                    },
+                )))
+            }
+        }
+        _ => Ok(None),
+    }
+}
+
 fn numbering_target<R: Read>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
@@ -403,9 +528,39 @@ pub fn resolve_relative_target(base_part: &str, target: &str) -> String {
     }
 }
 
+/// Resolves a relative target against `base_part` and canonicalizes `.` / `..`
+/// segments per ECMA-376 Part 2 §6.5.3 / RFC 3986 §5.2.
+///
+/// Word and other DOCX writers routinely emit `Target="../media/image1.png"`
+/// or `Target="../customXml/item1.xml"` from `word/_rels/document.xml.rels`;
+/// rejecting `..` outright (the old behavior of [`validate_document_path`])
+/// breaks reading those files. This helper collapses the segments instead,
+/// while still refusing references that escape the package root — a `..`
+/// segment that pops past the start of the resolved path returns
+/// [`docspec_core::Error::Parse`].
+fn normalize_relative_target(base_part: &str, target: &str) -> docspec_core::Result<String> {
+    let joined = resolve_relative_target(base_part, target);
+    let mut normalized: Vec<&str> = Vec::new();
+    for segment in joined.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                if normalized.pop().is_none() {
+                    return Err(parse_error(format!(
+                        "rels target escapes package root: {joined}"
+                    )));
+                }
+            }
+            other => normalized.push(other),
+        }
+    }
+    Ok(normalized.join("/"))
+}
+
 #[cfg(test)]
 #[cfg(not(coverage))]
 mod tests {
+    #![allow(clippy::expect_used, clippy::panic)]
     use super::*;
     use std::io::Cursor;
 
@@ -939,5 +1094,111 @@ mod tests {
     fn resolve_relative_target_without_directory() {
         let result = resolve_relative_target("document.xml", "styles.xml");
         assert_eq!(result, "styles.xml");
+    }
+
+    fn minimal_image_rels(target: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="{target}"/>
+</Relationships>"#
+        )
+    }
+
+    #[test]
+    fn collect_image_map_internal() {
+        let rels_xml = minimal_image_rels("media/image1.png");
+
+        let result = collect_image_map(rels_xml.as_bytes(), "word/document.xml");
+
+        match result {
+            Ok(map) => {
+                assert_eq!(map.len(), 1);
+                let rel = map.get("rId5").expect("rId5 must be present");
+                assert_eq!(rel.target, "word/media/image1.png");
+                assert!(!rel.is_external);
+            }
+            Err(err) => panic!("expected Ok, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn collect_image_map_external() {
+        let rels_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="https://example.com/img.png" TargetMode="External"/>
+</Relationships>"#;
+
+        let result = collect_image_map(rels_xml.as_bytes(), "word/document.xml");
+
+        match result {
+            Ok(map) => {
+                assert_eq!(map.len(), 1);
+                let rel = map.get("rId5").expect("rId5 must be present");
+                assert_eq!(rel.target, "https://example.com/img.png");
+                assert!(rel.is_external);
+            }
+            Err(err) => panic!("expected Ok, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn collect_image_map_rejects_dotdot_escaping_root() {
+        let rels_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../../../etc/passwd"/>
+</Relationships>"#;
+
+        let result = collect_image_map(rels_xml.as_bytes(), "word/document.xml");
+
+        match result {
+            Err(Error::Parse { message, position }) => {
+                assert_eq!(
+                    message,
+                    "rels target escapes package root: word/../../../etc/passwd"
+                );
+                assert_eq!(position, None);
+            }
+            other => panic!("expected Err(Parse), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn collect_image_map_normalizes_parent_segment_into_package_root() {
+        let rels_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
+</Relationships>"#;
+
+        let result = collect_image_map(rels_xml.as_bytes(), "word/document.xml");
+
+        match result {
+            Ok(map) => {
+                assert_eq!(map.len(), 1);
+                let rel = map.get("rId5").expect("rId5 must be present");
+                assert_eq!(rel.target, "media/image1.png");
+                assert!(!rel.is_external);
+            }
+            Err(err) => panic!("expected Ok, got {err:?}"),
+        }
+    }
+
+    #[test]
+    fn collect_image_map_collapses_dot_and_double_dot_segments() {
+        let rels_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId5" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="./media/sub/../image1.png"/>
+</Relationships>"#;
+
+        let result = collect_image_map(rels_xml.as_bytes(), "word/document.xml");
+
+        match result {
+            Ok(map) => {
+                let rel = map.get("rId5").expect("rId5 must be present");
+                assert_eq!(rel.target, "word/media/image1.png");
+                assert!(!rel.is_external);
+            }
+            Err(err) => panic!("expected Ok, got {err:?}"),
+        }
     }
 }

--- a/crates/docspec-docx-reader/tests/image_edge_cases.rs
+++ b/crates/docspec-docx-reader/tests/image_edge_cases.rs
@@ -1,0 +1,466 @@
+//! Integration tests for `DocxReader` image edge cases.
+#![allow(
+    clippy::arbitrary_source_item_ordering,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::redundant_test_prefix,
+    clippy::separated_literal_suffix,
+    clippy::std_instead_of_core,
+    clippy::tests_outside_test_module,
+    clippy::unseparated_literal_suffix,
+    clippy::unwrap_used
+)]
+
+mod fixture;
+
+use std::io::Cursor;
+
+use docspec_core::{AssetProvider as _, Event, EventSource as _, ImageSource};
+use docspec_docx_reader::{DocxAssetProvider, DocxReader};
+use zip::CompressionMethod;
+
+const ROOT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument"
+    Target="word/document.xml"/>
+</Relationships>"#;
+
+const IMAGE_REL_TYPE: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+
+fn doc_rels(body: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+{body}
+</Relationships>"#
+    )
+}
+
+fn drawing_doc(drawing_inner: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body><w:p><w:r><w:drawing>{drawing_inner}</w:drawing></w:r></w:p></w:body>
+</w:document>"#
+    )
+}
+
+fn inline_pic(blip: &str) -> String {
+    format!(
+        "<wp:inline><a:graphic><a:graphicData><pic:pic><pic:blipFill>{blip}</pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline>"
+    )
+}
+
+fn build_docx(doc_rels_xml: &str, document_xml: &str) -> Vec<u8> {
+    fixture::synth_docx_with_entries(&[
+        (
+            "_rels/.rels",
+            CompressionMethod::Deflated,
+            ROOT_RELS.as_bytes(),
+        ),
+        (
+            "word/_rels/document.xml.rels",
+            CompressionMethod::Deflated,
+            doc_rels_xml.as_bytes(),
+        ),
+        (
+            "word/document.xml",
+            CompressionMethod::Deflated,
+            document_xml.as_bytes(),
+        ),
+    ])
+}
+
+fn build_provider_docx() -> Vec<u8> {
+    fixture::synth_docx_with_entries(&[
+        (
+            "[Content_Types].xml",
+            CompressionMethod::Deflated,
+            br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="png" ContentType="image/png"/></Types>"#,
+        ),
+        (
+            "word/media/image1.png",
+            CompressionMethod::Stored,
+            &[0x89u8, 0x50, 0x4E, 0x47],
+        ),
+    ])
+}
+
+fn drive(reader: &mut DocxReader) -> Vec<Event> {
+    let mut events = Vec::new();
+    while let Some(event) = reader.next_event().expect("next_event") {
+        events.push(event);
+    }
+    events
+}
+
+fn start_doc() -> Event {
+    Event::StartDocument {
+        id: None,
+        language: None,
+        metadata: None,
+    }
+}
+
+fn start_para() -> Event {
+    Event::StartParagraph {
+        alignment: None,
+        id: None,
+    }
+}
+
+fn image_event(source: ImageSource, alt: Option<&str>) -> Event {
+    Event::Image {
+        alt: alt.map(str::to_string),
+        decorative: false,
+        id: None,
+        source,
+        title: None,
+    }
+}
+
+#[test]
+fn external_link_emits_uri() {
+    let rels = doc_rels(&format!(
+        r#"<Relationship Id="rId2" Type="{IMAGE_REL_TYPE}" Target="https://example.com/img.png" TargetMode="External"/>"#
+    ));
+    let drawing = inline_pic(r#"<a:blip r:link="rId2"/>"#);
+    let doc = drawing_doc(&drawing);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            image_event(
+                ImageSource::Uri {
+                    uri: "https://example.com/img.png".to_string(),
+                },
+                None,
+            ),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn embed_external_target_mode() {
+    let rels = doc_rels(&format!(
+        r#"<Relationship Id="rId5" Type="{IMAGE_REL_TYPE}" Target="https://cdn.example.com/x.png" TargetMode="External"/>"#
+    ));
+    let drawing = inline_pic(r#"<a:blip r:embed="rId5"/>"#);
+    let doc = drawing_doc(&drawing);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            image_event(
+                ImageSource::Uri {
+                    uri: "https://cdn.example.com/x.png".to_string(),
+                },
+                None,
+            ),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn missing_rel_emits_raw_rid() {
+    let rels = doc_rels("");
+    let drawing = inline_pic(r#"<a:blip r:embed="rId99"/>"#);
+    let doc = drawing_doc(&drawing);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            image_event(
+                ImageSource::Asset {
+                    asset_id: "rId99".to_string(),
+                },
+                None,
+            ),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn empty_drawing_no_event() {
+    let rels = doc_rels("");
+    let drawing = r#"<wp:inline><wp:docPr id="1" name="img1"/></wp:inline>"#;
+    let doc = drawing_doc(drawing);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn embed_wins_over_link() {
+    let rels = doc_rels(&format!(
+        r#"<Relationship Id="rId4" Type="{IMAGE_REL_TYPE}" Target="media/embed.png"/>
+<Relationship Id="rId5" Type="{IMAGE_REL_TYPE}" Target="https://example.com/link.png" TargetMode="External"/>"#
+    ));
+    let drawing = inline_pic(r#"<a:blip r:embed="rId4" r:link="rId5"/>"#);
+    let doc = drawing_doc(&drawing);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            image_event(
+                ImageSource::Asset {
+                    asset_id: "zip://word/media/embed.png".to_string(),
+                },
+                None,
+            ),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn pict_still_skipped() {
+    let rels = doc_rels("");
+    let doc = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:p>
+      <w:r><w:t>before</w:t></w:r>
+      <w:r><w:drawing><w:pict><w:r><w:t>hidden</w:t></w:r></w:pict></w:drawing></w:r>
+      <w:r><w:t>after</w:t></w:r>
+    </w:p>
+  </w:body>
+</w:document>"#;
+    let bytes = build_docx(&rels, doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            Event::Text {
+                content: "before".to_string(),
+            },
+            Event::Text {
+                content: "after".to_string(),
+            },
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn smartart_blip_ignored() {
+    let rels = doc_rels(&format!(
+        r#"<Relationship Id="rIdSmart" Type="{IMAGE_REL_TYPE}" Target="word/media/smart.png"/>"#
+    ));
+    // blip is at a:graphicData/a:blip — NOT inside pic:pic/pic:blipFill
+    let drawing = r#"<wp:inline><a:graphic><a:graphicData><a:blip r:embed="rIdSmart"/></a:graphicData></a:graphic></wp:inline>"#;
+    let doc = drawing_doc(drawing);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn multiple_pics_multiple_events() {
+    let rels = doc_rels(&format!(
+        r#"<Relationship Id="rId1" Type="{IMAGE_REL_TYPE}" Target="media/one.png"/>
+<Relationship Id="rId2" Type="{IMAGE_REL_TYPE}" Target="media/two.png"/>"#
+    ));
+    let drawing = format!(
+        "{}{}",
+        inline_pic(r#"<a:blip r:embed="rId1"/>"#),
+        inline_pic(r#"<a:blip r:embed="rId2"/>"#),
+    );
+    let doc = drawing_doc(&drawing);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            image_event(
+                ImageSource::Asset {
+                    asset_id: "zip://word/media/one.png".to_string(),
+                },
+                None,
+            ),
+            image_event(
+                ImageSource::Asset {
+                    asset_id: "zip://word/media/two.png".to_string(),
+                },
+                None,
+            ),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn provider_non_zip_scheme_returns_none() {
+    let bytes = build_provider_docx();
+    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).expect("from_reader");
+    let ct = provider.content_type("rId99");
+    assert_eq!(ct, None);
+    let mut buf = Vec::new();
+    let result = provider.stream_to("rId99", &mut buf);
+    assert!(result.is_none());
+}
+
+#[test]
+fn provider_unknown_internal_path_returns_none() {
+    let bytes = build_provider_docx();
+    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).expect("from_reader");
+    let mut buf = Vec::new();
+    let result = provider.stream_to("zip://word/media/nonexistent.png", &mut buf);
+    assert!(result.is_none());
+}
+
+const HYPERLINK_REL_TYPE: &str =
+    "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink";
+
+fn hyperlink_drawing_doc(paragraph_inner: &str) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body><w:p>{paragraph_inner}</w:p></w:body>
+</w:document>"#
+    )
+}
+
+#[test]
+fn hyperlink_wrapping_only_a_drawing_emits_start_and_end_link_around_image() {
+    let rels = doc_rels(&format!(
+        r#"<Relationship Id="rId1" Type="{HYPERLINK_REL_TYPE}" Target="https://example.com" TargetMode="External"/>
+<Relationship Id="rId2" Type="{IMAGE_REL_TYPE}" Target="media/image1.png"/>"#
+    ));
+    let drawing = inline_pic(r#"<a:blip r:embed="rId2"/>"#);
+    let paragraph_inner = format!(
+        r#"<w:hyperlink r:id="rId1"><w:r><w:drawing>{drawing}</w:drawing></w:r></w:hyperlink>"#
+    );
+    let doc = hyperlink_drawing_doc(&paragraph_inner);
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            Event::StartLink {
+                href: "https://example.com".to_string(),
+                id: None,
+                title: None,
+            },
+            image_event(
+                ImageSource::Asset {
+                    asset_id: "zip://word/media/image1.png".to_string(),
+                },
+                None,
+            ),
+            Event::EndLink,
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}
+
+#[test]
+fn sibling_drawing_without_docpr_does_not_inherit_alt() {
+    let rels = doc_rels(&format!(
+        r#"<Relationship Id="rId1" Type="{IMAGE_REL_TYPE}" Target="media/one.png"/>
+<Relationship Id="rId2" Type="{IMAGE_REL_TYPE}" Target="media/two.png"/>"#
+    ));
+    let drawing_with_alt = r#"<wp:inline><wp:docPr id="1" name="img1" descr="first"/><a:graphic><a:graphicData><pic:pic><pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill></pic:pic></a:graphicData></a:graphic></wp:inline>"#;
+    let drawing_without_alt = inline_pic(r#"<a:blip r:embed="rId2"/>"#);
+    let doc = format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document
+  xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+  xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body>
+    <w:p><w:r><w:drawing>{drawing_with_alt}</w:drawing></w:r></w:p>
+    <w:p><w:r><w:drawing>{drawing_without_alt}</w:drawing></w:r></w:p>
+  </w:body>
+</w:document>"#
+    );
+    let bytes = build_docx(&rels, &doc);
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).expect("from_reader");
+    assert_eq!(
+        drive(&mut reader),
+        vec![
+            start_doc(),
+            start_para(),
+            image_event(
+                ImageSource::Asset {
+                    asset_id: "zip://word/media/one.png".to_string(),
+                },
+                Some("first"),
+            ),
+            Event::EndParagraph,
+            start_para(),
+            image_event(
+                ImageSource::Asset {
+                    asset_id: "zip://word/media/two.png".to_string(),
+                },
+                None,
+            ),
+            Event::EndParagraph,
+            Event::EndDocument,
+        ]
+    );
+}

--- a/crates/docspec-docx-reader/tests/image_embedded.rs
+++ b/crates/docspec-docx-reader/tests/image_embedded.rs
@@ -1,0 +1,184 @@
+//! Integration tests for the embedded image happy path end-to-end pipeline.
+#![allow(
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::redundant_test_prefix,
+    clippy::separated_literal_suffix,
+    clippy::tests_outside_test_module,
+    clippy::unseparated_literal_suffix,
+    clippy::unwrap_used
+)]
+
+mod fixture;
+
+use std::io::Cursor;
+
+use docspec_blocknote_writer::BlockNoteWriter;
+use docspec_core::StackTrackingSink;
+use docspec_core::{AssetProvider as _, Event, EventSink as _, EventSource as _, ImageSource};
+use docspec_docx_reader::{DocxAssetProvider, DocxReader};
+use zip::CompressionMethod;
+
+const PNG_SIGNATURE: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+fn root_rels() -> &'static str {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#
+}
+
+fn doc_rels_with_image() -> &'static str {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>"#
+}
+
+fn content_types_xml() -> &'static str {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#
+}
+
+fn document_with_embedded_image() -> &'static str {
+    r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+    xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+    xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body><w:p><w:r><w:drawing>
+    <wp:inline>
+      <wp:docPr descr="alt text"/>
+      <a:graphic><a:graphicData>
+        <pic:pic><pic:blipFill><a:blip r:embed="rId4"/></pic:blipFill></pic:pic>
+      </a:graphicData></a:graphic>
+    </wp:inline>
+  </w:drawing></w:r></w:p></w:body>
+</w:document>"#
+}
+
+fn synth_image_docx() -> Vec<u8> {
+    fixture::synth_docx_with_entries(&[
+        (
+            "_rels/.rels",
+            CompressionMethod::Deflated,
+            root_rels().as_bytes(),
+        ),
+        (
+            "[Content_Types].xml",
+            CompressionMethod::Deflated,
+            content_types_xml().as_bytes(),
+        ),
+        (
+            "word/_rels/document.xml.rels",
+            CompressionMethod::Deflated,
+            doc_rels_with_image().as_bytes(),
+        ),
+        (
+            "word/document.xml",
+            CompressionMethod::Deflated,
+            document_with_embedded_image().as_bytes(),
+        ),
+        (
+            "word/media/image1.png",
+            CompressionMethod::Stored,
+            &PNG_SIGNATURE,
+        ),
+    ])
+}
+
+fn collect_events(bytes: Vec<u8>) -> Vec<Event> {
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).unwrap();
+    let mut events = Vec::new();
+    loop {
+        match reader.next_event() {
+            Ok(Some(event)) => events.push(event),
+            Ok(None) => break,
+            Err(e) => panic!("reader error: {e:?}"),
+        }
+    }
+    events
+}
+
+#[test]
+fn docx_reader_emits_exact_image_event() {
+    let bytes = synth_image_docx();
+    let events = collect_events(bytes);
+
+    let image_event = events
+        .iter()
+        .find(|e| matches!(e, Event::Image { .. }))
+        .expect("expected at least one Image event");
+
+    assert_eq!(
+        *image_event,
+        Event::Image {
+            source: ImageSource::Asset {
+                asset_id: "zip://word/media/image1.png".to_string(),
+            },
+            alt: Some("alt text".to_string()),
+            decorative: false,
+            title: None,
+            id: None,
+        }
+    );
+}
+
+#[test]
+fn docx_asset_provider_streams_exact_bytes() {
+    let bytes = synth_image_docx();
+    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).unwrap();
+    let mut buf = Vec::new();
+
+    let result = provider.stream_to("zip://word/media/image1.png", &mut buf);
+
+    // io::Error does not impl PartialEq — unpack with expect instead of assert_eq!
+    assert_eq!(
+        result
+            .expect("stream_to should return Some")
+            .expect("stream_to should return Ok"),
+        8u64
+    );
+    assert_eq!(buf.as_slice(), PNG_SIGNATURE.as_ref());
+}
+
+#[test]
+fn blocknote_writer_with_assets_produces_exact_data_uri() {
+    let bytes = synth_image_docx();
+
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes.clone())).unwrap();
+    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).unwrap();
+
+    let mut out = Vec::<u8>::new();
+    let mut writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut out, &provider));
+
+    loop {
+        match reader.next_event() {
+            Ok(Some(event)) => writer.handle_event(event).unwrap(),
+            Ok(None) => break,
+            Err(e) => panic!("reader error: {e:?}"),
+        }
+    }
+    writer.finish().unwrap();
+
+    let json: serde_json::Value =
+        serde_json::from_slice(&out).expect("BlockNoteWriter output must be valid JSON");
+    let blocks = json.as_array().expect("expected top-level JSON array");
+
+    let image_block = blocks
+        .iter()
+        .find(|b| b["type"] == "image")
+        .expect("expected at least one image block in JSON output");
+
+    let url = image_block["props"]["url"]
+        .as_str()
+        .expect("expected url field to be a string");
+
+    assert_eq!(url, "data:image/png;base64,iVBORw0KGgo=");
+}

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -4835,7 +4835,7 @@ mod events {
     }
 
     #[test]
-    fn hyperlink_inside_denied_subtree_emits_nothing() {
+    fn hyperlink_inside_drawing_subtree_emits_nothing() {
         let document_xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
   <w:body><w:p><w:drawing><w:hyperlink r:id="rId1"><w:r><w:t>inside-drawing</w:t></w:r></w:hyperlink></w:drawing></w:p></w:body>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added DrawingML image extraction—DOCX documents now emit `Image` events for embedded images
  * Introduced `DocxAssetProvider` utility to stream image assets from DOCX files with automatic MIME type detection

* **Documentation**
  * Expanded documentation with comprehensive image support details, including relationship resolution strategies, alt text mapping, and VML limitations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->