### PR TITLE
chore: drop typos pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,6 @@ repos:
       - id: check-yaml
       - id: check-toml
 
-  # ─── Spell checking ────────────────────────────────────────────────────────
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.32.0
-    hooks:
-      - id: typos
-
   # ─── TOML formatting ───────────────────────────────────────────────────────
   - repo: local
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,6 @@ Thank you for considering a contribution. DocSpec is a memory-conscious streamin
 - Git with your user name and email configured
 - [pre-commit](https://pre-commit.com/) for running pre-commit hooks
 - [taplo](https://taplo.tamasfe.dev/) for TOML formatting (`cargo install taplo-cli`)
-- [typos](https://github.com/crate-ci/typos) for spell checking (`cargo install typos-cli`)
 
 Clone the repository:
 ```bash
@@ -21,7 +20,7 @@ pre-commit install --hook-type commit-msg
 pre-commit install --hook-type pre-push
 ```
 
-The pre-commit hooks enforce formatting, linting, spell checking, and conventional commit message format; the pre-push hooks verify the full build, test suite, and documentation. Before diving into code, read the [Manifesto](MANIFESTO.md) to understand our philosophy: memory efficiency, streaming design, and strict quality above convenience.
+The pre-commit hooks enforce formatting, linting, and conventional commit message format; the pre-push hooks verify the full build, test suite, and documentation. Before diving into code, read the [Manifesto](MANIFESTO.md) to understand our philosophy: memory efficiency, streaming design, and strict quality above convenience.
 
 The pre-commit stage (runs on every commit) enforces formatting, linting, and hygiene checks. The pre-push stage (runs before push) runs the full build, test suite, and documentation build.
 


### PR DESCRIPTION
## Why

The `typos` pre-commit hook (`crate-ci/typos`) ships with `args: [--write-changes]` baked into its default `.pre-commit-hooks.yaml`, so the hook **auto-applies** every "correction" it thinks it has found before reporting failure. That bit us during the PR #277 rebase: typos saw `"caf\u{e9} ..."` in `crates/docspec-html-reader/tests/reader.rs` (an intentional UTF-8 multibyte test that builds the string "café"), decided `caf` was a typo of `calf`, and silently rewrote the test to `"calf\u{e9} ..."` (which renders as "calfé"). The pre-push then failed, and the corrupted test was left staged in the working tree for the next person to notice.

The auto-apply is the worst kind of linter behavior: false positives don't just block, they actively corrupt unrelated code. Dictionary-based spell-checking is also a poor fit for a codebase with deliberately mixed Latin/CJK/PUA test fixtures, escape-sequence literals, and OOXML/XML identifiers.

## What changes

- Remove the `crate-ci/typos` block from `.pre-commit-config.yaml`.
- Remove the `typos` prerequisite and "spell checking" mention from `CONTRIBUTING.md`.

`.sisyphus/` historical planning notes that mention typos are left as-is (they're past planning records, not live config).

## Validation

- All remaining pre-commit hooks (`trailing-whitespace`, `end-of-file-fixer`, `check-added-large-files`, `check-yaml`, `check-toml`, `taplo-fmt`, `cargo fmt`, `cargo clippy`, `conventional-pre-commit`) ran on the commit and passed.
- All pre-push hooks (`cargo build`, `cargo test`, `cargo doc` with `RUSTDOCFLAGS=-D warnings`) ran on the push and passed.

Closes nothing; this is just hygiene.