### PR TITLE
feat(blocknote-writer): lift in-cell images to siblings after enclosing table

### DIFF
--- a/crates/docspec-blocknote-writer/README.md
+++ b/crates/docspec-blocknote-writer/README.md
@@ -129,8 +129,9 @@ let json = String::from_utf8(buf)?;
 
 - `StartParagraph` / `EndParagraph` boundaries are absorbed silently (adjacent paragraphs concatenate without separator)
 - `Text` and `LineBreak` are preserved
-- Images, headings, code blocks, blockquotes, and list items are dropped silently
-- Nested tables are lifted: their events are buffered between the inner `StartTable` and matching `EndTable`, then replayed as top-level sibling blocks immediately after the enclosing outermost table closes. Deep nesting (`A` containing `B` containing `C`) flattens to a top-level sequence (`A, B, C`) in document order. Inline text adjacent to a nested table in the same outer cell stays in that outer cell.
+- Headings, code blocks, blockquotes, and list items are dropped silently
+- Images are lifted: each `Image` event encountered inside a cell is buffered and replayed as a top-level sibling block immediately after the enclosing outermost table closes, preserving document order with any other lifted content from the same table. Inline text adjacent to a lifted image in the same cell stays in that cell — only the image moves out.
+- Nested tables are lifted: their events are buffered between the inner `StartTable` and matching `EndTable`, then replayed as top-level sibling blocks immediately after the enclosing outermost table closes. Deep nesting (`A` containing `B` containing `C`) flattens to a top-level sequence (`A, B, C`) in document order. Inline text adjacent to a nested table in the same outer cell stays in that outer cell. Images inside a nested cell lift through the recursive drain — they emit as siblings of the already-lifted nested table.
 
 **Non-paragraph children inside list items**: headings, images, code blocks, and blockquotes that appear as children of a list item are dropped. The first paragraph's inline content populates the item's `content[]` array; each subsequent paragraph becomes a child `paragraph` block in `children[]`.
 

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -39,8 +39,8 @@
 //!
 //! - **Preserved**: [`StartTextStyle`](docspec_core::Event::StartTextStyle) / [`EndTextStyle`](docspec_core::Event::EndTextStyle), [`Text`](docspec_core::Event::Text) (with currently open inline styles), [`LineBreak`](docspec_core::Event::LineBreak), [`SoftBreak`](docspec_core::Event::SoftBreak)
 //! - **Absorbed silently**: [`StartParagraph`](docspec_core::Event::StartParagraph) / [`EndParagraph`](docspec_core::Event::EndParagraph) (paragraph boundaries are dropped — adjacent paragraphs concatenate without separator)
-//! - **Dropped**: [`Image`](docspec_core::Event::Image), [`StartBlockQuote`](docspec_core::Event::StartBlockQuote), [`StartPreformatted`](docspec_core::Event::StartPreformatted), [`StartHeading`](docspec_core::Event::StartHeading), [`ThematicBreak`](docspec_core::Event::ThematicBreak) — silently discarded
-//! - **Lifted**: nested [`StartTable`](docspec_core::Event::StartTable) and its children — buffered and replayed as top-level sibling blocks after the enclosing outermost table closes
+//! - **Dropped**: [`StartBlockQuote`](docspec_core::Event::StartBlockQuote), [`StartPreformatted`](docspec_core::Event::StartPreformatted), [`StartHeading`](docspec_core::Event::StartHeading), [`ThematicBreak`](docspec_core::Event::ThematicBreak) — silently discarded
+//! - **Lifted**: nested [`StartTable`](docspec_core::Event::StartTable) and its children, and [`Image`](docspec_core::Event::Image) events that appear inside a cell — buffered and replayed as top-level sibling blocks after the enclosing outermost table closes
 //!
 //! Nested tables (a `StartTable` inside a cell) are buffered between the first nested
 //! `StartTable` and its matching `EndTable`, then replayed through the writer after the
@@ -49,6 +49,13 @@
 //! number of levels deep collapses to a flat top-level sequence: `A` containing `B`
 //! containing `C` emits as `A, B, C`. Inline text adjacent to a nested table in the same
 //! outer cell stays in that outer cell.
+//!
+//! Images encountered inside a cell are likewise buffered and replayed as top-level sibling
+//! blocks after the enclosing outermost table closes. Their order in the output mirrors the
+//! order they appeared inside the table (interleaved with any lifted nested tables in
+//! document order). Inline text adjacent to a lifted image in the same cell stays in that
+//! cell — only the image moves out. Images inside a nested cell lift through the recursive
+//! drain: they emit as siblings of the (already-lifted) nested table.
 //!
 //! # List Support
 //!
@@ -258,7 +265,9 @@ pub struct BlockNoteWriter<W: Write> {
     json: JsonEmitter<StrusonBackend<W>>,
     /// Whether at least one `StyledText` has been emitted into the current link's content array.
     link_emitted_styled_text: bool,
-    /// Events from nested tables, replayed at the outermost `EndTable` to lift them to top level.
+    /// Events deferred for replay at the outermost `EndTable` as top-level siblings:
+    /// nested-table substreams and in-cell `Image` events. Both are illegal inside
+    /// `BlockNote`'s `tableCell.content`; co-buffering preserves their document order.
     lifted_nested_events: Vec<Event>,
     list_stack: Vec<ListStackEntry>,
     open_styles: Vec<TextStyleKind>,
@@ -1058,6 +1067,7 @@ impl<W: Write> BlockNoteWriter<W> {
     fn should_buffer_for_lift(&self, event: &Event) -> bool {
         match event {
             Event::StartTable { .. } => self.table_depth.is_positive(),
+            Event::Image { .. } if self.context.in_table_cell => true,
             _ => self.table_depth.get() >= 2,
         }
     }

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -2725,10 +2725,7 @@ mod tests {
     }
 
     #[test]
-    fn image_inside_table_cell_is_dropped() {
-        // Drives an Image event between StartTableCell / EndTableCell. BlockNote
-        // cell content is InlineContent[] — block-level events (including images)
-        // are silently dropped per the documented cell-content semantics.
+    fn image_inside_table_cell_is_lifted_after_table() {
         let json = run_events(&[
             start_document(),
             start_table(),
@@ -2738,7 +2735,7 @@ mod tests {
                 source: ImageSource::Uri {
                     uri: "https://example.com/img.png".to_string(),
                 },
-                alt: Some("dropped".to_string()),
+                alt: Some("in cell".to_string()),
                 title: None,
                 decorative: false,
                 id: None,
@@ -2750,7 +2747,346 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/img.png","caption":"in cell"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn multiple_images_in_same_cell_lift_in_document_order() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/a.png".to_string(),
+                },
+                alt: Some("A".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/b.png".to_string(),
+                },
+                alt: Some("B".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/a.png","caption":"A"},"content":null,"children":[]},{"type":"image","props":{"url":"https://example.com/b.png","caption":"B"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn images_in_different_cells_lift_in_document_order() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/cell1.png".to_string(),
+                },
+                alt: Some("cell1".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/cell2.png".to_string(),
+                },
+                alt: Some("cell2".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]},{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/cell1.png","caption":"cell1"},"content":null,"children":[]},{"type":"image","props":{"url":"https://example.com/cell2.png","caption":"cell2"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn text_around_image_in_cell_stays_in_cell_while_image_lifts() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            text("before"),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/img.png".to_string(),
+                },
+                alt: Some("middle".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            text("after"),
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"before","styles":{}},{"type":"text","text":"after","styles":{}}]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/img.png","caption":"middle"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn asset_image_in_cell_lifts_as_data_uri_block() {
+        let handle = Arc::new(MockAssetHandle::new(
+            "png1",
+            "image/png",
+            &[0x89, 0x50, 0x4E, 0x47],
+        ));
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Asset(handle),
+                alt: Some("png".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"data:image/png;base64,iVBORw==","caption":"png"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn image_id_in_cell_survives_lift() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/img.png".to_string(),
+                },
+                alt: None,
+                title: None,
+                decorative: false,
+                id: Some("img-99".to_string()),
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"id":"img-99","type":"image","props":{"url":"https://example.com/img.png","caption":""},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn image_inside_nested_table_cell_lifts_after_nested_table() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/nested.png".to_string(),
+                },
+                alt: Some("nested".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/nested.png","caption":"nested"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn outer_cell_image_and_nested_cell_image_lift_in_document_order() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/outer.png".to_string(),
+                },
+                alt: Some("outer".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/nested.png".to_string(),
+                },
+                alt: Some("nested".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/outer.png","caption":"outer"},"content":null,"children":[]},{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/nested.png","caption":"nested"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn image_inside_header_cell_lifts_after_table() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            Event::StartTableHeader {
+                id: None,
+                scope: None,
+                abbr: None,
+                colspan: None,
+                rowspan: None,
+            },
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/header.png".to_string(),
+                },
+                alt: Some("header".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableHeader,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/header.png","caption":"header"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn two_separate_tables_each_lift_their_own_in_cell_image() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/t1.png".to_string(),
+                },
+                alt: Some("t1".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/t2.png".to_string(),
+                },
+                alt: Some("t2".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/t1.png","caption":"t1"},"content":null,"children":[]},{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/t2.png","caption":"t2"},"content":null,"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn image_inside_paragraph_inside_cell_lifts_after_table() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            start_paragraph(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/wrapped.png".to_string(),
+                },
+                alt: Some("wrapped".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndParagraph,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/wrapped.png","caption":"wrapped"},"content":null,"children":[]}]"#
         );
     }
 


### PR DESCRIPTION
Images inside table cells were silently dropped (BlockNote's `tableCell.content` is `InlineContent[]`). They are now lifted as top-level sibling blocks after the enclosing outermost table closes, mirroring the existing nested-table lift.