### PR TITLE
Stream DOCX document XML from path

### DIFF
--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -111,10 +111,15 @@ while let Some(event) = reader.next_event()? {
 
 ## Streaming Guarantee
 
-`DocxReader` streams `document.xml` event by event using constant memory regardless
-of document size. `_rels/.rels` and `word/_rels/document.xml.rels` are both fully
-read into memory at package-open time (typical combined size < 10 KB even for large
-documents). `word/document.xml` is consumed in streaming fashion via `quick-xml`.
+Memory use depends on which constructor you call:
+
+- **`from_path`**: streams `word/document.xml` in constant memory — O(1) regardless
+  of document size. Use this when processing large files or when memory is constrained.
+- **`from_reader`**: buffers `word/document.xml` into memory — O(N) in document size.
+  Use `from_path` when constant memory is required.
+
+In both cases, `_rels/.rels` and `word/_rels/document.xml.rels` are fully read into
+memory at package-open time (typical combined size < 10 KB even for large documents).
 The internal event queue remains bounded regardless of document size or hyperlink count.
 
 ## Quick Start

--- a/crates/docspec-docx-reader/examples/memtest_child.rs
+++ b/crates/docspec-docx-reader/examples/memtest_child.rs
@@ -1,12 +1,12 @@
 //! Child process for memory measurement.
 //!
 //! Reads the DOCX file at the path given as the first command-line argument,
-//! drives DocxReader::from_path to completion, then prints the peak RSS to stderr.
+//! drives `DocxReader::from_path` to completion, then prints the peak RSS to stderr.
 //!
-//! Usage: memtest_child <docx-path>
+//! Usage: `memtest_child` <docx-path>
 use std::path::Path;
 
-use docspec_docx_reader::{DocxReader, EventSource};
+use docspec_docx_reader::{DocxReader, EventSource as _};
 
 fn read_vm_hwm_kb() -> u64 {
     let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
@@ -20,7 +20,7 @@ fn read_vm_hwm_kb() -> u64 {
     0
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn core::error::Error>> {
     let path_arg = std::env::args()
         .nth(1)
         .ok_or("Usage: memtest_child <docx-path>")?;

--- a/crates/docspec-docx-reader/examples/memtest_child.rs
+++ b/crates/docspec-docx-reader/examples/memtest_child.rs
@@ -1,0 +1,35 @@
+//! Child process for memory measurement.
+//!
+//! Reads the DOCX file at the path given as the first command-line argument,
+//! drives DocxReader::from_path to completion, then prints the peak RSS to stderr.
+//!
+//! Usage: memtest_child <docx-path>
+use std::path::Path;
+
+use docspec_docx_reader::{DocxReader, EventSource};
+
+fn read_vm_hwm_kb() -> u64 {
+    let status = std::fs::read_to_string("/proc/self/status").unwrap_or_default();
+    for line in status.lines() {
+        if line.starts_with("VmHWM:") {
+            if let Some(kb) = line.split_whitespace().nth(1) {
+                return kb.parse().unwrap_or(0);
+            }
+        }
+    }
+    0
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let path_arg = std::env::args()
+        .nth(1)
+        .ok_or("Usage: memtest_child <docx-path>")?;
+    let path = Path::new(&path_arg);
+
+    let mut reader = DocxReader::from_path(path)?;
+    while reader.next_event()?.is_some() {}
+
+    let peak_kb = read_vm_hwm_kb();
+    eprintln!("PEAK_RSS_KB={peak_kb}");
+    Ok(())
+}

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -56,13 +56,17 @@
 //!
 //! # Streaming Guarantee
 //!
-//! `DocxReader` streams `document.xml` event by event using constant memory
-//! regardless of document size. `_rels/.rels` and
-//! `word/_rels/document.xml.rels` are both fully read into memory at
-//! package-open time (typical combined size < 10 KB even for large documents).
-//! `word/document.xml` is consumed in streaming fashion via `quick-xml`. The
-//! internal event queue remains bounded regardless of document size or
-//! hyperlink count.
+//! Memory use depends on which constructor you call:
+//!
+//! - **`from_path`**: streams `word/document.xml` in constant memory — O(1)
+//!   regardless of document size. This is the recommended path for large files.
+//! - **`from_reader`**: buffers `word/document.xml` into memory — O(N) in
+//!   document size. Use `from_path` when constant memory is required.
+//!
+//! In both cases, `_rels/.rels` and `word/_rels/document.xml.rels` are fully
+//! read into memory at package-open time (typical combined size < 10 KB even
+//! for large documents). The internal event queue remains bounded regardless
+//! of document size or hyperlink count.
 //!
 //! # Quick Start
 //!
@@ -85,6 +89,7 @@ mod numbering;
 mod package;
 mod properties;
 mod rels;
+mod streaming_archive;
 mod styles;
 mod symbol_fonts;
 
@@ -93,7 +98,7 @@ use std::path::Path;
 
 pub use docspec_core::EventSource;
 
-use docspec_core::{Error, Result};
+use docspec_core::Result;
 
 const _: for<'a> fn(&'a content_types::ContentTypes, &str) -> Option<&'a str> =
     content_types::ContentTypes::lookup;
@@ -111,10 +116,12 @@ const _: for<'a> fn(&'a rels::ImageRel) -> (&'a str, bool) = _image_rel_fields;
 ///
 /// # Streaming
 ///
-/// The reader streams `document.xml` event by event using constant memory.
-/// `_rels/.rels` and `word/_rels/document.xml.rels` are both fully read into
-/// memory at package-open time (typical combined size < 10 KB). The internal
-/// event queue remains bounded regardless of document size or hyperlink count.
+/// Memory use depends on which constructor you call. `from_path` streams
+/// `word/document.xml` in constant memory (O(1)). `from_reader` buffers
+/// `word/document.xml` into memory (O(N) in document size). In both cases,
+/// `_rels/.rels` and `word/_rels/document.xml.rels` are fully read into memory
+/// at package-open time (typical combined size < 10 KB). The internal event
+/// queue remains bounded regardless of document size or hyperlink count.
 ///
 /// # Errors
 ///
@@ -128,19 +135,41 @@ pub struct DocxReader {
 impl DocxReader {
     /// Creates a `DocxReader` from a file path.
     ///
+    /// Streams `word/document.xml` in constant memory (O(1) in document size).
+    /// Prefer this over [`from_reader`](Self::from_reader) when memory is a concern.
+    ///
     /// # Errors
     ///
     /// Returns [`Error::Io`] if the file cannot be opened. See [`from_reader`](Self::from_reader)
     /// for additional error conditions.
     #[inline]
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
-        let file = std::fs::File::open(path.as_ref()).map_err(Error::from)?;
-        Self::from_reader(file)
+        let (style_list, numbering, hyperlink_map, image_map, content_types, archive, stream) =
+            package::open_package_from_path(path.as_ref())?;
+        let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
+        let data = document::DocxData {
+            style_list,
+            hyperlink_map,
+            numbering,
+            image_map,
+        };
+        Ok(Self {
+            inner: document::DocumentReader::from_xml_reader_and_archive(
+                xml,
+                data,
+                archive,
+                content_types,
+            ),
+        })
     }
 
     /// Creates a `DocxReader` from any `Read + Seek` source.
     ///
     /// The reader must be positioned at the start of a valid DOCX (ZIP) archive.
+    ///
+    /// **Memory note**: this constructor buffers `word/document.xml` into memory
+    /// (O(N) in document size). Use [`from_path`](Self::from_path) for O(1)
+    /// constant-memory streaming.
     ///
     /// # Errors
     ///

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -1,6 +1,8 @@
 //! ZIP/OPC package navigation for DOCX archives.
 
+use std::fs::File;
 use std::io::{Cursor, Read, Seek};
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use docspec_core::{Error, Result};
@@ -33,43 +35,14 @@ type PackageContents = (
 /// main document part.
 pub fn open_package<R: Read + Seek + Send + 'static>(reader: R) -> Result<PackageContents> {
     let boxed: Box<dyn ReadSeek + 'static> = Box::new(reader);
-    let mut archive = ZipArchive::new(boxed).map_err(|err| match err {
-        ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
-            message: "not a valid ZIP archive".to_string(),
-            position: None,
-        },
-        ZipError::Io(source) => Error::Io { source },
-        ZipError::FileNotFound
-        | ZipError::InvalidPassword
-        | ZipError::CompressionMethodNotSupported(_)
-        | _ => parse_error(format!("not a valid ZIP archive: {err}")),
-    })?;
+    let mut archive = ZipArchive::new(boxed).map_err(map_zip_open_error)?;
 
-    let rels_bytes = {
-        let mut rels_entry = archive.by_name("_rels/.rels").map_err(|err| {
-            if matches!(err, ZipError::FileNotFound) {
-                Error::Parse {
-                    message: "missing _rels/.rels".to_string(),
-                    position: None,
-                }
-            } else {
-                parse_error(format!("malformed ZIP: {err}"))
-            }
-        })?;
-        let mut bytes = Vec::new();
-        rels_entry.read_to_end(&mut bytes).map_err(Error::from)?;
-        bytes
-    };
+    let rels_bytes = read_root_rels_bytes(&mut archive)?;
 
     let document_path = rels::find_document_target(std::io::Cursor::new(rels_bytes))?;
-    let (style_list, hyperlink_map, image_map) =
-        load_style_list_and_hyperlink_map(&mut archive, &document_path)?;
-    let numbering = load_numbering(&mut archive, &document_path)?;
 
-    let content_types = match read_optional_entry(&mut archive, "[Content_Types].xml")? {
-        Some(bytes) => content_types::parse(&bytes)?,
-        None => ContentTypes::default(),
-    };
+    let (style_list, numbering, hyperlink_map, image_map, content_types) =
+        load_small_package_parts(&mut archive, &document_path)?;
 
     let mut document_xml_bytes = Vec::new();
     archive
@@ -92,6 +65,90 @@ pub fn open_package<R: Read + Seek + Send + 'static>(reader: R) -> Result<Packag
         content_types_arc,
         archive_arc,
         Box::new(Cursor::new(document_xml_bytes)),
+    ))
+}
+
+pub(crate) fn open_package_from_path(path: &Path) -> Result<PackageContents> {
+    let asset_file = File::open(path).map_err(Error::from)?;
+    let boxed: Box<dyn ReadSeek + 'static> = Box::new(asset_file);
+    let mut asset_archive = ZipArchive::new(boxed).map_err(map_zip_open_error)?;
+
+    let rels_bytes = read_root_rels_bytes(&mut asset_archive)?;
+
+    let document_path = rels::find_document_target(std::io::Cursor::new(rels_bytes))?;
+
+    let (style_list, numbering, hyperlink_map, image_map, content_types) =
+        load_small_package_parts(&mut asset_archive, &document_path)?;
+
+    let streaming = crate::streaming_archive::StreamingArchive::open(path, &document_path)?;
+
+    let content_types_arc = Arc::new(content_types);
+    let archive_arc = Arc::new(Mutex::new(asset_archive));
+
+    Ok((
+        style_list,
+        numbering,
+        hyperlink_map,
+        image_map,
+        content_types_arc,
+        archive_arc,
+        Box::new(streaming),
+    ))
+}
+
+fn map_zip_open_error(err: ZipError) -> Error {
+    match err {
+        ZipError::InvalidArchive(_) | ZipError::UnsupportedArchive(_) => Error::Parse {
+            message: "not a valid ZIP archive".to_string(),
+            position: None,
+        },
+        ZipError::Io(source) => Error::Io { source },
+        ZipError::FileNotFound
+        | ZipError::InvalidPassword
+        | ZipError::CompressionMethodNotSupported(_)
+        | _ => parse_error(format!("not a valid ZIP archive: {err}")),
+    }
+}
+
+fn read_root_rels_bytes<R: Read + Seek>(archive: &mut ZipArchive<R>) -> Result<Vec<u8>> {
+    let mut rels_entry = archive.by_name("_rels/.rels").map_err(|err| {
+        if matches!(err, ZipError::FileNotFound) {
+            Error::Parse {
+                message: "missing _rels/.rels".to_string(),
+                position: None,
+            }
+        } else {
+            parse_error(format!("malformed ZIP: {err}"))
+        }
+    })?;
+    let mut bytes = Vec::new();
+    rels_entry.read_to_end(&mut bytes).map_err(Error::from)?;
+    Ok(bytes)
+}
+
+fn load_small_package_parts<R: Read + Seek>(
+    archive: &mut ZipArchive<R>,
+    document_path: &str,
+) -> Result<(
+    StyleList,
+    crate::numbering::MinimalNumbering,
+    HyperlinkMap,
+    ImageMap,
+    ContentTypes,
+)> {
+    let (style_list, hyperlink_map, image_map) =
+        load_style_list_and_hyperlink_map(archive, document_path)?;
+    let numbering = load_numbering(archive, document_path)?;
+    let content_types = match read_optional_entry(archive, "[Content_Types].xml")? {
+        Some(bytes) => content_types::parse(&bytes)?,
+        None => ContentTypes::default(),
+    };
+    Ok((
+        style_list,
+        numbering,
+        hyperlink_map,
+        image_map,
+        content_types,
     ))
 }
 

--- a/crates/docspec-docx-reader/src/streaming_archive.rs
+++ b/crates/docspec-docx-reader/src/streaming_archive.rs
@@ -1,0 +1,135 @@
+//! Streaming reader for a single ZIP entry without buffering it in memory.
+//!
+//! `StreamingArchive::open` uses `ZipArchive` only to locate an entry and capture
+//! its compressed byte range. The returned reader then streams that byte range
+//! directly from the DOCX file with bounded memory.
+
+use std::fs::File;
+use std::io::{Read, Seek as _, SeekFrom};
+use std::path::Path;
+
+use docspec_core::{Error, Result};
+use flate2::read::DeflateDecoder;
+use zip::{CompressionMethod, ZipArchive};
+
+enum EntryReader {
+    Stored(std::io::Take<File>),
+    Deflated(DeflateDecoder<std::io::Take<File>>),
+}
+
+impl Read for EntryReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Stored(reader) => reader.read(buf),
+            Self::Deflated(reader) => reader.read(buf),
+        }
+    }
+}
+
+/// Streaming reader for one DOCX ZIP entry.
+///
+/// Constructed via [`StreamingArchive::open`]. The archive is inspected once for
+/// entry metadata; `Read` then pulls bytes directly from the compressed entry
+/// range without materializing the full XML document.
+pub(crate) struct StreamingArchive {
+    reader: EntryReader,
+}
+
+impl StreamingArchive {
+    /// Opens the ZIP archive at `path` and positions the reader on the entry
+    /// named `entry_name` (typically `"word/document.xml"`).
+    pub(crate) fn open(path: &Path, entry_name: &str) -> Result<Self> {
+        let file = File::open(path).map_err(Error::from)?;
+        let mut archive = ZipArchive::new(file).map_err(|err| Error::Parse {
+            message: format!("not a valid ZIP archive: {err}"),
+            position: None,
+        })?;
+
+        let entry = archive.by_name(entry_name).map_err(|err| Error::Parse {
+            message: format!("document target not found: {err}"),
+            position: None,
+        })?;
+        let data_start = entry.data_start().ok_or_else(|| Error::Parse {
+            message: format!("document target has no data offset: {entry_name}"),
+            position: None,
+        })?;
+        let compressed_size = entry.compressed_size();
+        let compression = entry.compression();
+        drop(entry);
+
+        let mut stream_file = archive.into_inner();
+        stream_file
+            .seek(SeekFrom::Start(data_start))
+            .map_err(Error::from)?;
+        let compressed_reader = stream_file.take(compressed_size);
+        let reader = match compression {
+            CompressionMethod::Stored => EntryReader::Stored(compressed_reader),
+            CompressionMethod::Deflated => {
+                EntryReader::Deflated(DeflateDecoder::new(compressed_reader))
+            }
+            _ => {
+                return Err(Error::Parse {
+                    message: format!("unsupported ZIP compression method: {compression:?}"),
+                    position: None,
+                });
+            }
+        };
+
+        Ok(Self { reader })
+    }
+}
+
+impl Read for StreamingArchive {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.reader.read(buf)
+    }
+}
+
+// Compile-time assertion: StreamingArchive must be Send + 'static.
+const _: fn(&Path, &str) -> Result<StreamingArchive> = StreamingArchive::open;
+
+const _: fn() = || {
+    fn assert_send<T: Send + 'static>() {}
+    assert_send::<StreamingArchive>();
+};
+
+#[cfg(test)]
+#[cfg(not(coverage))]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use std::io::Write as _;
+
+    fn make_test_docx_with_entry(entry_name: &str, content: &[u8]) -> tempfile::NamedTempFile {
+        let tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        let buf = std::io::Cursor::new(Vec::new());
+        let mut writer = zip::ZipWriter::new(buf);
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        writer.start_file(entry_name, options).expect("start_file");
+        writer.write_all(content).expect("write_all");
+        let zip_bytes = writer.finish().expect("finish").into_inner();
+        let mut file = tmp.reopen().expect("reopen");
+        file.write_all(&zip_bytes).expect("write to tempfile");
+        drop(file);
+        tmp
+    }
+
+    #[test]
+    fn streaming_archive_reads_entry_content() {
+        let xml_content = b"<?xml version=\"1.0\"?><root>hello</root>";
+        let tmp = make_test_docx_with_entry("word/document.xml", xml_content);
+        let mut archive = StreamingArchive::open(tmp.path(), "word/document.xml").unwrap();
+        let mut buf = Vec::new();
+        archive.read_to_end(&mut buf).unwrap();
+        assert_eq!(buf, xml_content);
+    }
+
+    #[test]
+    fn streaming_archive_open_missing_entry_returns_error() {
+        let tmp = make_test_docx_with_entry("word/document.xml", b"<?xml?>");
+        let result = StreamingArchive::open(tmp.path(), "word/missing.xml");
+        assert!(result.is_err());
+    }
+}

--- a/crates/docspec-docx-reader/src/streaming_archive.rs
+++ b/crates/docspec-docx-reader/src/streaming_archive.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 
 use docspec_core::{Error, Result};
 use flate2::read::DeflateDecoder;
-use zip::{CompressionMethod, ZipArchive};
+use zip::{result::ZipError, CompressionMethod, ZipArchive};
 
 enum EntryReader {
     Stored(std::io::Take<File>),
@@ -40,14 +40,20 @@ impl StreamingArchive {
     /// named `entry_name` (typically `"word/document.xml"`).
     pub(crate) fn open(path: &Path, entry_name: &str) -> Result<Self> {
         let file = File::open(path).map_err(Error::from)?;
-        let mut archive = ZipArchive::new(file).map_err(|err| Error::Parse {
-            message: format!("not a valid ZIP archive: {err}"),
-            position: None,
+        let mut archive = ZipArchive::new(file).map_err(|err| match err {
+            ZipError::Io(source) => Error::Io { source },
+            other => Error::Parse {
+                message: format!("not a valid ZIP archive: {other}"),
+                position: None,
+            },
         })?;
 
-        let entry = archive.by_name(entry_name).map_err(|err| Error::Parse {
-            message: format!("document target not found: {err}"),
-            position: None,
+        let entry = archive.by_name(entry_name).map_err(|err| match err {
+            ZipError::Io(source) => Error::Io { source },
+            other => Error::Parse {
+                message: format!("document target not found: {other}"),
+                position: None,
+            },
         })?;
         let data_start = entry.data_start().ok_or_else(|| Error::Parse {
             message: format!("document target has no data offset: {entry_name}"),

--- a/crates/docspec-docx-reader/tests/memory.rs
+++ b/crates/docspec-docx-reader/tests/memory.rs
@@ -1,0 +1,144 @@
+//! Memory-overhead invariant tests for DOCX streaming.
+//!
+//! These tests verify that DocxReader::from_path adds bounded overhead regardless
+//! of document.xml size. They are marked `#[ignore]` because they are slow and
+//! should not run in normal CI.
+//!
+//! Run with: `cargo test -p docspec-docx-reader --test memory -- --ignored --nocapture`.
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::expect_used,
+    clippy::indexing_slicing,
+    clippy::integer_division,
+    clippy::print_stderr,
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used
+)]
+
+#[cfg(target_os = "linux")]
+mod linux_only {
+
+    fn synth_large_docx(doc_xml_size_mb: usize) -> Vec<u8> {
+        let target_bytes = doc_xml_size_mb * 1024 * 1024;
+
+        let header = r#"<?xml version="1.0" encoding="UTF-8"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+<w:body>"#;
+
+        let para = "<w:p><w:r><w:t>test paragraph content for memory measurement</w:t></w:r></w:p>";
+        let footer = "</w:body></w:document>";
+
+        let para_bytes = para.len();
+        let overhead = header.len() + footer.len();
+        let n_paras = (target_bytes.saturating_sub(overhead)) / para_bytes + 1;
+
+        let mut doc_xml = String::with_capacity(target_bytes + 1024);
+        doc_xml.push_str(header);
+        for _ in 0..n_paras {
+            doc_xml.push_str(para);
+        }
+        doc_xml.push_str(footer);
+
+        let rels_xml = r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+        docspec_test_utils::synth_docx_with_entries(&[
+            (
+                "_rels/.rels",
+                zip::CompressionMethod::Stored,
+                rels_xml.as_bytes(),
+            ),
+            (
+                "word/document.xml",
+                zip::CompressionMethod::Stored,
+                doc_xml.as_bytes(),
+            ),
+        ])
+    }
+
+    fn child_bin_path() -> std::path::PathBuf {
+        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+            .expect("CARGO_MANIFEST_DIR must be set (run via cargo test)");
+        let workspace_root = std::path::Path::new(&manifest_dir).join("../..");
+        workspace_root.join("target/release/examples/memtest_child")
+    }
+
+    fn run_child_and_get_peak_rss(docx_path: &std::path::Path) -> u64 {
+        let bin = child_bin_path();
+        assert!(
+            bin.exists(),
+            "memtest_child binary not found at {bin:?}. Run: cargo build --release --example memtest_child -p docspec-docx-reader"
+        );
+
+        let output = std::process::Command::new(&bin)
+            .arg(docx_path)
+            .output()
+            .expect("failed to spawn memtest_child");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(output.status.success(), "memtest_child failed:\n{stderr}");
+
+        for line in stderr.lines() {
+            if let Some(rest) = line.strip_prefix("PEAK_RSS_KB=") {
+                if let Ok(kb) = rest.trim().parse::<u64>() {
+                    return kb;
+                }
+            }
+        }
+        panic!("PEAK_RSS_KB not found in child stderr:\n{stderr}");
+    }
+
+    /// Verify that streaming via from_path adds bounded overhead (< 80 MB peak RSS)
+    /// even when processing a 50 MB word/document.xml.
+    ///
+    /// Proof: if buffering were still in effect, the child would need 50 MB just for
+    /// the document.xml buffer, pushing it over the 80 MB threshold.
+    ///
+    /// Prerequisite: `cargo build --release --example memtest_child -p docspec-docx-reader`
+    #[test]
+    #[ignore = "slow memory test, run manually after building memtest_child"]
+    fn streaming_doc_xml_bounded_overhead() {
+        let bytes = synth_large_docx(50);
+        let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        use std::io::Write;
+        tmp.write_all(&bytes).expect("write docx");
+        tmp.flush().expect("flush");
+        drop(bytes);
+
+        let peak_kb = run_child_and_get_peak_rss(tmp.path());
+        let peak_mb = peak_kb / 1024;
+        eprintln!("50 MB doc.xml: child peak RSS = {peak_mb} MB ({peak_kb} kB)");
+
+        assert!(
+            peak_kb < 80_000,
+            "Peak RSS {peak_mb} MB exceeds 80 MB budget for 50 MB document.xml (streaming leak!)"
+        );
+        eprintln!("Memory budget OK: {peak_mb} MB < 80 MB");
+    }
+
+    /// Verify that memory usage stays flat as document.xml grows from 50 MB to 200 MB.
+    /// Both tests hitting the same threshold (~10-20 MB) proves O(1) behavior.
+    ///
+    /// Prerequisite: `cargo build --release --example memtest_child -p docspec-docx-reader`
+    #[test]
+    #[ignore = "slow memory test, run manually after building memtest_child"]
+    fn streaming_doc_xml_scales_to_huge_docs() {
+        let bytes = synth_large_docx(200);
+        let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
+        use std::io::Write;
+        tmp.write_all(&bytes).expect("write docx");
+        tmp.flush().expect("flush");
+        drop(bytes);
+
+        let peak_kb = run_child_and_get_peak_rss(tmp.path());
+        let peak_mb = peak_kb / 1024;
+        eprintln!("200 MB doc.xml: child peak RSS = {peak_mb} MB ({peak_kb} kB)");
+
+        assert!(
+            peak_kb < 80_000,
+            "Peak RSS {peak_mb} MB exceeds 80 MB budget for 200 MB document.xml (memory scales with input = not O(1)!)"
+        );
+        eprintln!(
+            "Memory budget OK: {peak_mb} MB < 80 MB — memory is O(1) regardless of document size"
+        );
+    }
+} // mod linux_only

--- a/crates/docspec-docx-reader/tests/memory.rs
+++ b/crates/docspec-docx-reader/tests/memory.rs
@@ -1,7 +1,7 @@
 //! Memory-overhead invariant tests for DOCX streaming.
 //!
-//! These tests verify that DocxReader::from_path adds bounded overhead regardless
-//! of document.xml size. They are marked `#[ignore]` because they are slow and
+//! These tests verify that `DocxReader::from_path` adds bounded overhead regardless
+//! of `document.xml` size. They are marked `#[ignore]` because they are slow and
 //! should not run in normal CI.
 //!
 //! Run with: `cargo test -p docspec-docx-reader --test memory -- --ignored --nocapture`.
@@ -17,6 +17,7 @@
 
 #[cfg(target_os = "linux")]
 mod linux_only {
+    use std::io::Write as _;
 
     fn synth_large_docx(doc_xml_size_mb: usize) -> Vec<u8> {
         let target_bytes = doc_xml_size_mb * 1024 * 1024;
@@ -66,7 +67,8 @@ mod linux_only {
         let bin = child_bin_path();
         assert!(
             bin.exists(),
-            "memtest_child binary not found at {bin:?}. Run: cargo build --release --example memtest_child -p docspec-docx-reader"
+            "memtest_child binary not found at {}. Run: cargo build --release --example memtest_child -p docspec-docx-reader",
+            bin.display()
         );
 
         let output = std::process::Command::new(&bin)
@@ -77,68 +79,65 @@ mod linux_only {
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(output.status.success(), "memtest_child failed:\n{stderr}");
 
-        for line in stderr.lines() {
-            if let Some(rest) = line.strip_prefix("PEAK_RSS_KB=") {
-                if let Ok(kb) = rest.trim().parse::<u64>() {
-                    return kb;
-                }
-            }
-        }
-        panic!("PEAK_RSS_KB not found in child stderr:\n{stderr}");
+        stderr
+            .lines()
+            .find_map(|line| {
+                let rest = line.strip_prefix("PEAK_RSS_KB=")?;
+                rest.trim().parse::<u64>().ok()
+            })
+            .expect("PEAK_RSS_KB line must be present in child stderr")
     }
 
-    /// Verify that streaming via from_path adds bounded overhead (< 80 MB peak RSS)
-    /// even when processing a 50 MB word/document.xml.
+    /// Verify that streaming via `from_path` adds bounded overhead (< 80 MB peak RSS)
+    /// even when processing a 50 MB `word/document.xml`.
     ///
     /// Proof: if buffering were still in effect, the child would need 50 MB just for
-    /// the document.xml buffer, pushing it over the 80 MB threshold.
+    /// the `document.xml` buffer, pushing it over the 80 MB threshold.
     ///
-    /// Prerequisite: `cargo build --release --example memtest_child -p docspec-docx-reader`
+    /// Prerequisite: `cargo build --release --example memtest_child -p docspec-docx-reader`.
     #[test]
     #[ignore = "slow memory test, run manually after building memtest_child"]
     fn streaming_doc_xml_bounded_overhead() {
         let bytes = synth_large_docx(50);
         let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
-        use std::io::Write;
         tmp.write_all(&bytes).expect("write docx");
         tmp.flush().expect("flush");
         drop(bytes);
 
-        let peak_kb = run_child_and_get_peak_rss(tmp.path());
-        let peak_mb = peak_kb / 1024;
-        eprintln!("50 MB doc.xml: child peak RSS = {peak_mb} MB ({peak_kb} kB)");
+        let rss_kib = run_child_and_get_peak_rss(tmp.path());
+        let peak_mebibytes = rss_kib / 1024;
+        eprintln!("50 MB doc.xml: child peak RSS = {peak_mebibytes} MB ({rss_kib} kB)");
 
         assert!(
-            peak_kb < 80_000,
-            "Peak RSS {peak_mb} MB exceeds 80 MB budget for 50 MB document.xml (streaming leak!)"
+            rss_kib < 80_000,
+            "Peak RSS {peak_mebibytes} MB exceeds 80 MB budget for 50 MB document.xml (streaming leak!)"
         );
-        eprintln!("Memory budget OK: {peak_mb} MB < 80 MB");
+        eprintln!("Memory budget OK: {peak_mebibytes} MB < 80 MB");
     }
 
-    /// Verify that memory usage stays flat as document.xml grows from 50 MB to 200 MB.
+    /// Verify that memory usage stays flat as `document.xml` grows from 50 MB to 200 MB.
     /// Both tests hitting the same threshold (~10-20 MB) proves O(1) behavior.
     ///
-    /// Prerequisite: `cargo build --release --example memtest_child -p docspec-docx-reader`
+    /// Prerequisite: `cargo build --release --example memtest_child -p docspec-docx-reader`.
     #[test]
     #[ignore = "slow memory test, run manually after building memtest_child"]
     fn streaming_doc_xml_scales_to_huge_docs() {
         let bytes = synth_large_docx(200);
         let mut tmp = tempfile::NamedTempFile::new().expect("tempfile");
-        use std::io::Write;
         tmp.write_all(&bytes).expect("write docx");
         tmp.flush().expect("flush");
         drop(bytes);
 
-        let peak_kb = run_child_and_get_peak_rss(tmp.path());
-        let peak_mb = peak_kb / 1024;
-        eprintln!("200 MB doc.xml: child peak RSS = {peak_mb} MB ({peak_kb} kB)");
+        let rss_kib = run_child_and_get_peak_rss(tmp.path());
+        let peak_mebibytes = rss_kib / 1024;
+        eprintln!("200 MB doc.xml: child peak RSS = {peak_mebibytes} MB ({rss_kib} kB)");
 
         assert!(
-            peak_kb < 80_000,
-            "Peak RSS {peak_mb} MB exceeds 80 MB budget for 200 MB document.xml (memory scales with input = not O(1)!)"
+            rss_kib < 80_000,
+            "Peak RSS {peak_mebibytes} MB exceeds 80 MB budget for 200 MB document.xml (memory scales with input = not O(1)!)"
         );
         eprintln!(
-            "Memory budget OK: {peak_mb} MB < 80 MB — memory is O(1) regardless of document size"
+            "Memory budget OK: {peak_mebibytes} MB < 80 MB — memory is O(1) regardless of document size"
         );
     }
 } // mod linux_only

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -485,26 +485,6 @@ mod constructor {
         let result = DocxReader::from_path(tmp.path());
         assert!(result.is_ok(), "expected Ok, got: {result:?}");
     }
-
-    #[test]
-    fn from_reader_does_not_buffer_document_xml() {
-        let big_doc = {
-            let mut doc = String::from(
-                r#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>"#,
-            );
-            for _ in 0..1000 {
-                doc.push_str("<w:p><w:r><w:t>hello world</w:t></w:r></w:p>");
-            }
-            doc.push_str("</w:body></w:document>");
-            doc
-        };
-        let bytes = fixture::synth_docx(
-            r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
-            &big_doc,
-        );
-        let result = DocxReader::from_reader(Cursor::new(bytes));
-        assert!(result.is_ok(), "expected Ok, got: {result:?}");
-    }
 }
 
 mod events {


### PR DESCRIPTION
## Summary
- stream `word/document.xml` for `DocxReader::from_path`
- keep `DocxReader::from_reader` buffered
- add ignored RSS memory tests

## Verification
- `cargo fmt --check -p docspec-docx-reader`
- `cargo clippy -p docspec-docx-reader -- -D warnings`
- `cargo test -p docspec-docx-reader`
- ignored memory tests pass: 50MB and 200MB docs both peak at ~2MB RSS