### PR TITLE
feat(blocknote-writer): propagate colspan and rowspan to tableCell props

### DIFF
--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -796,13 +796,47 @@ impl<W: Write> BlockNoteWriter<W> {
         self.json.key("cells").open_array()
     }
 
-    fn handle_table_cell(&mut self, id: Option<&str>) -> Result<()> {
+    fn handle_start_table_cell_event(&mut self, event: Event) -> Result<()> {
+        match event {
+            Event::StartTableCell {
+                colspan,
+                id,
+                rowspan,
+                ..
+            }
+            | Event::StartTableHeader {
+                colspan,
+                id,
+                rowspan,
+                ..
+            } => self.handle_table_cell(id.as_deref(), colspan, rowspan),
+            _ => Ok(()),
+        }
+    }
+
+    fn handle_table_cell(
+        &mut self,
+        id: Option<&str>,
+        colspan: Option<u32>,
+        rowspan: Option<u32>,
+    ) -> Result<()> {
         if self.drop_inside_list_depth.is_positive() {
             return Ok(());
         }
         self.json.open_object()?;
         self.json.key("type").value("tableCell")?;
         self.write_id(id)?;
+        if colspan.is_some() || rowspan.is_some() {
+            self.json.key("props").object(|j| {
+                if let Some(n) = colspan {
+                    j.key("colspan").value(n)?;
+                }
+                if let Some(n) = rowspan {
+                    j.key("rowspan").value(n)?;
+                }
+                Ok(())
+            })?;
+        }
         self.json.key("content").open_array()?;
         self.context.in_table_cell = true;
         self.context.in_text_block = false;
@@ -1174,8 +1208,8 @@ impl<W: Write> EventSink for BlockNoteWriter<W> {
             Event::EndTable => self.handle_end_table(),
             Event::StartTableRow { id, .. } => self.handle_start_table_row(id.as_deref()),
             Event::EndTableRow => self.handle_end_table_row(),
-            Event::StartTableCell { id, .. } | Event::StartTableHeader { id, .. } => {
-                self.handle_table_cell(id.as_deref())
+            event @ (Event::StartTableCell { .. } | Event::StartTableHeader { .. }) => {
+                self.handle_start_table_cell_event(event)
             }
             Event::EndTableCell | Event::EndTableHeader => self.handle_end_table_cell(),
             Event::StartLink { href, .. } => self.handle_start_link(&href),

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -2412,6 +2412,100 @@ mod tests {
     }
 
     #[test]
+    fn table_cell_with_colspan_emits_props_with_colspan() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            Event::StartTableCell {
+                colspan: Some(3),
+                id: None,
+                rowspan: None,
+            },
+            text("merged"),
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","props":{"colspan":3},"content":[{"type":"text","text":"merged","styles":{}}]}]}]},"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn table_cell_with_rowspan_emits_props_with_rowspan() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            Event::StartTableCell {
+                colspan: None,
+                id: None,
+                rowspan: Some(2),
+            },
+            text("merged"),
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","props":{"rowspan":2},"content":[{"type":"text","text":"merged","styles":{}}]}]}]},"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn table_cell_with_colspan_and_rowspan_emits_both_props() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            Event::StartTableCell {
+                colspan: Some(3),
+                id: None,
+                rowspan: Some(2),
+            },
+            text("merged"),
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","props":{"colspan":3,"rowspan":2},"content":[{"type":"text","text":"merged","styles":{}}]}]}]},"children":[]}]"#
+        );
+    }
+
+    #[test]
+    fn table_header_cell_with_colspan_emits_props_with_colspan() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            Event::StartTableHeader {
+                abbr: None,
+                colspan: Some(2),
+                id: None,
+                rowspan: None,
+                scope: None,
+            },
+            text("H"),
+            Event::EndTableHeader,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","props":{"colspan":2},"content":[{"type":"text","text":"H","styles":{}}]}]}]},"children":[]}]"#
+        );
+    }
+
+    #[test]
     fn table_preceded_by_paragraph_closes_paragraph() {
         let json = run_events(&[
             start_document(),


### PR DESCRIPTION
Reader already emits `colspan` / `rowspan` on `StartTableCell` / `StartTableHeader`; writer now forwards them as a `props` object on the emitted `tableCell`. Default (both `None`) is unchanged, so existing snapshots stay green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table cells now support colspan and rowspan attributes. The writer correctly emits these span dimensions in the output properties for both header and data cells, enabling more flexible and complex table layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->