### PR TITLE
docs(blocknote-writer): document highlight color name divergences

### DIFF
--- a/crates/docspec-blocknote-writer/COLOR_SNAPPING.md
+++ b/crates/docspec-blocknote-writer/COLOR_SNAPPING.md
@@ -1,0 +1,27 @@
+# Highlight Color: Known Name Divergences
+
+`Mark(Color)` events arriving from any upstream reader (e.g. OOXML `<w:highlight>`, OOXML `<w:shd w:fill>`, HTML `<mark>`) are snapped to BlockNote's 9-entry pastel background palette using squared Euclidean distance in 8-bit sRGB (`src/palette.rs`). The resulting palette name is emitted as the `backgroundColor` key in the inline `styles` object.
+
+When the source carries a *named* color from a different palette, the snap can pick a palette entry whose **name** differs from the source name, even though both palettes share many of the same names. This is deterministic, asserted by tests, and **semantically lossy**: a span highlighted "yellow" in the source can render under a different name in BlockNote.
+
+## Example case: OOXML `yellow` → BlockNote `orange`
+
+OOXML `<w:highlight w:val="yellow"/>` is parsed by the DOCX reader as `Color::Rgb { r: 255, g: 255, b: 0 }` and arrives at this writer as `Mark((255, 255, 0))`.
+
+The two relevant palette entries are:
+
+- `"yellow"` → `(251, 243, 219)`
+- `"orange"` → `(246, 233, 217)`
+
+```
+distance((255,255,0) → (251,243,219)) = 4² + 12² + 219² = 48121
+distance((255,255,0) → (246,233,217)) = 9² + 22² + 217² = 47654   ← shorter
+```
+
+`"orange"` wins by 467 squared units. Every yellow highlight in the source is emitted as `"backgroundColor":"orange"`. This is asserted by `palette::tests::r255_g255_b0_matches_orange` in `src/palette.rs`.
+
+## Mechanism
+
+Every entry in `BACKGROUND_PALETTE` has all three channels in the range 217-242 (pastel). Many source-palette colors place at least one channel at 0 or 255, far outside that anchor cluster. The squared-distance sum is then dominated by whichever channels are most extreme, and the snap is decided by small differences in the remaining channels. Those small differences do not track perceptual hue or color name, so the "nearest" pastel under this metric is frequently a *neighbouring* color rather than the same color in pastel form.
+
+The same metric applies to text color (`TextColor` → `textColor`) against `TEXT_PALETTE`. The text palette uses richer tones and a different anchor distribution, so the specific divergences differ.

--- a/crates/docspec-blocknote-writer/README.md
+++ b/crates/docspec-blocknote-writer/README.md
@@ -53,6 +53,8 @@ The palette snap uses squared Euclidean distance in 8-bit sRGB space. No percept
 
 The two palettes use different RGB values, so the same input color can snap to different names depending on whether it's a text color or a background color. For instance, the saturated red `(224, 62, 62)` snaps to background palette `"orange"` (not `"red"`) because the background palette uses pastel colors and the Euclidean distance to pastel orange is shorter than to pastel red. This is intentional and matches the reference implementation.
 
+See [COLOR_SNAPPING.md](./COLOR_SNAPPING.md) for an example of how this snap can rename a source color end-to-end (OOXML `<w:highlight w:val="yellow"/>` → BlockNote `"backgroundColor":"orange"`) and the mechanism behind it.
+
 ## Not Yet Supported
 
 - Footnotes — `StartFootnote`/`EndFootnote`/`FootnoteRef` are silently ignored; BlockNote's default schema has no equivalent


### PR DESCRIPTION
Documents that the BlockNote writer's RGB-Euclidean snap against the pastel `BACKGROUND_PALETTE` can rename a source color end-to-end. Worked example: OOXML `<w:highlight w:val="yellow"/>` renders as `"backgroundColor":"orange"`. Docs only; no behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide explaining how highlight and text colors are mapped to the BlockNote palette, including detailed behavior specifications and worked examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->