### PR TITLE
fix: embed asset access in ImageSource::Asset via AssetHandle trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,7 @@ name = "docspec-test-utils"
 version = "1.10.0"
 dependencies = [
  "docspec-core",
+ "docspec-docx-reader",
  "zip",
 ]
 

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -150,11 +150,8 @@ pub mod palette;
 
 use std::io::Write;
 
-use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
-use base64::write::EncoderWriter as Base64Encoder;
 use docspec_core::{
-    AssetProvider, Depth, Error, Event, EventSink, ImageSource, Result, TextAlignment,
-    TextStyleKind,
+    Depth, Error, Event, EventSink, ImageSource, Result, TextAlignment, TextStyleKind,
 };
 use docspec_json::{JsonEmitter, Null, StrusonBackend};
 
@@ -247,14 +244,10 @@ fn non_default_alignment_value(alignment: Option<&TextAlignment>) -> Option<&'st
 /// Writes JSON tokens directly to the underlying `Write` as events arrive using `docspec-json`.
 /// Implements [`EventSink`] for integration with the `DocSpec` pipeline.
 ///
-/// Use [`BlockNoteWriter::with_assets`] to provide an [`AssetProvider`] for resolving
-/// embedded asset images as base64 data URIs.
-///
 /// # Type Parameters
 ///
 /// * `W` - Any type implementing [`Write`]
-pub struct BlockNoteWriter<'a, W: Write> {
-    assets: Option<&'a dyn AssetProvider>,
+pub struct BlockNoteWriter<W: Write> {
     blockquote_depth: Depth,
     blockquote_force_closed_count: Depth,
     context: BlockContext,
@@ -272,7 +265,7 @@ pub struct BlockNoteWriter<'a, W: Write> {
     table_depth: Depth,
 }
 
-impl<'a, W: Write> BlockNoteWriter<'a, W> {
+impl<W: Write> BlockNoteWriter<W> {
     fn close_blockquote_for_sibling(&mut self) -> Result<()> {
         self.close_open_link_if_any()?;
         self.close_content_block()?;
@@ -344,39 +337,6 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             self.close_current_list_item_object()?;
         }
         Ok(())
-    }
-
-    /// Resolves `asset_id` through the configured provider and encodes the asset bytes
-    /// as a `data:<content-type>;base64,…` URI.
-    ///
-    /// Returns `Err` if no `AssetProvider` is configured, the asset cannot be found,
-    /// or the underlying I/O fails while streaming the asset bytes through the
-    /// base64 encoder.
-    fn encode_asset_as_data_uri(&self, asset_id: &str) -> Result<String> {
-        let provider = self.assets.ok_or_else(|| Error::Other {
-            message: "no AssetProvider configured".to_string(),
-        })?;
-        let content_type = provider
-            .content_type(asset_id)
-            .ok_or_else(|| Error::Other {
-                message: format!("asset not found: {asset_id}"),
-            })?;
-        let prefix = format!("data:{content_type};base64,");
-        let mut data_uri = Vec::with_capacity(prefix.len());
-        data_uri.extend_from_slice(prefix.as_bytes());
-        {
-            let mut enc = Base64Encoder::new(&mut data_uri, &BASE64_STANDARD);
-            provider
-                .stream_to(asset_id, &mut enc)
-                .ok_or_else(|| Error::Other {
-                    message: format!("asset not found: {asset_id}"),
-                })?
-                .map_err(Error::from)?;
-            enc.finish().map_err(Error::from)?
-        };
-        String::from_utf8(data_uri).map_err(|e| Error::Other {
-            message: format!("base64 encoding produced invalid UTF-8: {e}"),
-        })
     }
 
     fn handle_blockquote(&mut self, id: Option<&String>) -> Result<()> {
@@ -542,25 +502,53 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
             return Ok(());
         }
         self.close_for_block_sibling()?;
-        let url = match source {
-            ImageSource::Uri { uri } => uri,
-            ImageSource::Asset { asset_id } => self.encode_asset_as_data_uri(&asset_id)?,
-            _ => return Ok(()),
-        };
         let caption = alt.unwrap_or_default();
 
-        self.json.object(|j| {
-            if let Some(id_val) = id {
-                j.key("id").value(id_val.as_str())?;
+        match source {
+            ImageSource::Uri { uri } => self.json.object(|j| {
+                if let Some(id_val) = id {
+                    j.key("id").value(id_val.as_str())?;
+                }
+                j.key("type").value("image")?;
+                j.key("props").object(|p| {
+                    p.key("url").value(uri.as_str())?;
+                    p.key("caption").value(caption.as_str())
+                })?;
+                j.key("content").value(Null)?;
+                j.key("children").array(|_| Ok(()))
+            }),
+            ImageSource::Asset(handle) => {
+                let content_type = handle
+                    .content_type()
+                    .ok_or_else(|| Error::Other {
+                        message: format!("asset not found: {}", handle.asset_id()),
+                    })?
+                    .into_owned();
+
+                self.json.object(|j| {
+                    if let Some(id_val) = id {
+                        j.key("id").value(id_val.as_str())?;
+                    }
+                    j.key("type").value("image")?;
+                    j.key("props").object(|p| {
+                        p.key("url").string_value_streaming(|w| {
+                            write!(w, "data:{content_type};base64,")?;
+                            let mut enc = base64::write::EncoderWriter::new(
+                                w,
+                                &base64::engine::general_purpose::STANDARD,
+                            );
+                            handle.stream_to(&mut enc)?;
+                            enc.finish()?;
+                            Ok(())
+                        })?;
+                        p.key("caption").value(caption.as_str())
+                    })?;
+                    j.key("content").value(Null)?;
+                    j.key("children").array(|_| Ok(()))
+                })
             }
-            j.key("type").value("image")?;
-            j.key("props").object(|p| {
-                p.key("url").value(url.as_str())?;
-                p.key("caption").value(caption.as_str())
-            })?;
-            j.key("content").value(Null)?;
-            j.key("children").array(|_| Ok(()))
-        })
+            _ => Ok(()),
+        }
     }
 
     fn handle_line_break(&mut self) -> Result<()> {
@@ -936,7 +924,6 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
     #[must_use]
     pub fn new(writer: W) -> Self {
         Self {
-            assets: None,
             blockquote_depth: Depth::default(),
             blockquote_force_closed_count: Depth::default(),
             context: BlockContext::default(),
@@ -1050,36 +1037,6 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
         Ok(())
     }
 
-    /// Creates a new `BlockNoteWriter` with an [`AssetProvider`] for resolving embedded assets.
-    ///
-    /// When an [`Event::Image`] with [`ImageSource::Asset`] is encountered, the provider is called
-    /// to resolve the asset bytes. The bytes are base64-encoded and written as a data URI
-    /// (`data:{content_type};base64,{encoded}`) in the `BlockNote` JSON `url` field.
-    ///
-    /// # Arguments
-    ///
-    /// * `writer` - The underlying writer to emit JSON to
-    /// * `assets` - The asset provider for resolving embedded asset references
-    #[inline]
-    #[must_use]
-    pub fn with_assets(writer: W, assets: &'a dyn AssetProvider) -> Self {
-        Self {
-            assets: Some(assets),
-            blockquote_depth: Depth::default(),
-            blockquote_force_closed_count: Depth::default(),
-            context: BlockContext::default(),
-            drop_inside_list_depth: Depth::default(),
-            dropped_list_depth: Depth::default(),
-            in_link: false,
-            json: JsonEmitter::new(StrusonBackend::new(writer)),
-            lifted_nested_events: Vec::new(),
-            link_emitted_styled_text: false,
-            list_stack: Vec::new(),
-            open_styles: Vec::new(),
-            table_depth: Depth::default(),
-        }
-    }
-
     fn handle_end_document(&mut self) -> Result<()> {
         while !self.list_stack.is_empty() {
             self.close_current_list_item_object()?;
@@ -1126,7 +1083,7 @@ impl<'a, W: Write> BlockNoteWriter<'a, W> {
     }
 }
 
-impl<W: Write> EventSink for BlockNoteWriter<'_, W> {
+impl<W: Write> EventSink for BlockNoteWriter<W> {
     #[inline]
     fn finish(self) -> Result<()> {
         self.json.finish().map(|_| ())

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -2,84 +2,72 @@
 
 #![allow(clippy::expect_used, clippy::redundant_test_prefix)]
 
-extern crate alloc;
-
 #[cfg(test)]
 mod tests {
-    use alloc::borrow::Cow;
-    use std::collections::HashMap;
-    use std::io;
     use std::io::Write;
+    use std::sync::Arc;
 
     use docspec_blocknote_writer::BlockNoteWriter;
     use docspec_core::{
-        AssetProvider, Color, Event, EventSink as _, ImageSource, StackTrackingSink, TextAlignment,
+        AssetHandle, Color, Event, EventSink as _, ImageSource, StackTrackingSink, TextAlignment,
         TextStyleKind,
     };
     use docspec_test_utils::builders::text;
     use docspec_test_utils::FailingWriter;
 
-    struct MockAssetProvider {
-        assets: HashMap<String, (String, Vec<u8>)>,
-        content_type_only: HashMap<String, String>,
+    #[derive(Debug)]
+    struct MockAssetHandle {
+        asset_id: String,
+        content_type: Option<String>,
+        bytes: Vec<u8>,
         fail_stream: bool,
     }
 
-    impl MockAssetProvider {
-        fn new() -> Self {
+    impl MockAssetHandle {
+        fn new(asset_id: &str, content_type: &str, bytes: &[u8]) -> Self {
             Self {
-                assets: HashMap::new(),
-                content_type_only: HashMap::new(),
+                asset_id: asset_id.to_string(),
+                content_type: Some(content_type.to_string()),
+                bytes: bytes.to_vec(),
                 fail_stream: false,
             }
         }
 
-        fn with_asset(mut self, id: &str, content_type: &str, data: &[u8]) -> Self {
-            self.assets
-                .insert(id.to_string(), (content_type.to_string(), data.to_vec()));
-            self
-        }
-
-        fn with_content_type_only(mut self, id: &str, content_type: &str) -> Self {
-            self.content_type_only
-                .insert(id.to_string(), content_type.to_string());
-            self
-        }
-
-        fn with_failing_stream(mut self) -> Self {
-            self.fail_stream = true;
-            self
-        }
-    }
-
-    impl AssetProvider for MockAssetProvider {
-        fn content_type(&self, asset_id: &str) -> Option<Cow<'_, str>> {
-            self.assets
-                .get(asset_id)
-                .map(|(ct, _)| Cow::Borrowed(ct.as_str()))
-                .or_else(|| {
-                    self.content_type_only
-                        .get(asset_id)
-                        .map(|ct| Cow::Borrowed(ct.as_str()))
-                })
-        }
-
-        fn stream_to(&self, asset_id: &str, writer: &mut dyn Write) -> Option<io::Result<u64>> {
-            if self.fail_stream {
-                return Some(Err(io::Error::other("simulated stream failure")));
+        fn unknown_content_type(asset_id: &str) -> Self {
+            Self {
+                asset_id: asset_id.to_string(),
+                content_type: None,
+                bytes: Vec::new(),
+                fail_stream: false,
             }
-            self.assets.get(asset_id).map(|(_, data)| {
-                writer.write_all(data)?;
-                Ok(u64::try_from(data.len()).unwrap_or(0))
-            })
+        }
+
+        fn failing(asset_id: &str, content_type: &str) -> Self {
+            Self {
+                asset_id: asset_id.to_string(),
+                content_type: Some(content_type.to_string()),
+                bytes: Vec::new(),
+                fail_stream: true,
+            }
         }
     }
 
-    fn run_events_with_assets(events: &[Event], provider: &dyn AssetProvider) -> String {
-        let mut buf = Vec::<u8>::new();
-        let writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut buf, provider));
-        docspec_test_utils::drive(writer, events.iter().cloned());
-        String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8")
+    impl AssetHandle for MockAssetHandle {
+        fn content_type(&self) -> Option<std::borrow::Cow<'_, str>> {
+            self.content_type.as_deref().map(std::borrow::Cow::Borrowed)
+        }
+
+        fn stream_to(&self, writer: &mut dyn Write) -> std::io::Result<u64> {
+            if self.fail_stream {
+                return Err(std::io::Error::other("mock stream failure"));
+            }
+            writer.write_all(&self.bytes)?;
+            Ok(u64::try_from(self.bytes.len()).unwrap_or(u64::MAX))
+        }
+
+        fn asset_id(&self) -> &str {
+            &self.asset_id
+        }
     }
 
     fn run_events(events: &[Event]) -> String {
@@ -523,29 +511,6 @@ mod tests {
             json,
             r#"[{"type":"image","props":{"url":"https://example.com/img.png","caption":""},"content":null,"children":[]}]"#
         );
-    }
-
-    #[test]
-    fn image_with_asset_source_without_provider_errors() {
-        let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
-        let start_result = writer.handle_event(Event::StartDocument {
-            id: None,
-            language: None,
-            metadata: None,
-        });
-        assert!(start_result.is_ok(), "start document should succeed");
-        let result = writer.handle_event(Event::Image {
-            source: ImageSource::Asset {
-                asset_id: "img1".to_string(),
-            },
-            alt: None,
-            title: None,
-            decorative: false,
-            id: None,
-        });
-        let err = result.expect_err("Image with asset source requires a provider");
-        assert_eq!(err.to_string(), "no AssetProvider configured");
     }
 
     #[test]
@@ -1435,10 +1400,13 @@ mod tests {
 
     #[test]
     fn image_with_asset_provider_success() {
-        let provider =
-            MockAssetProvider::new().with_asset("img1", "image/png", &[0x89, 0x50, 0x4E, 0x47]);
+        let handle = Arc::new(MockAssetHandle::new(
+            "img1",
+            "image/png",
+            &[0x89, 0x50, 0x4E, 0x47],
+        ));
         let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut buf, &provider));
+        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
         let start_result = writer.handle_event(Event::StartDocument {
             id: None,
             language: None,
@@ -1446,9 +1414,7 @@ mod tests {
         });
         assert!(start_result.is_ok(), "start should succeed");
         let img_result = writer.handle_event(Event::Image {
-            source: ImageSource::Asset {
-                asset_id: "img1".to_string(),
-            },
+            source: ImageSource::Asset(handle),
             alt: Some("Test image".to_string()),
             title: None,
             decorative: false,
@@ -1468,9 +1434,9 @@ mod tests {
 
     #[test]
     fn image_with_asset_not_found_content_type() {
-        let provider = MockAssetProvider::new();
+        let handle = Arc::new(MockAssetHandle::unknown_content_type("missing"));
         let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut buf, &provider));
+        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
         let start_result = writer.handle_event(Event::StartDocument {
             id: None,
             language: None,
@@ -1478,9 +1444,7 @@ mod tests {
         });
         assert!(start_result.is_ok(), "start should succeed");
         let result = writer.handle_event(Event::Image {
-            source: ImageSource::Asset {
-                asset_id: "missing".to_string(),
-            },
+            source: ImageSource::Asset(handle),
             alt: None,
             title: None,
             decorative: false,
@@ -1492,11 +1456,9 @@ mod tests {
 
     #[test]
     fn image_with_asset_stream_io_error() {
-        let provider = MockAssetProvider::new()
-            .with_asset("img1", "image/png", &[0x89])
-            .with_failing_stream();
+        let handle = Arc::new(MockAssetHandle::failing("img1", "image/png"));
         let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut buf, &provider));
+        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
         let start_result = writer.handle_event(Event::StartDocument {
             id: None,
             language: None,
@@ -1504,38 +1466,64 @@ mod tests {
         });
         assert!(start_result.is_ok(), "start should succeed");
         let result = writer.handle_event(Event::Image {
-            source: ImageSource::Asset {
-                asset_id: "img1".to_string(),
-            },
+            source: ImageSource::Asset(handle),
             alt: None,
             title: None,
             decorative: false,
             id: None,
         });
         let err = result.expect_err("image with failing stream must fail");
-        assert_eq!(err.to_string(), "I/O error: simulated stream failure");
+        assert_eq!(err.to_string(), "I/O error: mock stream failure");
+    }
+
+    #[test]
+    fn writer_not_poisoned_after_mid_stream_error() {
+        use docspec_core::{Event, EventSink as _, ImageSource};
+
+        let handle = Arc::new(MockAssetHandle::failing("img1", "image/png"));
+        let mut buf = Vec::<u8>::new();
+        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+
+        let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        });
+        assert!(start_result.is_ok(), "start should succeed");
+
+        let img_result = writer.handle_event(Event::Image {
+            source: ImageSource::Asset(handle),
+            alt: None,
+            title: None,
+            decorative: false,
+            id: None,
+        });
+        assert!(img_result.is_err(), "image with failing stream must fail");
+
+        let end_result = writer.handle_event(Event::EndDocument);
+        drop(end_result);
+
+        let finish_result = writer.finish();
+        drop(finish_result);
     }
 
     #[test]
     fn asset_image_jpeg() {
-        let provider =
-            MockAssetProvider::new().with_asset("photo", "image/jpeg", &[0xFF, 0xD8, 0xFF]);
-        let json = run_events_with_assets(
-            &[
-                start_document(),
-                Event::Image {
-                    source: ImageSource::Asset {
-                        asset_id: "photo".to_string(),
-                    },
-                    alt: None,
-                    title: None,
-                    decorative: false,
-                    id: None,
-                },
-                Event::EndDocument,
-            ],
-            &provider,
-        );
+        let json = run_events(&[
+            start_document(),
+            Event::Image {
+                source: ImageSource::Asset(Arc::new(MockAssetHandle::new(
+                    "photo",
+                    "image/jpeg",
+                    &[0xFF, 0xD8, 0xFF],
+                ))),
+                alt: None,
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
             r#"[{"type":"image","props":{"url":"data:image/jpeg;base64,/9j/","caption":""},"content":null,"children":[]}]"#
@@ -1544,23 +1532,21 @@ mod tests {
 
     #[test]
     fn asset_image_empty_bytes() {
-        let provider = MockAssetProvider::new().with_asset("empty", "image/png", &[]);
-        let json = run_events_with_assets(
-            &[
-                start_document(),
-                Event::Image {
-                    source: ImageSource::Asset {
-                        asset_id: "empty".to_string(),
-                    },
-                    alt: None,
-                    title: None,
-                    decorative: false,
-                    id: None,
-                },
-                Event::EndDocument,
-            ],
-            &provider,
-        );
+        let json = run_events(&[
+            start_document(),
+            Event::Image {
+                source: ImageSource::Asset(Arc::new(MockAssetHandle::new(
+                    "empty",
+                    "image/png",
+                    &[],
+                ))),
+                alt: None,
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
             r#"[{"type":"image","props":{"url":"data:image/png;base64,","caption":""},"content":null,"children":[]}]"#
@@ -1569,33 +1555,30 @@ mod tests {
 
     #[test]
     fn asset_and_uri_images_mixed() {
-        let provider =
-            MockAssetProvider::new().with_asset("img1", "image/png", &[0x89, 0x50, 0x4E, 0x47]);
-        let json = run_events_with_assets(
-            &[
-                start_document(),
-                Event::Image {
-                    source: ImageSource::Asset {
-                        asset_id: "img1".to_string(),
-                    },
-                    alt: None,
-                    title: None,
-                    decorative: false,
-                    id: None,
+        let json = run_events(&[
+            start_document(),
+            Event::Image {
+                source: ImageSource::Asset(Arc::new(MockAssetHandle::new(
+                    "img1",
+                    "image/png",
+                    &[0x89, 0x50, 0x4E, 0x47],
+                ))),
+                alt: None,
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/img.png".to_string(),
                 },
-                Event::Image {
-                    source: ImageSource::Uri {
-                        uri: "https://example.com/img.png".to_string(),
-                    },
-                    alt: None,
-                    title: None,
-                    decorative: false,
-                    id: None,
-                },
-                Event::EndDocument,
-            ],
-            &provider,
-        );
+                alt: None,
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
             r#"[{"type":"image","props":{"url":"data:image/png;base64,iVBORw==","caption":""},"content":null,"children":[]},{"type":"image","props":{"url":"https://example.com/img.png","caption":""},"content":null,"children":[]}]"#
@@ -1604,33 +1587,29 @@ mod tests {
 
     #[test]
     fn asset_image_same_id_twice() {
-        let provider =
-            MockAssetProvider::new().with_asset("img1", "image/png", &[0x89, 0x50, 0x4E, 0x47]);
-        let json = run_events_with_assets(
-            &[
-                start_document(),
-                Event::Image {
-                    source: ImageSource::Asset {
-                        asset_id: "img1".to_string(),
-                    },
-                    alt: None,
-                    title: None,
-                    decorative: false,
-                    id: None,
-                },
-                Event::Image {
-                    source: ImageSource::Asset {
-                        asset_id: "img1".to_string(),
-                    },
-                    alt: None,
-                    title: None,
-                    decorative: false,
-                    id: None,
-                },
-                Event::EndDocument,
-            ],
-            &provider,
-        );
+        let handle: Arc<dyn AssetHandle> = Arc::new(MockAssetHandle::new(
+            "img1",
+            "image/png",
+            &[0x89, 0x50, 0x4E, 0x47],
+        ));
+        let json = run_events(&[
+            start_document(),
+            Event::Image {
+                source: ImageSource::Asset(Arc::clone(&handle)),
+                alt: None,
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::Image {
+                source: ImageSource::Asset(Arc::clone(&handle)),
+                alt: None,
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
             r#"[{"type":"image","props":{"url":"data:image/png;base64,iVBORw==","caption":""},"content":null,"children":[]},{"type":"image","props":{"url":"data:image/png;base64,iVBORw==","caption":""},"content":null,"children":[]}]"#
@@ -1639,27 +1618,24 @@ mod tests {
 
     #[test]
     fn asset_image_in_paragraph() {
-        let provider =
-            MockAssetProvider::new().with_asset("img1", "image/png", &[0x89, 0x50, 0x4E, 0x47]);
-        let json = run_events_with_assets(
-            &[
-                start_document(),
-                start_paragraph(),
-                text("Before"),
-                Event::EndParagraph,
-                Event::Image {
-                    source: ImageSource::Asset {
-                        asset_id: "img1".to_string(),
-                    },
-                    alt: None,
-                    title: None,
-                    decorative: false,
-                    id: None,
-                },
-                Event::EndDocument,
-            ],
-            &provider,
-        );
+        let json = run_events(&[
+            start_document(),
+            start_paragraph(),
+            text("Before"),
+            Event::EndParagraph,
+            Event::Image {
+                source: ImageSource::Asset(Arc::new(MockAssetHandle::new(
+                    "img1",
+                    "image/png",
+                    &[0x89, 0x50, 0x4E, 0x47],
+                ))),
+                alt: None,
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
             r#"[{"type":"paragraph","content":[{"type":"text","text":"Before","styles":{}}],"children":[]},{"type":"image","props":{"url":"data:image/png;base64,iVBORw==","caption":""},"content":null,"children":[]}]"#
@@ -1675,9 +1651,9 @@ mod tests {
 
     #[test]
     fn image_with_asset_stream_not_found() {
-        let provider = MockAssetProvider::new().with_content_type_only("img1", "image/png");
+        let handle = Arc::new(MockAssetHandle::unknown_content_type("img1"));
         let mut buf = Vec::<u8>::new();
-        let mut writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut buf, &provider));
+        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
         let start_result = writer.handle_event(Event::StartDocument {
             id: None,
             language: None,
@@ -1685,9 +1661,7 @@ mod tests {
         });
         assert!(start_result.is_ok(), "start should succeed");
         let result = writer.handle_event(Event::Image {
-            source: ImageSource::Asset {
-                asset_id: "img1".to_string(),
-            },
+            source: ImageSource::Asset(handle),
             alt: None,
             title: None,
             decorative: false,
@@ -3978,25 +3952,6 @@ mod tests {
     }
 
     #[test]
-    fn with_assets_constructor_accepts_asset_provider() {
-        // Drives BlockNoteWriter::with_assets constructor body (line 804).
-        let provider = MockAssetProvider::new();
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::with_assets(&mut buf, &provider);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_paragraph()).is_ok());
-        assert!(writer.handle_event(text("hello")).is_ok());
-        assert!(writer.handle_event(Event::EndParagraph).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
-        assert_eq!(
-            json,
-            r#"[{"type":"paragraph","content":[{"type":"text","text":"hello","styles":{}}],"children":[]}]"#
-        );
-    }
-
-    #[test]
     fn level_down_to_nested_parent_breaks_loop() {
         // Drives the break statement (line 592) in the level-down while-loop of
         // handle_start_list_item: level-0 → level-1 → level-2 → back to level-1.
@@ -4942,6 +4897,74 @@ mod tests {
         assert_eq!(
             json,
             r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn streaming_writes_never_exceed_8kb() {
+        use docspec_core::{Event, EventSink as _, ImageSource};
+        use std::io::Write;
+
+        struct CountingWriter {
+            inner: Vec<u8>,
+            max_single_write: usize,
+            total_writes: usize,
+        }
+        impl Write for CountingWriter {
+            fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                self.max_single_write = self.max_single_write.max(buf.len());
+                self.total_writes += 1;
+                self.inner.extend_from_slice(buf);
+                Ok(buf.len())
+            }
+            fn flush(&mut self) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let payload: Vec<u8> = (0..(1024 * 1024))
+            .map(|i: usize| u8::try_from(i.rem_euclid(256)).unwrap_or(0))
+            .collect();
+        let payload_len = payload.len();
+        let handle = Arc::new(MockAssetHandle::new("big", "image/png", &payload));
+        let mut counting = CountingWriter {
+            inner: Vec::new(),
+            max_single_write: 0,
+            total_writes: 0,
+        };
+
+        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut counting));
+        let start_result = writer.handle_event(Event::StartDocument {
+            id: None,
+            language: None,
+            metadata: None,
+        });
+        assert!(start_result.is_ok(), "start should succeed");
+
+        let img_result = writer.handle_event(Event::Image {
+            source: ImageSource::Asset(handle),
+            alt: Some("Large image".to_string()),
+            title: None,
+            decorative: false,
+            id: None,
+        });
+        assert!(img_result.is_ok(), "image should succeed");
+
+        let end_result = writer.handle_event(Event::EndDocument);
+        assert!(end_result.is_ok(), "end should succeed");
+
+        let finish_result = writer.finish();
+        assert!(finish_result.is_ok(), "finish should succeed");
+
+        assert!(
+             counting.max_single_write < 16 * 1024,
+             "expected streaming (max write < 16KB), got max single write of {} bytes (total payload {})",
+             counting.max_single_write, payload_len
+         );
+        assert!(
+            counting.total_writes > 64,
+            "expected many small writes for 1MB payload; got {} writes",
+            counting.total_writes
         );
     }
 }

--- a/crates/docspec-cli/src/commands/convert.rs
+++ b/crates/docspec-cli/src/commands/convert.rs
@@ -9,7 +9,6 @@ use crate::args::ConvertArgs;
 use crate::error::{CliError, Result};
 use crate::format;
 
-/// Runs the streaming conversion pipeline.
 fn run_pipeline<W: Write>(
     reader: AnyReader,
     output_format: docspec::OutputFormat,
@@ -39,7 +38,6 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         }
     }
 
-    // Resolve formats BEFORE reading input (fail-fast)
     let input_format = format::resolve_input_format(
         from,
         input_path.as_deref(),
@@ -51,8 +49,7 @@ pub fn run(args: ConvertArgs) -> Result<()> {
         "cannot detect output format: use --to",
     )?;
 
-    // Read input AFTER format validation
-    let reader = match input_path.as_ref() {
+    let reader: AnyReader = match input_path.as_ref() {
         Some(path) if path.as_os_str() != "-" => AnyReader::from_path(input_format, path)?,
         _ => {
             let mut buf = Vec::new();

--- a/crates/docspec-cli/tests/cli.rs
+++ b/crates/docspec-cli/tests/cli.rs
@@ -13,7 +13,7 @@ use predicates::prelude::PredicateBooleanExt as _;
 use predicates::str::contains;
 use tempfile::NamedTempFile;
 
-use docspec_test_utils::synth_docx;
+use docspec_test_utils::{synth_docx, synth_docx_with_image_png};
 
 fn docspec_cmd() -> Command {
     let result = Command::cargo_bin("docspec");
@@ -64,6 +64,20 @@ fn read_output(path: &std::path::Path) -> String {
 }
 
 const SIMPLE_RELS: &str = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+fn find_image_node(value: &serde_json::Value) -> Option<&serde_json::Value> {
+    match value {
+        serde_json::Value::Array(arr) => arr.iter().find_map(find_image_node),
+        serde_json::Value::Object(obj) => {
+            if obj.get("type").and_then(|t| t.as_str()) == Some("image") {
+                Some(value)
+            } else {
+                obj.values().find_map(find_image_node)
+            }
+        }
+        _ => None,
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -646,5 +660,68 @@ mod tests {
             .assert()
             .failure()
             .stderr(contains("pdf"));
+    }
+
+    #[test]
+    fn convert_docx_with_image_via_file_path_emits_data_uri() {
+        let bytes = synth_docx_with_image_png();
+        let input = markdown_tempfile(&bytes, ".docx");
+
+        let assert = docspec_cmd()
+            .arg("convert")
+            .arg(input.path())
+            .assert()
+            .success();
+
+        let stdout = assert.get_output().stdout.clone();
+        let json: serde_json::Value =
+            serde_json::from_slice(&stdout).unwrap_or_else(|_| std::process::abort());
+
+        let image_node = find_image_node(&json);
+        assert!(
+            image_node.is_some(),
+            "expected at least one image node in output: {json}"
+        );
+        let url = image_node
+            .unwrap_or_else(|| std::process::abort())
+            .get("props")
+            .and_then(|p| p.get("url"))
+            .and_then(|u| u.as_str())
+            .unwrap_or("");
+        assert!(
+            url.starts_with("data:image/png;base64,"),
+            "expected data URI starting with 'data:image/png;base64,', got: {url:?}"
+        );
+    }
+
+    #[test]
+    fn convert_docx_with_image_via_stdin_emits_data_uri() {
+        let bytes = synth_docx_with_image_png();
+
+        let assert = docspec_cmd()
+            .args(["convert", "--from", "docx"])
+            .write_stdin(bytes)
+            .assert()
+            .success();
+
+        let stdout = assert.get_output().stdout.clone();
+        let json: serde_json::Value =
+            serde_json::from_slice(&stdout).unwrap_or_else(|_| std::process::abort());
+
+        let image_node = find_image_node(&json);
+        assert!(
+            image_node.is_some(),
+            "expected at least one image node in output: {json}"
+        );
+        let url = image_node
+            .unwrap_or_else(|| std::process::abort())
+            .get("props")
+            .and_then(|p| p.get("url"))
+            .and_then(|u| u.as_str())
+            .unwrap_or("");
+        assert!(
+            url.starts_with("data:image/png;base64,"),
+            "expected data URI starting with 'data:image/png;base64,', got: {url:?}"
+        );
     }
 }

--- a/crates/docspec-core/src/event.rs
+++ b/crates/docspec-core/src/event.rs
@@ -17,8 +17,8 @@
 //!
 //! # Asset References
 //!
-//! [`Event::Image`] carries an [`crate::ImageSource`] (asset id or URI), not bytes.
-//! Writers resolve bytes lazily via [`crate::AssetProvider`]; assets must remain
+//! [`Event::Image`] carries an [`crate::ImageSource`] (asset handle or URI), not bytes.
+//! Writers resolve bytes lazily via [`crate::AssetHandle`]; assets must remain
 //! accessible until [`Event::EndDocument`].
 //!
 //! # Well-Formedness Rules
@@ -170,7 +170,7 @@ pub enum Event {
 
     /// An image reference.
     ///
-    /// Asset bytes resolve lazily via [`crate::AssetProvider`]. `decorative` means
+    /// Asset bytes resolve lazily via [`crate::AssetHandle`]. `decorative` means
     /// purely visual — no alt text is needed for accessibility. Images may appear
     /// inline within paragraphs/headings or directly in block containers.
     Image {

--- a/crates/docspec-core/src/lib.rs
+++ b/crates/docspec-core/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! `DocSpec` converts documents through a streaming event pipeline. This crate defines
 //! the [`Event`] enum, supporting types, error types, and the [`EventSource`],
-//! [`EventSink`], and [`AssetProvider`] traits that decouple readers from writers.
+//! [`EventSink`], and [`AssetHandle`] traits that decouple readers from writers.
 //!
 //! # Quick Start
 //!
@@ -31,7 +31,7 @@ pub use error::{Error, Position, Result};
 pub use event::{Event, TextStyleKind};
 pub use pipeline::pipe;
 pub use stack::{block_kind_for_end, block_kind_for_start, BlockKind, StackTrackingSink};
-pub use traits::{AssetProvider, EventSink, EventSource};
+pub use traits::{AssetHandle, EventSink, EventSource};
 pub use types::{
     Author, Color, DocumentMeta, ImageSource, ListStyleType, TableHeaderScope, TextAlignment,
 };

--- a/crates/docspec-core/src/traits.rs
+++ b/crates/docspec-core/src/traits.rs
@@ -1,23 +1,24 @@
-//! Core traits for event sources, sinks, and asset providers.
+//! Core traits for event sources, sinks, and asset handles.
 
-use alloc::borrow::Cow;
-use std::io;
-use std::io::Write;
-
-/// Provides access to binary assets referenced in the event stream.
+/// A self-contained handle to a single embedded asset.
 ///
-/// Readers register assets as they are encountered. Writers call [`AssetProvider::stream_to`]
-/// on demand — bytes stream through, never buffer. Assets must remain accessible until
-/// the `EndDocument` event is processed.
-pub trait AssetProvider: Send + Sync {
-    /// Returns the MIME content type for the given asset ID, or `None` if the asset is not found.
-    fn content_type(&self, asset_id: &str) -> Option<Cow<'_, str>>;
+/// Returned by readers inside `ImageSource::Asset(Arc<dyn AssetHandle>)`.
+/// The handle carries everything needed to resolve content type and stream
+/// bytes — no external provider lookup is required.
+pub trait AssetHandle: Send + Sync + core::fmt::Debug {
+    /// MIME content type (e.g. `"image/png"`). `None` means unknown.
+    fn content_type(&self) -> Option<std::borrow::Cow<'_, str>>;
 
-    /// Streams the asset bytes to the given writer.
+    /// Stream the asset bytes to `writer`. Returns total bytes written.
     ///
-    /// Returns `Some(Ok(bytes_written))` on success, `Some(Err(_))` on write error,
-    /// or `None` if the asset is not found.
-    fn stream_to(&self, asset_id: &str, writer: &mut dyn Write) -> Option<io::Result<u64>>;
+    /// # Errors
+    /// Returns `io::Error` if the underlying source fails or the asset is
+    /// no longer accessible (e.g. ZIP entry vanished, mutex poisoned).
+    fn stream_to(&self, writer: &mut dyn std::io::Write) -> std::io::Result<u64>;
+
+    /// Opaque identifier used for `Debug` formatting and `PartialEq` on
+    /// `ImageSource::Asset`. Format is reader-defined (e.g. `"zip://word/media/image1.png"`).
+    fn asset_id(&self) -> &str;
 }
 
 /// Consumes a stream of [`crate::Event`]s to produce output.

--- a/crates/docspec-core/src/types.rs
+++ b/crates/docspec-core/src/types.rs
@@ -66,20 +66,30 @@ pub enum Color {
 }
 
 /// A reference to an image asset, either embedded or external.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum ImageSource {
-    /// An embedded asset resolved through [`crate::AssetProvider`].
-    Asset {
-        /// The asset identifier.
-        asset_id: String,
-    },
+    /// An embedded asset handle.
+    Asset(std::sync::Arc<dyn crate::traits::AssetHandle>),
     /// An external URI.
     Uri {
         /// The external resource URI.
         uri: String,
     },
 }
+
+impl PartialEq for ImageSource {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Asset(a), Self::Asset(b)) => a.asset_id() == b.asset_id(),
+            (Self::Uri { uri: a }, Self::Uri { uri: b }) => a == b,
+            _ => false,
+        }
+    }
+}
+// Note: Eq is intentionally NOT derived — Arc<dyn> cannot guarantee
+// reflexivity for arbitrary handle implementations.
 
 /// An author with a name and optional email address.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/docspec-core/tests/event.rs
+++ b/crates/docspec-core/tests/event.rs
@@ -7,6 +7,26 @@ mod tests {
         Author, Color, DocumentMeta, ImageSource, ListStyleType, TableHeaderScope, TextAlignment,
     };
 
+    #[derive(Debug)]
+    struct TestAssetHandle {
+        asset_id: String,
+        content_type: Option<String>,
+    }
+
+    impl docspec_core::AssetHandle for TestAssetHandle {
+        fn content_type(&self) -> Option<std::borrow::Cow<'_, str>> {
+            self.content_type.as_deref().map(std::borrow::Cow::Borrowed)
+        }
+
+        fn stream_to(&self, _w: &mut dyn std::io::Write) -> std::io::Result<u64> {
+            Ok(0)
+        }
+
+        fn asset_id(&self) -> &str {
+            &self.asset_id
+        }
+    }
+
     #[test]
     fn end_block_quote() {
         let event = Event::EndBlockQuote;
@@ -144,9 +164,10 @@ mod tests {
     #[test]
     fn image_asset() {
         let event = Event::Image {
-            source: ImageSource::Asset {
+            source: ImageSource::Asset(std::sync::Arc::new(TestAssetHandle {
                 asset_id: "img_001".to_string(),
-            },
+                content_type: None,
+            })),
             alt: Some("A picture".to_string()),
             title: Some("Image Title".to_string()),
             decorative: false,

--- a/crates/docspec-core/tests/traits.rs
+++ b/crates/docspec-core/tests/traits.rs
@@ -150,94 +150,9 @@ mod tests {
         }
     }
 
-    extern crate alloc;
-
-    use alloc::borrow::Cow;
-    use docspec_core::*;
-    use std::collections::HashMap;
-    use std::io::{self, Write};
-
-    /// Mock `AssetProvider` for testing.
-    struct MockAssetProvider {
-        assets: HashMap<String, (String, Vec<u8>)>,
-    }
-
-    impl MockAssetProvider {
-        fn new() -> Self {
-            let mut assets = HashMap::new();
-            assets.insert(
-                "image1".to_string(),
-                ("image/png".to_string(), vec![0x89, 0x50, 0x4E, 0x47]),
-            );
-            assets.insert(
-                "doc1".to_string(),
-                ("application/pdf".to_string(), vec![0x25, 0x50, 0x44, 0x46]),
-            );
-            Self { assets }
-        }
-    }
-
-    impl AssetProvider for MockAssetProvider {
-        fn content_type(&self, asset_id: &str) -> Option<Cow<'_, str>> {
-            self.assets
-                .get(asset_id)
-                .map(|(mime, _)| Cow::Borrowed(mime.as_str()))
-        }
-
-        fn stream_to(&self, asset_id: &str, writer: &mut dyn Write) -> Option<io::Result<u64>> {
-            self.assets.get(asset_id).map(|(_, bytes)| {
-                writer
-                    .write_all(bytes)
-                    .map(|()| u64::try_from(bytes.len()).unwrap_or(u64::MAX))
-            })
-        }
-    }
-
     #[test]
-    fn content_type_known_asset() {
-        let provider = MockAssetProvider::new();
-        let mime = provider.content_type("image1");
-        assert_eq!(mime, Some(Cow::Borrowed("image/png")));
-    }
-
-    #[test]
-    fn content_type_unknown_asset() {
-        let provider = MockAssetProvider::new();
-        let mime = provider.content_type("unknown");
-        assert_eq!(mime, None);
-    }
-
-    #[test]
-    fn stream_to_known_asset() {
-        let provider = MockAssetProvider::new();
-        let mut buffer = Vec::new();
-        let result = provider.stream_to("image1", &mut buffer);
-        assert!(matches!(result, Some(Ok(4))));
-        assert_eq!(buffer, vec![0x89, 0x50, 0x4E, 0x47]);
-    }
-
-    #[test]
-    fn stream_to_multiple_assets() {
-        let provider = MockAssetProvider::new();
-        let mut buffer1 = Vec::new();
-        let mut buffer2 = Vec::new();
-
-        let result1 = provider.stream_to("image1", &mut buffer1);
-        let result2 = provider.stream_to("doc1", &mut buffer2);
-
-        assert!(matches!(result1, Some(Ok(4))));
-        assert_eq!(buffer1, vec![0x89, 0x50, 0x4E, 0x47]);
-
-        assert!(matches!(result2, Some(Ok(4))));
-        assert_eq!(buffer2, vec![0x25, 0x50, 0x44, 0x46]);
-    }
-
-    #[test]
-    fn stream_to_unknown_asset() {
-        let provider = MockAssetProvider::new();
-        let mut buffer = Vec::new();
-        let result = provider.stream_to("unknown", &mut buffer);
-        assert!(result.is_none());
-        assert_eq!(buffer, Vec::<u8>::new());
+    fn asset_handle_is_dyn_compatible_send_sync() {
+        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        assert_send_sync_static::<std::sync::Arc<dyn docspec_core::AssetHandle>>();
     }
 }

--- a/crates/docspec-core/tests/types.rs
+++ b/crates/docspec-core/tests/types.rs
@@ -4,6 +4,26 @@
 mod tests {
     use docspec_core::*;
 
+    #[derive(Debug)]
+    struct TestAssetHandle {
+        asset_id: String,
+        content_type: Option<String>,
+    }
+
+    impl docspec_core::AssetHandle for TestAssetHandle {
+        fn content_type(&self) -> Option<std::borrow::Cow<'_, str>> {
+            self.content_type.as_deref().map(std::borrow::Cow::Borrowed)
+        }
+
+        fn stream_to(&self, _w: &mut dyn std::io::Write) -> std::io::Result<u64> {
+            Ok(0)
+        }
+
+        fn asset_id(&self) -> &str {
+            &self.asset_id
+        }
+    }
+
     #[test]
     fn author_clone() {
         let author = Author {
@@ -142,11 +162,37 @@ mod tests {
 
     #[test]
     fn image_source_asset_clone() {
-        let source = ImageSource::Asset {
+        let source = ImageSource::Asset(std::sync::Arc::new(TestAssetHandle {
             asset_id: "img_001".to_string(),
-        };
+            content_type: None,
+        }));
         let cloned = source.clone();
         assert_eq!(source, cloned);
+    }
+
+    #[test]
+    fn image_source_partial_eq_via_asset_id() {
+        use std::sync::Arc;
+        #[derive(Debug)]
+        struct H(String);
+        impl docspec_core::AssetHandle for H {
+            fn content_type(&self) -> Option<std::borrow::Cow<'_, str>> {
+                None
+            }
+            fn stream_to(&self, _: &mut dyn std::io::Write) -> std::io::Result<u64> {
+                Ok(0)
+            }
+            fn asset_id(&self) -> &str {
+                &self.0
+            }
+        }
+        let a = ImageSource::Asset(Arc::new(H("x".into())));
+        let b = ImageSource::Asset(Arc::new(H("x".into())));
+        let c = ImageSource::Asset(Arc::new(H("y".into())));
+        let u = ImageSource::Uri { uri: "x".into() };
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a, u);
     }
 
     #[test]
@@ -160,9 +206,10 @@ mod tests {
 
     #[test]
     fn image_source_variants() {
-        let asset = ImageSource::Asset {
+        let asset = ImageSource::Asset(std::sync::Arc::new(TestAssetHandle {
             asset_id: "id1".to_string(),
-        };
+            content_type: None,
+        }));
         let uri = ImageSource::Uri {
             uri: "http://example.com".to_string(),
         };

--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -77,43 +77,37 @@ The following list features are intentionally out of scope for V1:
 
 `<w:drawing>` elements are parsed and emit `Event::Image`. The `source` field is one of two variants:
 
-- **Embedded image** (`r:embed`): `ImageSource::Asset { asset_id: "zip://word/media/image1.png" }`. The `asset_id` is the resolved ZIP entry path with a `zip://` scheme prefix. Use [`DocxAssetProvider`] to stream the raw bytes.
+- **Embedded image** (`r:embed`): `ImageSource::Asset(handle)` where `handle.asset_id()` returns `"zip://word/media/image1.png"`. The asset ID is the resolved ZIP entry path with a `zip://` scheme prefix. Call `handle.stream_to(&mut buf)` to stream the raw bytes, or `handle.content_type()` to get the MIME type.
 - **External image** (`r:link`): `ImageSource::Uri { uri: "<url>" }`. The URL is passed through verbatim from the relationship target.
 
 When both `r:embed` and `r:link` appear on the same blip, `r:embed` wins.
 
 A relationship marked `TargetMode="External"` is honored even when referenced via `r:embed` — the reader emits `ImageSource::Uri` in that case, matching Word and LibreOffice behavior.
 
-If the relationship ID cannot be resolved (missing or malformed rels), the reader emits `ImageSource::Asset { asset_id: "<rId>" }` using the raw relationship ID with no `zip://` prefix. Writers should apply their own missing-asset policy.
+If the relationship ID cannot be resolved (missing or malformed rels), the reader emits `ImageSource::Asset(handle)` where `handle.asset_id()` returns the raw relationship ID with no `zip://` prefix. Writers should apply their own missing-asset policy.
 
 `wp:docPr/@descr` maps to `Event::Image.alt`. The `title` field is always `None` in this release.
 
 VML images (`<w:pict>`) are not supported in this release — their subtree is silently dropped.
 
-### DocxAssetProvider
+### Asset Handles
 
-[`DocxAssetProvider`] implements the `AssetProvider` trait and streams asset bytes from the DOCX ZIP archive on demand. Open it independently from [`DocxReader`] using the same file path or an in-memory buffer.
+Each `ImageSource::Asset(handle)` carries an `Arc<dyn AssetHandle>` that holds everything needed to resolve the asset. Call methods directly on the handle:
 
 ```rust,no_run
-use docspec_docx_reader::{DocxReader, DocxAssetProvider, EventSource};
-use docspec_core::{AssetProvider, Event, ImageSource};
+use docspec_docx_reader::{DocxReader, EventSource};
+use docspec_core::{Event, ImageSource};
 
 let mut reader = DocxReader::from_path("document.docx")?;
-let provider = DocxAssetProvider::from_path("document.docx")?;
-
 while let Some(event) = reader.next_event()? {
-    if let Event::Image { source: ImageSource::Asset { asset_id }, .. } = &event {
+    if let Event::Image { source: ImageSource::Asset(handle), .. } = &event {
         let mut buf = Vec::new();
-        if let Some(result) = provider.stream_to(asset_id, &mut buf) {
-            result?;
-        }
-        // buf now contains the raw image bytes (or is empty if the asset was missing)
+        handle.stream_to(&mut buf)?;
+        // buf now contains the raw image bytes
     }
 }
 # Ok::<(), docspec_core::Error>(())
 ```
-
-For in-memory DOCX data, use `DocxAssetProvider::from_reader` with a `Cursor<Vec<u8>>`.
 
 ## Streaming Guarantee
 

--- a/crates/docspec-docx-reader/src/asset_provider.rs
+++ b/crates/docspec-docx-reader/src/asset_provider.rs
@@ -1,240 +1,80 @@
-//! DOCX ZIP archive asset provider.
+//! Per-asset handle for DOCX embedded images.
 
-use std::borrow::Cow;
-use std::io::{self, Read, Seek, Write};
-use std::path::Path;
-use std::sync::Mutex;
+use std::{
+    borrow::Cow,
+    io::{self, Write},
+    sync::{Arc, Mutex},
+};
 
-use docspec_core::{AssetProvider, Error, Result};
-use zip::result::ZipError;
-use zip::ZipArchive;
+use docspec_core::AssetHandle;
 
-use crate::content_types::{self, ContentTypes};
+use crate::{content_types::ContentTypes, package::ReadSeek};
 
-/// Object-safe alias combining [`Read`], [`Seek`], and [`Send`] for use in trait objects.
-trait ReadSeek: Read + Seek + Send {}
-impl<T: Read + Seek + Send> ReadSeek for T {}
-
-/// Provides streaming access to binary assets stored inside a DOCX ZIP archive.
-///
-/// Holds the docx ZIP file open until dropped. Uses internal Mutex to serialize
-/// concurrent ZIP reads. Not Clone — use `Arc<DocxAssetProvider>` to share.
-pub struct DocxAssetProvider {
-    archive: Mutex<ZipArchive<Box<dyn ReadSeek + 'static>>>,
-    content_types: ContentTypes,
+/// Resolves a single embedded asset from a shared DOCX ZIP archive.
+pub struct DocxAssetHandle {
+    archive: Arc<Mutex<zip::ZipArchive<Box<dyn ReadSeek + 'static>>>>,
+    content_types: Arc<ContentTypes>,
+    asset_id: String,
 }
 
-impl DocxAssetProvider {
-    /// Creates a `DocxAssetProvider` from a file path.
-    ///
-    /// Opens the DOCX ZIP file and reads `[Content_Types].xml` to build the
-    /// content type lookup table.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Io`] if the file cannot be opened, or [`Error::Parse`]
-    /// if the file is not a valid ZIP archive.
-    #[inline]
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = std::fs::File::open(path.as_ref()).map_err(Error::from)?;
-        Self::from_reader(file)
+impl core::fmt::Debug for DocxAssetHandle {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("DocxAssetHandle")
+            .field("asset_id", &self.asset_id)
+            .finish_non_exhaustive()
     }
+}
 
-    /// Creates a `DocxAssetProvider` from any [`Read`] + [`Seek`] + [`Send`] source.
-    ///
-    /// The source must be positioned at the start of a valid DOCX (ZIP) archive.
-    /// Reads `[Content_Types].xml` to build the content type lookup table.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`Error::Parse`] if the input is not a valid ZIP archive, or
-    /// [`Error::Io`] for I/O failures when reading `[Content_Types].xml`.
-    #[inline]
-    pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
-        let boxed: Box<dyn ReadSeek + 'static> = Box::new(reader);
-        let mut archive = ZipArchive::new(boxed).map_err(|err| match err {
-            ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
-                message: "not a valid ZIP archive".to_string(),
-                position: None,
-            },
-            ZipError::Io(source) => Error::Io { source },
-            ZipError::FileNotFound
-            | ZipError::InvalidPassword
-            | ZipError::CompressionMethodNotSupported(_)
-            | _ => Error::Parse {
-                message: format!("not a valid ZIP archive: {err}"),
-                position: None,
-            },
-        })?;
-
-        let ct_bytes = match archive.by_name("[Content_Types].xml") {
-            Ok(mut entry) => {
-                let mut bytes: Vec<u8> = Vec::new();
-                io::copy(&mut entry, &mut bytes).map_err(Error::from)?;
-                bytes
-            }
-            Err(_) => Vec::new(),
-        };
-
-        let content_types = content_types::parse(&ct_bytes)?;
-
-        Ok(Self {
-            archive: Mutex::new(archive),
+impl DocxAssetHandle {
+    pub(crate) fn new(
+        archive: Arc<Mutex<zip::ZipArchive<Box<dyn ReadSeek + 'static>>>>,
+        content_types: Arc<ContentTypes>,
+        asset_id: String,
+    ) -> Self {
+        Self {
+            archive,
             content_types,
-        })
+            asset_id,
+        }
     }
 }
 
-impl AssetProvider for DocxAssetProvider {
-    /// Returns the MIME content type for an asset ID with a `zip://` scheme prefix.
-    ///
-    /// Strips the `zip://` prefix and looks up the path in `[Content_Types].xml`.
-    /// Returns `None` if the scheme is not `zip://` or if no content type is registered
-    /// for the path.
-    #[inline]
-    fn content_type(&self, asset_id: &str) -> Option<Cow<'_, str>> {
-        asset_id
+impl AssetHandle for DocxAssetHandle {
+    fn content_type(&self) -> Option<Cow<'_, str>> {
+        self.asset_id
             .strip_prefix("zip://")
             .and_then(|p| self.content_types.lookup(p))
             .map(Cow::Borrowed)
     }
 
-    /// Streams the asset bytes at `asset_id` to `writer`.
-    ///
-    /// Strips the `zip://` prefix, acquires the archive mutex, locates the ZIP entry,
-    /// and copies bytes via [`io::copy`] — never buffers the full asset. Returns:
-    ///
-    /// - `None` if `asset_id` does not start with `zip://`
-    /// - `None` if the mutex is poisoned
-    /// - `None` if the entry is not found in the archive
-    /// - `Some(Ok(n))` on success with `n` bytes written
-    /// - `Some(Err(_))` on I/O error during copy
-    #[inline]
-    fn stream_to(&self, asset_id: &str, writer: &mut dyn Write) -> Option<io::Result<u64>> {
-        let path = asset_id.strip_prefix("zip://")?;
-        let mut archive = self.archive.lock().ok()?;
-        let mut entry = archive.by_name(path).ok()?;
-        Some(io::copy(&mut entry, writer))
+    fn stream_to(&self, writer: &mut dyn Write) -> io::Result<u64> {
+        let path = self
+            .asset_id
+            .strip_prefix("zip://")
+            .ok_or_else(|| io::Error::other(format!("not a zip:// asset_id: {}", self.asset_id)))?;
+        let mut archive = self
+            .archive
+            .lock()
+            .map_err(|_e| io::Error::other("docx archive mutex poisoned"))?;
+        let mut entry = archive
+            .by_name(path)
+            .map_err(|e| io::Error::other(format!("zip by_name({path}): {e}")))?;
+        io::copy(&mut entry, writer)
+    }
+
+    fn asset_id(&self) -> &str {
+        &self.asset_id
     }
 }
 
 #[cfg(test)]
-#[cfg(not(coverage))]
 mod tests {
-    #![allow(
-        clippy::unwrap_used,
-        clippy::expect_used,
-        clippy::separated_literal_suffix,
-        clippy::unseparated_literal_suffix
-    )]
-    use std::borrow::Cow;
-    use std::io::{Cursor, Write as _};
-    use zip::write::SimpleFileOptions;
-    use zip::CompressionMethod;
-
-    use super::DocxAssetProvider;
-    use docspec_core::AssetProvider as _;
-
-    fn synth_zip(entries: &[(&str, &[u8])]) -> Vec<u8> {
-        let buf = Cursor::new(Vec::new());
-        let mut writer = zip::ZipWriter::new(buf);
-        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
-        for (name, data) in entries {
-            writer.start_file(*name, options).unwrap();
-            writer.write_all(data).unwrap();
-        }
-        writer.finish().unwrap().into_inner()
-    }
-
-    fn content_types_png_xml() -> &'static [u8] {
-        br#"<?xml version="1.0"?>
-<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
-  <Default Extension="png" ContentType="image/png"/>
-</Types>"#
-    }
-
-    fn synth_png_docx() -> Vec<u8> {
-        synth_zip(&[
-            ("[Content_Types].xml", content_types_png_xml()),
-            ("word/media/image1.png", &[0x89, 0x50, 0x4E, 0x47]),
-        ])
-    }
+    use super::*;
 
     #[test]
-    fn is_send_sync() {
-        fn assert_send_sync<T: Send + Sync>() {}
-        assert_send_sync::<DocxAssetProvider>();
-    }
-
-    #[test]
-    fn stream_to_exact_bytes() {
-        let zip_bytes = synth_png_docx();
-        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
-        let mut buf = Vec::new();
-        let result = provider.stream_to("zip://word/media/image1.png", &mut buf);
-        assert_eq!(
-            result.expect("should return Some").expect("should be Ok"),
-            4u64
-        );
-        assert_eq!(buf, &[0x89, 0x50, 0x4E, 0x47]);
-    }
-
-    #[test]
-    fn content_type_from_default() {
-        let zip_bytes = synth_png_docx();
-        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
-        let ct = provider.content_type("zip://word/media/image1.png");
-        assert_eq!(ct, Some(Cow::Borrowed("image/png")));
-    }
-
-    #[test]
-    fn non_zip_scheme_returns_none() {
-        let zip_bytes = synth_png_docx();
-        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
-        assert_eq!(provider.content_type("rId99"), None);
-        let mut buf = Vec::new();
-        assert!(provider.stream_to("rId99", &mut buf).is_none());
-    }
-
-    #[test]
-    fn missing_asset_stream_returns_none() {
-        let zip_bytes = synth_png_docx();
-        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
-        let mut buf = Vec::new();
-        assert!(provider
-            .stream_to("zip://word/media/noexist.png", &mut buf)
-            .is_none());
-    }
-
-    #[test]
-    fn content_type_returns_none_for_unregistered_extension() {
-        let zip_bytes = synth_png_docx();
-        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
-        assert_eq!(provider.content_type("zip://word/document.xml"), None);
-    }
-
-    #[test]
-    fn from_path_opens_file() {
-        let dir = tempfile::tempdir().expect("tempdir");
-        let path = dir.path().join("test.docx");
-        let zip_bytes = synth_png_docx();
-        std::fs::write(&path, &zip_bytes).expect("write file");
-        let provider = DocxAssetProvider::from_path(&path).expect("should open");
-        let ct = provider.content_type("zip://word/media/image1.png");
-        assert_eq!(ct, Some(Cow::Borrowed("image/png")));
-    }
-
-    #[test]
-    fn missing_content_types_yields_empty_lookup() {
-        let zip_bytes = synth_zip(&[("word/media/image1.png", &[0x89, 0x50, 0x4E, 0x47])]);
-        let provider = DocxAssetProvider::from_reader(Cursor::new(zip_bytes)).expect("should open");
-        assert_eq!(provider.content_type("zip://word/media/image1.png"), None);
-        let mut buf = Vec::new();
-        let result = provider.stream_to("zip://word/media/image1.png", &mut buf);
-        assert_eq!(
-            result.expect("should return Some").expect("should be Ok"),
-            4u64
-        );
-        assert_eq!(buf, &[0x89, 0x50, 0x4E, 0x47]);
+    fn is_send_sync_static() {
+        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        assert_send_sync_static::<DocxAssetHandle>();
+        assert_send_sync_static::<Arc<dyn AssetHandle>>();
     }
 }

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -3,6 +3,7 @@
 use alloc::collections::VecDeque;
 use core::fmt;
 use std::io::{BufReader, Read};
+use std::sync::{Arc, Mutex};
 
 use docspec_core::{
     Color, Error, Event, ImageSource, Result, TableHeaderScope, TextAlignment, TextStyleKind,
@@ -238,6 +239,10 @@ pub struct DocumentReader {
     pending_num_pr_ilvl: Option<u32>,
     /// The quick-xml reader streaming from the document entry.
     xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
+    /// Shared DOCX ZIP archive — used to stream embedded asset bytes on demand.
+    archive: Arc<Mutex<zip::ZipArchive<Box<dyn crate::package::ReadSeek + 'static>>>>,
+    /// Content-type lookup table — used by `DocxAssetHandle` to resolve MIME types.
+    content_types: Arc<crate::content_types::ContentTypes>,
 }
 
 impl fmt::Debug for DocumentReader {
@@ -304,14 +309,18 @@ impl fmt::Debug for DocumentReader {
                 .field("header_band_open", &self.header_band_open);
         }
         debug.field("xml", &"<quick_xml::Reader>");
+        debug.field("archive", &"<Arc<Mutex<ZipArchive>>>");
+        debug.field("content_types", &"<Arc<ContentTypes>>");
         debug.finish()
     }
 }
 
 impl DocumentReader {
-    pub fn from_xml_reader(
+    pub fn from_xml_reader_and_archive(
         mut xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
         data: DocxData,
+        archive: Arc<Mutex<zip::ZipArchive<Box<dyn crate::package::ReadSeek + 'static>>>>,
+        content_types: Arc<crate::content_types::ContentTypes>,
     ) -> Self {
         xml.config_mut().check_end_names = false;
         let DocxData {
@@ -372,7 +381,33 @@ impl DocumentReader {
             pending_num_pr_id: None,
             pending_num_pr_ilvl: None,
             xml,
+            archive,
+            content_types,
         }
+    }
+
+    #[cfg(test)]
+    #[cfg(test)]
+    #[allow(clippy::expect_used, clippy::as_conversions)]
+    pub(crate) fn from_xml_reader(
+        xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
+        data: DocxData,
+    ) -> Self {
+        use std::io::Cursor;
+        const EMPTY_ZIP: &[u8] = &[
+            0x50, 0x4B, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ];
+        let archive = zip::ZipArchive::new(
+            Box::new(Cursor::new(EMPTY_ZIP)) as Box<dyn crate::package::ReadSeek + 'static>
+        )
+        .expect("minimal empty zip must be valid");
+        Self::from_xml_reader_and_archive(
+            xml,
+            data,
+            Arc::new(Mutex::new(archive)),
+            Arc::new(crate::content_types::ContentTypes::default()),
+        )
     }
 }
 
@@ -1147,17 +1182,20 @@ impl DocumentReader {
     }
 
     fn image_source_for_rid(&self, rid: &str) -> ImageSource {
-        match self.data.image_map.get(rid) {
-            Some(rel) if rel.is_external => ImageSource::Uri {
-                uri: rel.target.clone(),
-            },
-            Some(rel) => ImageSource::Asset {
-                asset_id: format!("zip://{}", rel.target),
-            },
-            None => ImageSource::Asset {
-                asset_id: rid.to_string(),
-            },
-        }
+        let asset_id = match self.data.image_map.get(rid) {
+            Some(rel) if rel.is_external => {
+                return ImageSource::Uri {
+                    uri: rel.target.clone(),
+                }
+            }
+            Some(rel) => format!("zip://{}", rel.target),
+            None => rid.to_string(),
+        };
+        ImageSource::Asset(Arc::new(crate::asset_provider::DocxAssetHandle::new(
+            Arc::clone(&self.archive),
+            Arc::clone(&self.content_types),
+            asset_id,
+        )))
     }
 
     fn handle_hyperlink_start(&mut self, tag: &BytesStart<'_>) {
@@ -1636,10 +1674,28 @@ mod tests {
     )]
     use core::fmt::Write as _;
     use std::io::{Cursor, Read};
+    use std::sync::Arc;
 
-    use docspec_core::{ImageSource, ListStyleType};
+    use docspec_core::{AssetHandle, ImageSource, ListStyleType};
 
     use super::*;
+
+    fn asset_source(id: &str) -> ImageSource {
+        #[derive(Debug)]
+        struct StubHandle(String);
+        impl AssetHandle for StubHandle {
+            fn asset_id(&self) -> &str {
+                &self.0
+            }
+            fn content_type(&self) -> Option<std::borrow::Cow<'_, str>> {
+                None
+            }
+            fn stream_to(&self, _: &mut dyn std::io::Write) -> std::io::Result<u64> {
+                Ok(0)
+            }
+        }
+        ImageSource::Asset(Arc::new(StubHandle(id.to_string())))
+    }
 
     fn styles_xml(body: &str) -> String {
         format!(
@@ -1842,9 +1898,7 @@ mod tests {
                 start_doc(),
                 start_para(),
                 image_event(
-                    ImageSource::Asset {
-                        asset_id: "zip://word/media/image1.png".to_string(),
-                    },
+                    asset_source("zip://word/media/image1.png"),
                     Some("alt text"),
                 ),
                 Event::EndParagraph,
@@ -1893,12 +1947,7 @@ mod tests {
             vec![
                 start_doc(),
                 start_para(),
-                image_event(
-                    ImageSource::Asset {
-                        asset_id: "rId99".to_string(),
-                    },
-                    Some("missing rel"),
-                ),
+                image_event(asset_source("rId99"), Some("missing rel"),),
                 Event::EndParagraph,
                 Event::EndDocument,
             ]
@@ -1944,9 +1993,7 @@ mod tests {
                 start_doc(),
                 start_para(),
                 image_event(
-                    ImageSource::Asset {
-                        asset_id: "zip://word/media/embed.png".to_string(),
-                    },
+                    asset_source("zip://word/media/embed.png"),
                     Some("embed wins"),
                 ),
                 Event::EndParagraph,
@@ -2025,18 +2072,8 @@ mod tests {
             vec![
                 start_doc(),
                 start_para(),
-                image_event(
-                    ImageSource::Asset {
-                        asset_id: "zip://word/media/one.png".to_string(),
-                    },
-                    Some("one"),
-                ),
-                image_event(
-                    ImageSource::Asset {
-                        asset_id: "zip://word/media/two.png".to_string(),
-                    },
-                    Some("two"),
-                ),
+                image_event(asset_source("zip://word/media/one.png"), Some("one"),),
+                image_event(asset_source("zip://word/media/two.png"), Some("two"),),
                 Event::EndParagraph,
                 Event::EndDocument,
             ]
@@ -2062,9 +2099,7 @@ mod tests {
                 start_doc(),
                 start_para(),
                 image_event(
-                    ImageSource::Asset {
-                        asset_id: "zip://word/media/image1.png".to_string(),
-                    },
+                    asset_source("zip://word/media/image1.png"),
                     Some("start tag"),
                 ),
                 Event::EndParagraph,

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -19,7 +19,7 @@
 //! `<w:sdtPr>`/`<w:sdtEndPr>` dropped), tracked insertions and moves
 //! (`<w:ins>`, `<w:moveTo>` — accept-changes semantics), and `DrawingML` images
 //! (`<w:drawing>` — emitted as `Image` events; see the crate README for
-//! `ImageSource` variants and `DocxAssetProvider` usage).
+//! `ImageSource` variants and `AssetHandle` usage).
 //! Emits: `StartDocument`, `StartParagraph`, `StartTextStyle`, `Text`,
 //! `EndTextStyle`, `LineBreak`, `EndParagraph`, `StartTable`, `StartTableRow`,
 //! `StartTableCell`, `StartTableHeader`, `EndTableHeader`, `EndTableCell`,
@@ -93,27 +93,6 @@ use std::path::Path;
 
 pub use docspec_core::EventSource;
 
-/// Provides streaming access to binary assets stored inside a DOCX ZIP archive.
-///
-/// Use this alongside [`DocxReader`] when you need to resolve embedded images.
-/// [`DocxReader`] emits `Event::Image` with an `asset_id` of the form
-/// `zip://word/media/image1.png`; pass that `asset_id` to
-/// [`DocxAssetProvider`] to stream the raw bytes.
-///
-/// # Example
-///
-/// ```no_run
-/// use docspec_docx_reader::DocxAssetProvider;
-/// use docspec_core::AssetProvider;
-///
-/// let provider = DocxAssetProvider::from_path("document.docx")?;
-/// let mut buf = Vec::new();
-/// if let Some(result) = provider.stream_to("zip://word/media/image1.png", &mut buf) {
-///     result?;
-/// }
-/// # Ok::<(), docspec_core::Error>(())
-/// ```
-pub use asset_provider::DocxAssetProvider;
 use docspec_core::{Error, Result};
 
 const _: for<'a> fn(&'a content_types::ContentTypes, &str) -> Option<&'a str> =
@@ -122,18 +101,6 @@ fn _image_rel_fields(r: &rels::ImageRel) -> (&str, bool) {
     (&r.target, r.is_external)
 }
 const _: for<'a> fn(&'a rels::ImageRel) -> (&'a str, bool) = _image_rel_fields;
-fn _use_docx_asset_provider_from_path(p: &Path) -> Result<asset_provider::DocxAssetProvider> {
-    asset_provider::DocxAssetProvider::from_path(p)
-}
-const _: fn(&Path) -> Result<asset_provider::DocxAssetProvider> =
-    _use_docx_asset_provider_from_path;
-fn _use_docx_asset_provider_from_reader(
-    r: std::io::Cursor<Vec<u8>>,
-) -> Result<asset_provider::DocxAssetProvider> {
-    asset_provider::DocxAssetProvider::from_reader(r)
-}
-const _: fn(std::io::Cursor<Vec<u8>>) -> Result<asset_provider::DocxAssetProvider> =
-    _use_docx_asset_provider_from_reader;
 
 /// A streaming DOCX reader that implements [`EventSource`].
 ///
@@ -182,7 +149,7 @@ impl DocxReader {
     /// cannot be opened. Returns [`Error::Io`] for I/O failures.
     #[inline]
     pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
-        let (style_list, numbering, hyperlink_map, image_map, _content_types, stream) =
+        let (style_list, numbering, hyperlink_map, image_map, content_types, archive, stream) =
             package::open_package(reader)?;
         let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
         let data = document::DocxData {
@@ -192,7 +159,12 @@ impl DocxReader {
             image_map,
         };
         Ok(Self {
-            inner: document::DocumentReader::from_xml_reader(xml, data),
+            inner: document::DocumentReader::from_xml_reader_and_archive(
+                xml,
+                data,
+                archive,
+                content_types,
+            ),
         })
     }
 }

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -1,9 +1,11 @@
 //! ZIP/OPC package navigation for DOCX archives.
 
-use std::io::{Read, Seek};
+use std::io::{Cursor, Read, Seek};
+use std::sync::{Arc, Mutex};
 
 use docspec_core::{Error, Result};
 use zip::result::ZipError;
+use zip::ZipArchive;
 
 use crate::content_types;
 use crate::content_types::ContentTypes;
@@ -11,12 +13,17 @@ use crate::rels;
 use crate::rels::{HyperlinkMap, ImageMap};
 use crate::styles::StyleList;
 
+/// Object-safe alias combining [`Read`], [`Seek`], and [`Send`] for use in trait objects.
+pub(crate) trait ReadSeek: Read + Seek + Send {}
+impl<T: Read + Seek + Send> ReadSeek for T {}
+
 type PackageContents = (
     StyleList,
     crate::numbering::MinimalNumbering,
     HyperlinkMap,
     ImageMap,
-    ContentTypes,
+    Arc<ContentTypes>,
+    Arc<Mutex<ZipArchive<Box<dyn ReadSeek + 'static>>>>,
     Box<dyn Read + Send>,
 );
 
@@ -24,8 +31,9 @@ type PackageContents = (
 /// relationships, locates `document.xml`, reads `[Content_Types].xml`, and returns
 /// a [`PackageContents`] tuple with all parsed data and a streaming reader for the
 /// main document part.
-pub fn open_package<R: Read + Seek + Send + 'static>(mut reader: R) -> Result<PackageContents> {
-    let mut archive = zip::ZipArchive::new(&mut reader).map_err(|err| match err {
+pub fn open_package<R: Read + Seek + Send + 'static>(reader: R) -> Result<PackageContents> {
+    let boxed: Box<dyn ReadSeek + 'static> = Box::new(reader);
+    let mut archive = ZipArchive::new(boxed).map_err(|err| match err {
         ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
             message: "not a valid ZIP archive".to_string(),
             position: None,
@@ -63,49 +71,32 @@ pub fn open_package<R: Read + Seek + Send + 'static>(mut reader: R) -> Result<Pa
         None => ContentTypes::default(),
     };
 
-    let (data_start, compressed_size, method) = {
-        let entry = archive
-            .by_name(&document_path)
-            .map_err(|_err| Error::Parse {
-                message: format!("document target not found: {document_path}"),
-                position: None,
-            })?;
-        let data_start = entry
-            .data_start()
-            .ok_or_else(|| parse_error("document.xml has no data offset".to_string()))?;
-        (data_start, entry.compressed_size(), entry.compression())
-    };
-    drop(archive);
-
-    reader
-        .seek(std::io::SeekFrom::Start(data_start))
+    let mut document_xml_bytes = Vec::new();
+    archive
+        .by_name(&document_path)
+        .map_err(|_err| Error::Parse {
+            message: format!("document target not found: {document_path}"),
+            position: None,
+        })?
+        .read_to_end(&mut document_xml_bytes)
         .map_err(Error::from)?;
 
-    let limited = reader.take(compressed_size);
-
-    let stream: Box<dyn Read + Send> = if method == zip::CompressionMethod::Stored {
-        Box::new(limited)
-    } else if method == zip::CompressionMethod::Deflated {
-        Box::new(flate2::read::DeflateDecoder::new(limited))
-    } else {
-        return Err(Error::Parse {
-            message: format!("unsupported compression: {method:?}"),
-            position: None,
-        });
-    };
+    let content_types_arc = Arc::new(content_types);
+    let archive_arc = Arc::new(Mutex::new(archive));
 
     Ok((
         style_list,
         numbering,
         hyperlink_map,
         image_map,
-        content_types,
-        stream,
+        content_types_arc,
+        archive_arc,
+        Box::new(Cursor::new(document_xml_bytes)),
     ))
 }
 
 fn load_style_list_and_hyperlink_map<R: Read + Seek>(
-    archive: &mut zip::ZipArchive<&mut R>,
+    archive: &mut ZipArchive<R>,
     document_path: &str,
 ) -> Result<(StyleList, HyperlinkMap, ImageMap)> {
     let doc_rels_path = rels::derive_part_rels_path(document_path);
@@ -156,7 +147,7 @@ fn load_style_list_and_hyperlink_map<R: Read + Seek>(
 }
 
 fn read_optional_entry<R: Read + Seek>(
-    archive: &mut zip::ZipArchive<&mut R>,
+    archive: &mut ZipArchive<R>,
     path: &str,
 ) -> Result<Option<Vec<u8>>> {
     match archive.by_name(path) {
@@ -171,7 +162,7 @@ fn read_optional_entry<R: Read + Seek>(
 }
 
 fn load_numbering<R: Read + Seek>(
-    archive: &mut zip::ZipArchive<&mut R>,
+    archive: &mut ZipArchive<R>,
     document_path: &str,
 ) -> Result<crate::numbering::MinimalNumbering> {
     let doc_rels_path = rels::derive_part_rels_path(document_path);
@@ -503,6 +494,7 @@ mod tests {
                 _hyperlink_map,
                 _image_map,
                 _content_types,
+                _archive,
                 mut stream,
             )) => {
                 assert!(style_list.get_by_id("Normal").is_some());
@@ -529,7 +521,15 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
+            Ok((
+                style_list,
+                _numbering,
+                _hyperlink_map,
+                _image_map,
+                _content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert_eq!(style_list, StyleList::default());
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
@@ -552,7 +552,15 @@ mod tests {
         });
 
         match result {
-            Ok((style_list, _numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
+            Ok((
+                style_list,
+                _numbering,
+                _hyperlink_map,
+                _image_map,
+                _content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert_eq!(style_list, StyleList::default());
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected default StyleList"),
@@ -610,7 +618,15 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
+            Ok((
+                _style_list,
+                numbering,
+                _hyperlink_map,
+                _image_map,
+                _content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert!(numbering.resolve(1, 0).is_list);
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected numbering and document stream"),
@@ -631,7 +647,15 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
+            Ok((
+                _style_list,
+                numbering,
+                _hyperlink_map,
+                _image_map,
+                _content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert!(!numbering.resolve(1, 0).is_list);
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected empty numbering"),
@@ -655,7 +679,15 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, numbering, _hyperlink_map, _image_map, _content_types, _stream)) => {
+            Ok((
+                _style_list,
+                numbering,
+                _hyperlink_map,
+                _image_map,
+                _content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert!(!numbering.resolve(1, 0).is_list);
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected empty numbering"),
@@ -705,7 +737,15 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, _numbering, _hyperlink_map, image_map, _content_types, _stream)) => {
+            Ok((
+                _style_list,
+                _numbering,
+                _hyperlink_map,
+                image_map,
+                _content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert_eq!(image_map.len(), 1);
                 let rel = &image_map["rId5"];
                 assert_eq!(rel.target, "word/media/image1.png");
@@ -729,7 +769,15 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, _numbering, _hyperlink_map, _image_map, content_types, _stream)) => {
+            Ok((
+                _style_list,
+                _numbering,
+                _hyperlink_map,
+                _image_map,
+                content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert_eq!(content_types.lookup("word/document.xml"), None);
                 assert_eq!(content_types.lookup("word/media/image1.png"), None);
             }
@@ -757,7 +805,15 @@ mod tests {
         });
 
         match result {
-            Ok((_style_list, _numbering, _hyperlink_map, _image_map, content_types, _stream)) => {
+            Ok((
+                _style_list,
+                _numbering,
+                _hyperlink_map,
+                _image_map,
+                content_types,
+                _archive,
+                _stream,
+            )) => {
                 assert_eq!(
                     content_types.lookup("word/media/image1.png"),
                     Some("image/png")

--- a/crates/docspec-docx-reader/tests/image_edge_cases.rs
+++ b/crates/docspec-docx-reader/tests/image_edge_cases.rs
@@ -15,9 +15,10 @@
 mod fixture;
 
 use std::io::Cursor;
+use std::sync::Arc;
 
-use docspec_core::{AssetProvider as _, Event, EventSource as _, ImageSource};
-use docspec_docx_reader::{DocxAssetProvider, DocxReader};
+use docspec_core::{AssetHandle, Event, EventSource as _, ImageSource};
+use docspec_docx_reader::DocxReader;
 use zip::CompressionMethod;
 
 const ROOT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -29,6 +30,23 @@ const ROOT_RELS: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 
 const IMAGE_REL_TYPE: &str =
     "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image";
+
+#[derive(Debug)]
+struct StubHandle(String);
+impl AssetHandle for StubHandle {
+    fn asset_id(&self) -> &str {
+        &self.0
+    }
+    fn content_type(&self) -> Option<std::borrow::Cow<'_, str>> {
+        None
+    }
+    fn stream_to(&self, _: &mut dyn std::io::Write) -> std::io::Result<u64> {
+        Ok(0)
+    }
+}
+fn asset_source(id: &str) -> ImageSource {
+    ImageSource::Asset(Arc::new(StubHandle(id.to_string())))
+}
 
 fn doc_rels(body: &str) -> String {
     format!(
@@ -75,21 +93,6 @@ fn build_docx(doc_rels_xml: &str, document_xml: &str) -> Vec<u8> {
             "word/document.xml",
             CompressionMethod::Deflated,
             document_xml.as_bytes(),
-        ),
-    ])
-}
-
-fn build_provider_docx() -> Vec<u8> {
-    fixture::synth_docx_with_entries(&[
-        (
-            "[Content_Types].xml",
-            CompressionMethod::Deflated,
-            br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="png" ContentType="image/png"/></Types>"#,
-        ),
-        (
-            "word/media/image1.png",
-            CompressionMethod::Stored,
-            &[0x89u8, 0x50, 0x4E, 0x47],
         ),
     ])
 }
@@ -191,12 +194,7 @@ fn missing_rel_emits_raw_rid() {
         vec![
             start_doc(),
             start_para(),
-            image_event(
-                ImageSource::Asset {
-                    asset_id: "rId99".to_string(),
-                },
-                None,
-            ),
+            image_event(asset_source("rId99"), None),
             Event::EndParagraph,
             Event::EndDocument,
         ]
@@ -236,12 +234,7 @@ fn embed_wins_over_link() {
         vec![
             start_doc(),
             start_para(),
-            image_event(
-                ImageSource::Asset {
-                    asset_id: "zip://word/media/embed.png".to_string(),
-                },
-                None,
-            ),
+            image_event(asset_source("zip://word/media/embed.png"), None),
             Event::EndParagraph,
             Event::EndDocument,
         ]
@@ -290,7 +283,6 @@ fn smartart_blip_ignored() {
     let rels = doc_rels(&format!(
         r#"<Relationship Id="rIdSmart" Type="{IMAGE_REL_TYPE}" Target="word/media/smart.png"/>"#
     ));
-    // blip is at a:graphicData/a:blip — NOT inside pic:pic/pic:blipFill
     let drawing = r#"<wp:inline><a:graphic><a:graphicData><a:blip r:embed="rIdSmart"/></a:graphicData></a:graphic></wp:inline>"#;
     let doc = drawing_doc(drawing);
     let bytes = build_docx(&rels, &doc);
@@ -325,42 +317,12 @@ fn multiple_pics_multiple_events() {
         vec![
             start_doc(),
             start_para(),
-            image_event(
-                ImageSource::Asset {
-                    asset_id: "zip://word/media/one.png".to_string(),
-                },
-                None,
-            ),
-            image_event(
-                ImageSource::Asset {
-                    asset_id: "zip://word/media/two.png".to_string(),
-                },
-                None,
-            ),
+            image_event(asset_source("zip://word/media/one.png"), None),
+            image_event(asset_source("zip://word/media/two.png"), None),
             Event::EndParagraph,
             Event::EndDocument,
         ]
     );
-}
-
-#[test]
-fn provider_non_zip_scheme_returns_none() {
-    let bytes = build_provider_docx();
-    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).expect("from_reader");
-    let ct = provider.content_type("rId99");
-    assert_eq!(ct, None);
-    let mut buf = Vec::new();
-    let result = provider.stream_to("rId99", &mut buf);
-    assert!(result.is_none());
-}
-
-#[test]
-fn provider_unknown_internal_path_returns_none() {
-    let bytes = build_provider_docx();
-    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).expect("from_reader");
-    let mut buf = Vec::new();
-    let result = provider.stream_to("zip://word/media/nonexistent.png", &mut buf);
-    assert!(result.is_none());
 }
 
 const HYPERLINK_REL_TYPE: &str =
@@ -403,12 +365,7 @@ fn hyperlink_wrapping_only_a_drawing_emits_start_and_end_link_around_image() {
                 id: None,
                 title: None,
             },
-            image_event(
-                ImageSource::Asset {
-                    asset_id: "zip://word/media/image1.png".to_string(),
-                },
-                None,
-            ),
+            image_event(asset_source("zip://word/media/image1.png"), None),
             Event::EndLink,
             Event::EndParagraph,
             Event::EndDocument,
@@ -445,20 +402,10 @@ fn sibling_drawing_without_docpr_does_not_inherit_alt() {
         vec![
             start_doc(),
             start_para(),
-            image_event(
-                ImageSource::Asset {
-                    asset_id: "zip://word/media/one.png".to_string(),
-                },
-                Some("first"),
-            ),
+            image_event(asset_source("zip://word/media/one.png"), Some("first")),
             Event::EndParagraph,
             start_para(),
-            image_event(
-                ImageSource::Asset {
-                    asset_id: "zip://word/media/two.png".to_string(),
-                },
-                None,
-            ),
+            image_event(asset_source("zip://word/media/two.png"), None),
             Event::EndParagraph,
             Event::EndDocument,
         ]

--- a/crates/docspec-docx-reader/tests/image_embedded.rs
+++ b/crates/docspec-docx-reader/tests/image_embedded.rs
@@ -13,14 +13,32 @@
 mod fixture;
 
 use std::io::Cursor;
+use std::sync::Arc;
 
 use docspec_blocknote_writer::BlockNoteWriter;
 use docspec_core::StackTrackingSink;
-use docspec_core::{AssetProvider as _, Event, EventSink as _, EventSource as _, ImageSource};
-use docspec_docx_reader::{DocxAssetProvider, DocxReader};
+use docspec_core::{AssetHandle, Event, EventSink as _, EventSource as _, ImageSource};
+use docspec_docx_reader::DocxReader;
 use zip::CompressionMethod;
 
 const PNG_SIGNATURE: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+#[derive(Debug)]
+struct StubHandle(String);
+impl AssetHandle for StubHandle {
+    fn asset_id(&self) -> &str {
+        &self.0
+    }
+    fn content_type(&self) -> Option<std::borrow::Cow<'_, str>> {
+        None
+    }
+    fn stream_to(&self, _: &mut dyn std::io::Write) -> std::io::Result<u64> {
+        Ok(0)
+    }
+}
+fn asset_source(id: &str) -> ImageSource {
+    ImageSource::Asset(Arc::new(StubHandle(id.to_string())))
+}
 
 fn root_rels() -> &'static str {
     r#"<?xml version="1.0" encoding="UTF-8"?>
@@ -119,9 +137,7 @@ fn docx_reader_emits_exact_image_event() {
     assert_eq!(
         *image_event,
         Event::Image {
-            source: ImageSource::Asset {
-                asset_id: "zip://word/media/image1.png".to_string(),
-            },
+            source: asset_source("zip://word/media/image1.png"),
             alt: Some("alt text".to_string()),
             decorative: false,
             title: None,
@@ -131,32 +147,38 @@ fn docx_reader_emits_exact_image_event() {
 }
 
 #[test]
-fn docx_asset_provider_streams_exact_bytes() {
+fn docx_reader_handle_streams_exact_bytes() {
     let bytes = synth_image_docx();
-    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).unwrap();
-    let mut buf = Vec::new();
+    let events = collect_events(bytes);
 
-    let result = provider.stream_to("zip://word/media/image1.png", &mut buf);
+    let image_event = events
+        .iter()
+        .find(|e| matches!(e, Event::Image { .. }))
+        .expect("expected at least one Image event");
 
-    // io::Error does not impl PartialEq — unpack with expect instead of assert_eq!
-    assert_eq!(
-        result
-            .expect("stream_to should return Some")
-            .expect("stream_to should return Ok"),
-        8u64
-    );
-    assert_eq!(buf.as_slice(), PNG_SIGNATURE.as_ref());
+    if let Event::Image {
+        source: ImageSource::Asset(handle),
+        ..
+    } = image_event
+    {
+        let mut buf = Vec::new();
+        let n = handle
+            .stream_to(&mut buf)
+            .expect("stream_to should succeed");
+        assert_eq!(n, 8u64);
+        assert_eq!(buf.as_slice(), PNG_SIGNATURE.as_ref());
+    } else {
+        panic!("expected ImageSource::Asset, got: {image_event:?}");
+    }
 }
 
 #[test]
-fn blocknote_writer_with_assets_produces_exact_data_uri() {
+fn blocknote_writer_produces_data_uri_from_handle() {
     let bytes = synth_image_docx();
-
-    let mut reader = DocxReader::from_reader(Cursor::new(bytes.clone())).unwrap();
-    let provider = DocxAssetProvider::from_reader(Cursor::new(bytes)).unwrap();
+    let mut reader = DocxReader::from_reader(Cursor::new(bytes)).unwrap();
 
     let mut out = Vec::<u8>::new();
-    let mut writer = StackTrackingSink::new(BlockNoteWriter::with_assets(&mut out, &provider));
+    let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut out));
 
     loop {
         match reader.next_event() {

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -234,26 +234,28 @@ mod constructor {
     }
 
     #[test]
-    fn from_reader_errors_on_unsupported_compression() {
+    fn from_reader_opens_bzip2_compressed_document() {
         let bytes = fixture::synth_docx_with_entries(&[
             (
                 "_rels/.rels",
                 zip::CompressionMethod::Deflated,
                 r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#.as_bytes(),
             ),
-            ("word/document.xml", zip::CompressionMethod::Bzip2, b"<doc/>"),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Bzip2,
+                b"<?xml version=\"1.0\"?><w:document xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\"><w:body></w:body></w:document>",
+            ),
         ]);
         let result = DocxReader::from_reader(Cursor::new(bytes));
-        match result {
-            Err(Error::Parse { message, .. }) => {
-                assert_eq!(message, "unsupported compression: Bzip2");
-            }
-            other => panic!("expected Error::Parse, got: {other:?}"),
-        }
+        assert!(
+            result.is_ok(),
+            "bzip2-compressed document should open: {result:?}"
+        );
     }
 
     #[test]
-    fn next_event_passes_through_mid_parse_io_error() {
+    fn document_xml_buffered_at_open_time_so_reader_failure_after_open_is_harmless() {
         let bytes = fixture::synth_docx_with_entries(&[
             (
                 "_rels/.rels",
@@ -271,23 +273,25 @@ mod constructor {
         let fail_enabled = Arc::new(AtomicBool::new(false));
         let failing_reader = FailingReader::new(bytes, fail_at, Arc::clone(&fail_enabled));
         let mut reader = DocxReader::from_reader(failing_reader).expect("from_reader");
+
         fail_enabled.store(true, Ordering::SeqCst);
 
-        assert_eq!(
-            reader.next_event().expect("start document"),
-            Some(Event::StartDocument {
+        let mut events = Vec::new();
+        loop {
+            match reader.next_event() {
+                Ok(Some(ev)) => events.push(ev),
+                Ok(None) => break,
+                Err(e) => panic!("unexpected error after buffered open: {e:?}"),
+            }
+        }
+        assert!(
+            events.contains(&Event::StartDocument {
                 id: None,
                 language: None,
-                metadata: None,
-            })
+                metadata: None
+            }),
+            "expected at least StartDocument event"
         );
-        match reader.next_event() {
-            Err(Error::Io { source }) => {
-                assert_eq!(source.kind(), std::io::ErrorKind::Other);
-                assert_eq!(source.to_string(), "forced read failure");
-            }
-            other => panic!("expected Error::Io, got: {other:?}"),
-        }
     }
 
     fn document_data_start(bytes: &[u8]) -> u64 {
@@ -1811,7 +1815,7 @@ mod events {
 
         assert_eq!(
             format!("{reader:?}"),
-            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", hyperlink_map: {}, hyperlink_depth: 0, pending_link: None, list_stack: [], seen_lists: {}, pending_paragraph_list: None, in_numpr: false, pending_num_pr_id: None, pending_num_pr_ilvl: None, xml: \"<quick_xml::Reader>\" } }"
+            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", hyperlink_map: {}, hyperlink_depth: 0, pending_link: None, list_stack: [], seen_lists: {}, pending_paragraph_list: None, in_numpr: false, pending_num_pr_id: None, pending_num_pr_ilvl: None, xml: \"<quick_xml::Reader>\", archive: \"<Arc<Mutex<ZipArchive>>>\", content_types: \"<Arc<ContentTypes>>\" } }"
         );
     }
 

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -150,6 +150,7 @@ pub async fn post_conversion(
 ///
 /// Body size is recorded here because it is only known after header validation
 /// succeeds and the body is confirmed non-empty.
+#[allow(clippy::too_many_lines)]
 async fn do_conversion(
     input_mime_label: &'static str,
     headers: HeaderMap,
@@ -198,13 +199,16 @@ async fn do_conversion(
 
     let join_result = tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64), HttpError> {
         let mut output_buffer = Vec::new();
-        let mut reader = docspec::AnyReader::from_reader(input_format, std::io::Cursor::new(body))
-            .map_err(|error| {
-                tracing::debug!(error = %error, "reader construction failed");
-                HttpError::Unprocessable {
-                    detail: error.to_string(),
-                }
-            })?;
+        let body_vec: Vec<u8> = body.into();
+        let mut reader =
+            docspec::AnyReader::from_reader(input_format, std::io::Cursor::new(body_vec)).map_err(
+                |error| {
+                    tracing::debug!(error = %error, "reader construction failed");
+                    HttpError::Unprocessable {
+                        detail: error.to_string(),
+                    }
+                },
+            )?;
         let mut sink = docspec::AnyWriter::new(output_format, &mut output_buffer);
 
         loop {

--- a/crates/docspec-http/tests/http_integration.rs
+++ b/crates/docspec-http/tests/http_integration.rs
@@ -214,6 +214,46 @@ async fn post_conversion_missing_content_type() {
     );
 }
 
+fn find_image_url(blocks: &[Value]) -> Option<String> {
+    for block in blocks {
+        if block.get("type").and_then(Value::as_str) == Some("image") {
+            if let Some(url) = block
+                .get("props")
+                .and_then(|p| p.get("url"))
+                .and_then(Value::as_str)
+            {
+                return Some(url.to_owned());
+            }
+        }
+        if let Some(children) = block.get("children").and_then(Value::as_array) {
+            if let Some(url) = find_image_url(children) {
+                return Some(url);
+            }
+        }
+    }
+    None
+}
+
+#[tokio::test]
+async fn http_convert_docx_with_image() {
+    let docx_bytes = docspec_test_utils::synth_docx_with_image_png();
+    let response = app()
+        .oneshot(common::docx_request(docx_bytes))
+        .await
+        .expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response_body_json(response.into_body()).await;
+    let blocks = body.as_array().expect("response is a JSON array");
+
+    let image_url = find_image_url(blocks).expect("at least one image block with a url");
+    assert!(
+        image_url.starts_with("data:image/png;base64,"),
+        "expected data URI but got: {image_url}"
+    );
+}
+
 const DOCX_MIME: &str = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
 fn hello_docx_bytes() -> Vec<u8> {

--- a/crates/docspec-json/src/backend.rs
+++ b/crates/docspec-json/src/backend.rs
@@ -1,6 +1,6 @@
 //! Backend trait for JSON token emission.
 
-use docspec_core::Result;
+use docspec_core::{Error, Result};
 
 /// Low-level JSON token emitter. Implementations write JSON tokens to an
 /// underlying sink. State validation is performed by [`crate::JsonEmitter`],
@@ -69,6 +69,27 @@ pub trait JsonBackend {
     ///
     /// Returns any error produced by the underlying backend.
     fn write_string(&mut self, s: &str) -> Result<()>;
+    /// Write a string value by streaming bytes through a closure.
+    ///
+    /// The default implementation buffers the bytes into a `Vec<u8>`, converts
+    /// to a `&str`, and delegates to [`write_string`](Self::write_string).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the closure returns an I/O error, or if the buffered
+    /// bytes are not valid UTF-8.
+    #[allow(clippy::missing_inline_in_public_items)]
+    fn write_string_streaming<F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+    {
+        let mut buf: Vec<u8> = Vec::new();
+        f(&mut buf).map_err(Error::from)?;
+        let s = core::str::from_utf8(&buf).map_err(|e| Error::Other {
+            message: format!("write_string_streaming produced invalid UTF-8: {e}"),
+        })?;
+        self.write_string(s)
+    }
 }
 
 /// A token captured by [`CapturingBackend`].
@@ -181,11 +202,97 @@ impl JsonBackend for CapturingBackend {
         self.tokens.push(Token::StringValue(s.to_string()));
         Ok(())
     }
+
+    #[inline]
+    fn write_string_streaming<F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+    {
+        let mut buf: Vec<u8> = Vec::new();
+        f(&mut buf).map_err(Error::from)?;
+        let s = core::str::from_utf8(&buf).map_err(|e| Error::Other {
+            message: format!("write_string_streaming produced invalid UTF-8: {e}"),
+        })?;
+        self.tokens.push(Token::StringValue(s.to_string()));
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Mock backend that records `write_string` calls for testing the default impl.
+    #[derive(Debug, Default)]
+    struct MockBackend {
+        write_string_calls: Vec<String>,
+    }
+
+    impl JsonBackend for MockBackend {
+        type Output = ();
+
+        fn begin_array(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn begin_object(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn end_array(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn end_object(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn finish(self) -> Result<()> {
+            Ok(())
+        }
+
+        fn write_bool(&mut self, _b: bool) -> Result<()> {
+            Ok(())
+        }
+
+        fn write_name(&mut self, _name: &str) -> Result<()> {
+            Ok(())
+        }
+
+        fn write_null(&mut self) -> Result<()> {
+            Ok(())
+        }
+
+        fn write_number(&mut self, _n: u32) -> Result<()> {
+            Ok(())
+        }
+
+        fn write_string(&mut self, s: &str) -> Result<()> {
+            self.write_string_calls.push(s.to_string());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn default_impl_buffers_and_delegates_to_write_string() {
+        let mut mock = MockBackend::default();
+        let result = mock.write_string_streaming(|w| {
+            w.write_all(b"hello world")?;
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert_eq!(mock.write_string_calls, vec!["hello world"]);
+    }
+
+    #[test]
+    fn default_impl_errors_on_invalid_utf8() {
+        let mut mock = MockBackend::default();
+        let result = mock.write_string_streaming(|w| {
+            w.write_all(&[0xFF, 0xFE, 0x00])?;
+            Ok(())
+        });
+        assert!(result.is_err());
+    }
 
     #[test]
     fn capturing_backend_starts_empty() {
@@ -237,5 +344,34 @@ mod tests {
         assert!(result.is_ok());
         let tokens = result.unwrap_or_default();
         assert!(tokens == vec![Token::BeginObject, Token::EndObject]);
+    }
+
+    #[test]
+    fn capturing_streaming_pushes_single_token() {
+        let mut b = CapturingBackend::new();
+        let result = b.write_string_streaming(|w| w.write_all(b"hello"));
+        assert!(result.is_ok());
+        assert_eq!(b.tokens(), &[Token::StringValue("hello".to_string())]);
+    }
+
+    #[test]
+    fn capturing_streaming_multi_chunk_concatenates() {
+        let mut b = CapturingBackend::new();
+        let result = b.write_string_streaming(|w| {
+            w.write_all(b"hello")?;
+            w.write_all(b" ")?;
+            w.write_all(b"world")?;
+            Ok(())
+        });
+        assert!(result.is_ok());
+        assert_eq!(b.tokens(), &[Token::StringValue("hello world".to_string())]);
+    }
+
+    #[test]
+    fn capturing_streaming_error_does_not_push_token() {
+        let mut b = CapturingBackend::new();
+        let result = b.write_string_streaming(|_w| Err(std::io::Error::other("test error")));
+        assert!(result.is_err());
+        assert!(b.tokens().is_empty());
     }
 }

--- a/crates/docspec-json/src/emitter.rs
+++ b/crates/docspec-json/src/emitter.rs
@@ -260,6 +260,27 @@ impl<B: JsonBackend> KeyedEmitter<'_, B> {
         v.write_to(&mut emitter.backend)?;
         emitter.stack.mark_value_written()
     }
+
+    /// Consume the key and write a string value via streaming closure.
+    ///
+    /// Best-effort scope guard: if the closure returns `Err`, the value mark is
+    /// still attempted; the closure's error takes precedence.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` if a key is not allowed here, or if the closure or backend errors.
+    #[inline]
+    pub fn string_value_streaming<F>(self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut dyn std::io::Write) -> std::io::Result<()>,
+    {
+        let emitter = self.emitter;
+        let name = self.name;
+        emitter.write_key(name)?;
+        let inner = emitter.backend.write_string_streaming(f);
+        let mark = emitter.stack.mark_value_written();
+        inner.and(mark)
+    }
 }
 
 #[cfg(test)]
@@ -835,6 +856,71 @@ mod tests {
                     Token::StringValue("2".to_string()),
                     Token::EndObject,
                     Token::EndArray,
+                ]
+            );
+        }
+
+        #[test]
+        fn keyed_streaming_value_writes_correct_json() {
+            let mut e = make();
+            assert!(e.open_object().is_ok());
+            assert!(e
+                .key("url")
+                .string_value_streaming(|w| w.write_all(b"hello"))
+                .is_ok());
+            assert!(e.close_object().is_ok());
+            let t = finish_tokens(e);
+            assert_eq!(
+                t,
+                vec![
+                    Token::BeginObject,
+                    Token::Name("url".to_string()),
+                    Token::StringValue("hello".to_string()),
+                    Token::EndObject,
+                ]
+            );
+        }
+
+        #[test]
+        fn keyed_streaming_value_consumes_key_on_error_then_allows_next_key() {
+            let mut e = make();
+            assert!(e.open_object().is_ok());
+            let err_result = e
+                .key("first")
+                .string_value_streaming(|_w| Err(std::io::Error::other("test error")));
+            assert!(err_result.is_err());
+            assert!(e.key("other").value("x").is_ok());
+            assert!(e.close_object().is_ok());
+            let t = finish_tokens(e);
+            assert_eq!(
+                t,
+                vec![
+                    Token::BeginObject,
+                    Token::Name("first".to_string()),
+                    Token::Name("other".to_string()),
+                    Token::StringValue("x".to_string()),
+                    Token::EndObject,
+                ]
+            );
+        }
+
+        #[test]
+        fn keyed_streaming_value_with_base64_chars() {
+            let mut e = make();
+            assert!(e.open_object().is_ok());
+            assert!(e
+                .key("data")
+                .string_value_streaming(|w| w.write_all(b"data:image/png;base64,iVBORw=="))
+                .is_ok());
+            assert!(e.close_object().is_ok());
+            let t = finish_tokens(e);
+            assert_eq!(
+                t,
+                vec![
+                    Token::BeginObject,
+                    Token::Name("data".to_string()),
+                    Token::StringValue("data:image/png;base64,iVBORw==".to_string()),
+                    Token::EndObject,
                 ]
             );
         }

--- a/crates/docspec-json/src/struson_backend.rs
+++ b/crates/docspec-json/src/struson_backend.rs
@@ -77,11 +77,27 @@ impl<W: Write> JsonBackend for StrusonBackend<W> {
     fn write_string(&mut self, s: &str) -> Result<()> {
         self.writer.string_value(s).map_err(Error::from)
     }
+
+    #[inline]
+    fn write_string_streaming<F>(&mut self, f: F) -> Result<()>
+    where
+        F: FnOnce(&mut dyn Write) -> std::io::Result<()>,
+    {
+        use struson::writer::StringValueWriter as _;
+
+        let mut svw = self.writer.string_value_writer().map_err(Error::from)?;
+        let inner_result = f(&mut svw);
+        let finish_result = svw.finish_value().map_err(Error::from);
+        inner_result.map_err(Error::from)?;
+        finish_result
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::cell::RefCell;
+    use std::rc::Rc;
 
     struct ErrorWriter;
 
@@ -175,5 +191,165 @@ mod tests {
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
         assert!(bytes == br#"{"k":"v"}"#);
+    }
+
+    #[test]
+    fn streaming_writes_simple_string() {
+        let mut b = StrusonBackend::new(Vec::new());
+        assert!(b.write_string_streaming(|w| w.write_all(b"hello")).is_ok());
+        let result = b.finish();
+        assert!(result.is_ok());
+        let bytes = result.unwrap_or_default();
+        assert!(bytes == br#""hello""#);
+    }
+
+    #[test]
+    fn streaming_writes_base64_safe_chars() {
+        let mut b = StrusonBackend::new(Vec::new());
+        assert!(b
+            .write_string_streaming(|w| w.write_all(b"data:image/png;base64,iVBORw=="))
+            .is_ok());
+        let result = b.finish();
+        assert!(result.is_ok());
+        let bytes = result.unwrap_or_default();
+        assert!(bytes == br#""data:image/png;base64,iVBORw==""#);
+    }
+
+    #[test]
+    fn streaming_writes_json_special_chars_are_escaped() {
+        let mut b = StrusonBackend::new(Vec::new());
+        assert!(b
+            .write_string_streaming(|w| w.write_all(br#""quoted""#))
+            .is_ok());
+        let result = b.finish();
+        assert!(result.is_ok());
+        let bytes = result.unwrap_or_default();
+        assert!(bytes == br#""\"quoted\"""#);
+    }
+
+    #[test]
+    fn streaming_writes_multi_chunk() {
+        let mut b = StrusonBackend::new(Vec::new());
+        assert!(b
+            .write_string_streaming(|w| {
+                w.write_all(b"one")?;
+                w.write_all(b"-")?;
+                w.write_all(b"two")?;
+                w.write_all(b"-")?;
+                w.write_all(b"three")
+            })
+            .is_ok());
+        let result = b.finish();
+        assert!(result.is_ok());
+        let bytes = result.unwrap_or_default();
+        assert!(bytes == br#""one-two-three""#);
+    }
+
+    #[test]
+    fn streaming_writes_error_in_closure_still_finishes_value() {
+        let mut b = StrusonBackend::new(Vec::new());
+        assert!(b.begin_object().is_ok());
+        assert!(b.write_name("failed").is_ok());
+
+        let result = b.write_string_streaming(|_| Err(std::io::Error::other("closure failed")));
+        assert!(result.is_err());
+
+        let after_key =
+            std::panic::catch_unwind(core::panic::AssertUnwindSafe(|| b.write_name("after")));
+        #[allow(clippy::expect_used)]
+        let write_result = after_key.expect("asserted catch_unwind returned Ok");
+        assert!(write_result.is_ok());
+
+        assert!(b.write_string("ok").is_ok());
+        assert!(b.end_object().is_ok());
+        let finish_result = b.finish();
+        assert!(finish_result.is_ok());
+        let bytes = finish_result.unwrap_or_default();
+        assert!(bytes == br#"{"failed":"","after":"ok"}"#);
+    }
+
+    /// Tracks each write call to the inner writer.
+    struct CallCountingWriter {
+        write_calls: Rc<RefCell<Vec<usize>>>,
+        buffer: Vec<u8>,
+    }
+
+    impl CallCountingWriter {
+        fn new() -> Self {
+            Self {
+                write_calls: Rc::new(RefCell::new(Vec::new())),
+                buffer: Vec::new(),
+            }
+        }
+
+        fn write_calls(&self) -> Vec<usize> {
+            self.write_calls.borrow().clone()
+        }
+
+        fn total_bytes(&self) -> usize {
+            self.write_calls.borrow().iter().sum()
+        }
+    }
+
+    impl Write for CallCountingWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.write_calls.borrow_mut().push(buf.len());
+            self.buffer.extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn override_chunks_through_inner_writer() {
+        // This test proves that write_string_streaming override is actually used,
+        // not the default buffering impl. If the override is wired correctly,
+        // the inner writer should see multiple separate write calls (streaming).
+        // If buffering was used, we'd see one large write.
+
+        let mut counter = CallCountingWriter::new();
+        let mut b = StrusonBackend::new(&mut counter);
+
+        // Write 1024 bytes in 4 separate chunks of 256 bytes each.
+        // This is large enough that if buffering was used, we'd see ONE write of 1024 bytes.
+        // If streaming is used (override is wired), we should see multiple smaller writes.
+        let chunk = vec![b'x'; 256];
+        assert!(b
+            .write_string_streaming(|w| {
+                w.write_all(&chunk)?;
+                w.write_all(&chunk)?;
+                w.write_all(&chunk)?;
+                w.write_all(&chunk)
+            })
+            .is_ok());
+
+        let write_calls = counter.write_calls();
+        let total_bytes = counter.total_bytes();
+
+        // Verify total bytes written is at least 1024 (the content we wrote).
+        // The actual total may be slightly more due to JSON escaping/framing.
+        assert!(
+            total_bytes >= 1024,
+            "Expected at least 1024 bytes written, got {total_bytes}"
+        );
+
+        // Verify that the largest single write is less than the total.
+        // This proves streaming: if buffering was used, we'd see ONE write of ~1024 bytes.
+        // If streaming is used, we see multiple smaller writes.
+        let max_write = write_calls.iter().max().copied().unwrap_or(0);
+        assert!(
+             max_write < total_bytes,
+             "Expected multiple writes (streaming), but got one large write: max={max_write}, total={total_bytes}"
+         );
+
+        // Verify we got multiple write calls (not just one).
+        assert!(
+            write_calls.len() > 1,
+            "Expected multiple write calls (streaming), got {}",
+            write_calls.len()
+        );
     }
 }

--- a/crates/docspec-test-utils/Cargo.toml
+++ b/crates/docspec-test-utils/Cargo.toml
@@ -11,5 +11,8 @@ description = "Internal test fixtures shared across the docspec workspace. Not p
 docspec-core = { workspace = true }
 zip = { version = "8", default-features = false, features = ["deflate"] }
 
+[dev-dependencies]
+docspec-docx-reader = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/docspec-test-utils/src/lib.rs
+++ b/crates/docspec-test-utils/src/lib.rs
@@ -6,6 +6,8 @@
 // Reason: Helpers panic on internal ZIP write failure to keep test call sites
 // terse. Equivalent to the per-file allows used in workspace test modules.
 #![allow(clippy::expect_used)]
+// Reason: Literal suffix rules have conflicting requirements in this crate
+#![allow(clippy::separated_literal_suffix)]
 
 pub mod builders;
 
@@ -68,4 +70,176 @@ pub fn synth_docx_with_entries(entries: &[(&str, CompressionMethod, &[u8])]) -> 
         writer.write_all(data).expect("write_all failed");
     }
     writer.finish().expect("finish failed").into_inner()
+}
+
+/// Builds a minimal DOCX archive with an embedded PNG image.
+///
+/// The synthetic DOCX contains:
+/// - `[Content_Types].xml` with PNG content type registration
+/// - `_rels/.rels` with root relationships
+/// - `word/_rels/document.xml.rels` with image relationship (rId1)
+/// - `word/document.xml` with inline image drawing
+/// - `word/media/image1.png` with PNG signature bytes (8 bytes)
+///
+/// The PNG payload is exactly the PNG file signature: `[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]`.
+///
+/// This helper is useful for testing image asset handling in DOCX readers without
+/// requiring real image files or rendering logic.
+///
+/// # Panics
+///
+/// Panics if the ZIP writer fails (should never happen for in-memory buffers).
+#[inline]
+#[must_use]
+pub fn synth_docx_with_image_png() -> Vec<u8> {
+    const PNG_SIGNATURE: &[u8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+    let root_rels = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>"#;
+
+    let content_types = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="png" ContentType="image/png"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+</Types>"#;
+
+    let doc_rels = r#"<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="media/image1.png"/>
+</Relationships>"#;
+
+    let document = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+    xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+    xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+    xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture"
+    xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing">
+  <w:body><w:p><w:r><w:drawing>
+    <wp:inline>
+      <wp:docPr descr="alt text"/>
+      <a:graphic><a:graphicData>
+        <pic:pic><pic:blipFill><a:blip r:embed="rId1"/></pic:blipFill></pic:pic>
+      </a:graphicData></a:graphic>
+    </wp:inline>
+  </w:drawing></w:r></w:p></w:body>
+</w:document>"#;
+
+    synth_docx_with_entries(&[
+        (
+            "_rels/.rels",
+            CompressionMethod::Deflated,
+            root_rels.as_bytes(),
+        ),
+        (
+            "[Content_Types].xml",
+            CompressionMethod::Deflated,
+            content_types.as_bytes(),
+        ),
+        (
+            "word/_rels/document.xml.rels",
+            CompressionMethod::Deflated,
+            doc_rels.as_bytes(),
+        ),
+        (
+            "word/document.xml",
+            CompressionMethod::Deflated,
+            document.as_bytes(),
+        ),
+        (
+            "word/media/image1.png",
+            CompressionMethod::Stored,
+            PNG_SIGNATURE,
+        ),
+    ])
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+
+    use std::borrow::Cow;
+    use std::io::Cursor;
+
+    use super::*;
+
+    fn get_image_handle(bytes: Vec<u8>) -> (docspec_core::ImageSource, Option<String>) {
+        use docspec_core::{Event, EventSource as _};
+        use docspec_docx_reader::DocxReader;
+
+        let mut reader =
+            DocxReader::from_reader(Cursor::new(bytes)).expect("should open DOCX with DocxReader");
+        loop {
+            match reader.next_event() {
+                Ok(Some(Event::Image { source, alt, .. })) => return (source, alt),
+                Ok(Some(_)) => {}
+                Ok(None) => panic!("no Image event found"),
+                Err(e) => panic!("reader error: {e:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn synth_docx_with_image_png_handle_has_content_type() {
+        let bytes = synth_docx_with_image_png();
+        let (source, _) = get_image_handle(bytes);
+        if let docspec_core::ImageSource::Asset(handle) = source {
+            assert_eq!(handle.content_type(), Some(Cow::Borrowed("image/png")));
+        } else {
+            panic!("expected ImageSource::Asset");
+        }
+    }
+
+    #[test]
+    fn synth_docx_with_image_png_streams_png_signature() {
+        const PNG_SIGNATURE: &[u8] = &[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+
+        let bytes = synth_docx_with_image_png();
+        let (source, _) = get_image_handle(bytes);
+        if let docspec_core::ImageSource::Asset(handle) = source {
+            let mut buf = Vec::new();
+            let n = handle
+                .stream_to(&mut buf)
+                .expect("stream_to should succeed");
+            assert_eq!(n, 8_u64);
+            assert_eq!(buf.as_slice(), PNG_SIGNATURE);
+        } else {
+            panic!("expected ImageSource::Asset");
+        }
+    }
+
+    #[test]
+    #[allow(clippy::panic)]
+    fn synth_docx_with_image_png_emits_image_event() {
+        use docspec_core::{Event, EventSource as _, ImageSource};
+        use docspec_docx_reader::DocxReader;
+
+        let bytes = synth_docx_with_image_png();
+        let mut reader =
+            DocxReader::from_reader(Cursor::new(bytes)).expect("should open DOCX with DocxReader");
+
+        let mut found_image_event = false;
+        loop {
+            match reader.next_event() {
+                Ok(Some(event)) => {
+                    if let Event::Image {
+                        source: ImageSource::Asset(handle),
+                        alt,
+                        ..
+                    } = event
+                    {
+                        assert_eq!(handle.asset_id(), "zip://word/media/image1.png");
+                        assert_eq!(alt, Some("alt text".to_string()));
+                        found_image_event = true;
+                    }
+                }
+                Ok(None) => break,
+                Err(e) => panic!("reader error: {e:?}"),
+            }
+        }
+
+        assert!(found_image_event, "expected at least one Image event");
+    }
 }

--- a/crates/docspec/src/factory/writer.rs
+++ b/crates/docspec/src/factory/writer.rs
@@ -2,7 +2,7 @@
 
 use std::io::Write;
 
-use docspec_core::{AssetProvider, Event, EventSink, Result, StackTrackingSink};
+use docspec_core::{Event, EventSink, Result, StackTrackingSink};
 
 #[cfg(feature = "blocknote-writer")]
 use docspec_blocknote_writer::BlockNoteWriter;
@@ -21,14 +21,14 @@ use crate::format::OutputFormat;
 ///
 /// Internally wraps the chosen writer in [`StackTrackingSink`] so callers
 /// never need to compose normalization manually. Constructed via
-/// [`AnyWriter::new`] or [`AnyWriter::with_assets`].
-pub struct AnyWriter<'a, W: Write> {
-    inner: StackTrackingSink<AnyWriterInner<'a, W>>,
+/// [`AnyWriter::new`].
+pub struct AnyWriter<W: Write> {
+    inner: StackTrackingSink<AnyWriterInner<W>>,
 }
 
-enum AnyWriterInner<'a, W: Write> {
+enum AnyWriterInner<W: Write> {
     #[cfg(feature = "blocknote-writer")]
-    BlockNote(BlockNoteWriter<'a, W>),
+    BlockNote(BlockNoteWriter<W>),
     #[cfg(feature = "html-writer")]
     Html(HtmlWriter<W>),
     #[cfg(feature = "oxa-writer")]
@@ -37,11 +37,9 @@ enum AnyWriterInner<'a, W: Write> {
     PandocNative(PandocNativeWriter<W>),
     #[cfg(feature = "markdown-writer")]
     Markdown(MarkdownWriter<W>),
-    #[cfg(not(feature = "blocknote-writer"))]
-    _Phantom(std::marker::PhantomData<&'a W>),
 }
 
-impl<'a, W: Write> AnyWriter<'a, W> {
+impl<W: Write> AnyWriter<W> {
     /// Construct a writer for the given format.
     #[inline]
     #[must_use]
@@ -84,70 +82,9 @@ impl<'a, W: Write> AnyWriter<'a, W> {
             }
         }
     }
-
-    /// Construct a writer with an asset provider, where supported.
-    ///
-    /// Writers that do not consume an [`AssetProvider`] (currently `OxaWriter`,
-    /// `HtmlWriter`, and `PandocNativeWriter`) silently ignore the `assets` argument;
-    /// the resulting
-    /// writer behaves identically to [`AnyWriter::new`].
-    #[inline]
-    #[must_use]
-    pub fn with_assets(format: OutputFormat, writer: W, assets: &'a dyn AssetProvider) -> Self {
-        #[cfg(not(any(
-            feature = "blocknote-writer",
-            feature = "oxa-writer",
-            feature = "html-writer",
-            feature = "pandoc-native-writer",
-            feature = "markdown-writer"
-        )))]
-        {
-            drop(writer);
-            let _ = assets;
-            match format {}
-        }
-        #[cfg(any(
-            feature = "blocknote-writer",
-            feature = "oxa-writer",
-            feature = "html-writer",
-            feature = "pandoc-native-writer",
-            feature = "markdown-writer"
-        ))]
-        {
-            let inner = match format {
-                #[cfg(feature = "blocknote-writer")]
-                OutputFormat::Blocknote => {
-                    AnyWriterInner::BlockNote(BlockNoteWriter::with_assets(writer, assets))
-                }
-                #[cfg(feature = "html-writer")]
-                OutputFormat::Html => {
-                    let _ = assets;
-                    AnyWriterInner::Html(HtmlWriter::new(writer))
-                }
-                #[cfg(feature = "oxa-writer")]
-                OutputFormat::Oxa => {
-                    let _ = assets;
-                    AnyWriterInner::Oxa(OxaWriter::new(writer))
-                }
-                #[cfg(feature = "pandoc-native-writer")]
-                OutputFormat::PandocNative => {
-                    let _ = assets;
-                    AnyWriterInner::PandocNative(PandocNativeWriter::new(writer))
-                }
-                #[cfg(feature = "markdown-writer")]
-                OutputFormat::Markdown => {
-                    let _ = assets;
-                    AnyWriterInner::Markdown(MarkdownWriter::new(writer))
-                }
-            };
-            Self {
-                inner: StackTrackingSink::new(inner),
-            }
-        }
-    }
 }
 
-impl<W: Write> EventSink for AnyWriterInner<'_, W> {
+impl<W: Write> EventSink for AnyWriterInner<W> {
     fn finish(self) -> Result<()> {
         match self {
             #[cfg(feature = "blocknote-writer")]
@@ -186,7 +123,7 @@ impl<W: Write> EventSink for AnyWriterInner<'_, W> {
     }
 }
 
-impl<W: Write> EventSink for AnyWriter<'_, W> {
+impl<W: Write> EventSink for AnyWriter<W> {
     #[inline]
     fn finish(self) -> Result<()> {
         self.inner.finish()
@@ -195,150 +132,5 @@ impl<W: Write> EventSink for AnyWriter<'_, W> {
     #[inline]
     fn handle_event(&mut self, event: Event) -> Result<()> {
         self.inner.handle_event(event)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::borrow::Cow;
-    use std::io::Write;
-
-    use docspec_core::AssetProvider;
-    #[cfg(any(
-        feature = "blocknote-writer",
-        feature = "html-writer",
-        feature = "oxa-writer",
-        feature = "pandoc-native-writer",
-        feature = "markdown-writer"
-    ))]
-    use docspec_core::{Event, EventSink as _};
-
-    #[cfg(any(
-        feature = "blocknote-writer",
-        feature = "html-writer",
-        feature = "oxa-writer",
-        feature = "pandoc-native-writer",
-        feature = "markdown-writer"
-    ))]
-    use super::{AnyWriter, OutputFormat};
-
-    struct NullAssets;
-
-    impl AssetProvider for NullAssets {
-        fn content_type(&self, _asset_id: &str) -> Option<Cow<'_, str>> {
-            None
-        }
-
-        fn stream_to(
-            &self,
-            _asset_id: &str,
-            _writer: &mut dyn Write,
-        ) -> Option<std::io::Result<u64>> {
-            None
-        }
-    }
-
-    #[cfg(feature = "blocknote-writer")]
-    #[test]
-    fn with_assets_constructs_writer_for_blocknote() {
-        let assets = NullAssets;
-        assert!(assets.content_type("any-id").is_none());
-        assert!(assets.stream_to("any-id", &mut std::io::sink()).is_none());
-        let mut buf = Vec::new();
-        let mut writer = AnyWriter::with_assets(OutputFormat::Blocknote, &mut buf, &assets);
-        assert!(writer
-            .handle_event(Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            })
-            .is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        assert!(writer.finish().is_ok());
-        assert!(!buf.is_empty());
-    }
-
-    #[cfg(feature = "oxa-writer")]
-    #[test]
-    fn with_assets_constructs_writer_for_oxa() {
-        let assets = NullAssets;
-        let mut buf = Vec::new();
-        let mut writer = AnyWriter::with_assets(OutputFormat::Oxa, &mut buf, &assets);
-        assert!(writer
-            .handle_event(Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            })
-            .is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        assert!(writer.finish().is_ok());
-        assert_eq!(buf, br#"{"type":"Document","children":[]}"#);
-    }
-
-    #[cfg(feature = "html-writer")]
-    #[test]
-    fn with_assets_ignores_provider_for_html_writer() {
-        let assets = NullAssets;
-        let mut buf = Vec::new();
-        let mut writer = AnyWriter::with_assets(OutputFormat::Html, &mut buf, &assets);
-        assert!(writer
-            .handle_event(Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            })
-            .is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        assert!(writer.finish().is_ok());
-        assert_eq!(buf, b"<html><body></body></html>");
-    }
-
-    #[cfg(feature = "pandoc-native-writer")]
-    #[test]
-    fn with_assets_ignores_provider_for_pandoc_native_writer() {
-        let assets = NullAssets;
-        let mut buf = Vec::new();
-        let mut writer = AnyWriter::with_assets(OutputFormat::PandocNative, &mut buf, &assets);
-        assert!(writer
-            .handle_event(Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            })
-            .is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        assert!(writer.finish().is_ok());
-        assert_eq!(buf, b"[]");
-    }
-
-    #[cfg(feature = "markdown-writer")]
-    #[test]
-    fn with_assets_ignores_provider_for_markdown_writer() {
-        let assets = NullAssets;
-        let mut buf = Vec::new();
-        let mut writer = AnyWriter::with_assets(OutputFormat::Markdown, &mut buf, &assets);
-        assert!(writer
-            .handle_event(Event::StartDocument {
-                id: None,
-                language: None,
-                metadata: None,
-            })
-            .is_ok());
-        assert!(writer
-            .handle_event(Event::StartParagraph {
-                alignment: None,
-                id: None
-            })
-            .is_ok());
-        assert!(writer
-            .handle_event(Event::Text {
-                content: "Hi".to_string()
-            })
-            .is_ok());
-        assert!(writer.handle_event(Event::EndParagraph).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        assert!(writer.finish().is_ok());
-        assert_eq!(buf, b"Hi\n\n");
     }
 }


### PR DESCRIPTION
Replace `AssetProvider` + `DocxAssetProvider` with `AssetHandle` instances embedded in `ImageSource::Asset(Arc<dyn AssetHandle>)`. Handles carry their own resolver; no external provider needed.