### PR TITLE
feat(docx-reader): effective numPr resolution via pStyle chain

### DIFF
--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -155,6 +155,10 @@ pub struct DocumentReader {
     in_ppr: bool,
     /// Paragraph alignment captured from `<w:jc>` while inside `<w:pPr>`.
     pending_paragraph_alignment: Option<TextAlignment>,
+    /// Raw `<w:pStyle>` identifier for the current paragraph, retained for
+    /// effective numPr resolution via `StyleList::resolve_num_pr`.
+    /// Set by the `pStyle` attribute handler; cleared in `start_paragraph()`.
+    pending_paragraph_style_id: Option<String>,
     /// Style classification pending for the current paragraph, set by `<w:pStyle>` parsing.
     /// Consumed and cleared by `ensure_paragraph_started()`.
     pending_paragraph_classification: Option<crate::styles::StyleClassification>,
@@ -276,6 +280,10 @@ impl fmt::Debug for DocumentReader {
                 "pending_paragraph_classification",
                 &self.pending_paragraph_classification,
             )
+            .field(
+                "pending_paragraph_style_id",
+                &self.pending_paragraph_style_id,
+            )
             .field("current_paragraph_block", &self.current_paragraph_block)
             .field(
                 "pending_preformatted_close",
@@ -349,6 +357,7 @@ impl DocumentReader {
             in_text: false,
             in_ppr: false,
             pending_paragraph_alignment: None,
+            pending_paragraph_style_id: None,
             pending_paragraph_classification: None,
             current_paragraph_block: ParagraphBlockKind::Paragraph,
             pending_preformatted_close: false,
@@ -400,8 +409,7 @@ impl DocumentReader {
         }
     }
 
-    #[cfg(test)]
-    #[cfg(test)]
+    #[cfg(all(test, not(coverage)))]
     #[allow(clippy::expect_used, clippy::as_conversions)]
     pub(crate) fn from_xml_reader(
         xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
@@ -493,6 +501,7 @@ impl DocumentReader {
         self.pending_num_pr_ilvl = None;
         self.pending_paragraph_list = None;
         self.pending_paragraph_alignment = None;
+        self.pending_paragraph_style_id = None;
         self.pending_paragraph_classification = None;
         self.current_paragraph_block = ParagraphBlockKind::Paragraph;
         self.paragraph_started_emitted = false;
@@ -781,9 +790,11 @@ impl DocumentReader {
                     val.as_deref().and_then(properties::parse_alignment);
             }
             b"pStyle" if self.in_ppr && !self.paragraph_started_emitted => {
-                self.pending_paragraph_classification = read_val_attribute(tag)
-                    .filter(|s| !s.is_empty())
-                    .and_then(|s| self.data.style_list.classify(&s));
+                let style_id = read_val_attribute(tag).filter(|s| !s.is_empty());
+                self.pending_paragraph_style_id = style_id.clone();
+                self.pending_paragraph_classification = style_id
+                    .as_deref()
+                    .and_then(|s| self.data.style_list.classify(s));
             }
             b"numId" if self.in_numpr => {
                 if let Some(val) = read_val_attribute(tag) {
@@ -1542,6 +1553,7 @@ impl DocumentReader {
         self.pending_text.clear();
         self.paragraph_started_emitted = false;
         self.pending_paragraph_alignment = None;
+        self.pending_paragraph_style_id = None;
         self.pending_paragraph_classification = None;
         self.pending_paragraph_list = None;
         self.current_paragraph_block = ParagraphBlockKind::Paragraph;
@@ -1559,6 +1571,7 @@ impl DocumentReader {
                     self.pending_preformatted_close = false;
                     self.current_paragraph_block = ParagraphBlockKind::Preformatted;
                     self.paragraph_started_emitted = true;
+                    self.pending_paragraph_style_id = None;
                     self.pending_paragraph_classification = None;
                     return;
                 }
@@ -1566,16 +1579,39 @@ impl DocumentReader {
             }
 
             let list_classification = match self.pending_paragraph_list.take() {
-                None => None,
                 Some((num_id, raw_ilvl)) => {
+                    // Branch 1 & 2: direct numPr present.
+                    // numbering.resolve(0, _) already returns is_list:false, so
+                    // numId=0 (ECMA-376 §17.9.18 explicit clear) is handled here.
                     let ilvl = core::cmp::min(raw_ilvl, MAX_LIST_LEVEL);
                     let result = self.data.numbering.resolve(num_id, ilvl);
                     result
                         .is_list
                         .then_some((num_id, ilvl, result.is_ordered, result.style_type))
                 }
+                None => {
+                    // Branch 3: no direct numPr — resolve via pStyle chain.
+                    match self
+                        .pending_paragraph_style_id
+                        .as_deref()
+                        .and_then(|sid| self.data.style_list.resolve_num_pr(sid))
+                    {
+                        Some((num_id, raw_ilvl)) => {
+                            let ilvl = core::cmp::min(raw_ilvl, MAX_LIST_LEVEL);
+                            let result = self.data.numbering.resolve(num_id, ilvl);
+                            result.is_list.then_some((
+                                num_id,
+                                ilvl,
+                                result.is_ordered,
+                                result.style_type,
+                            ))
+                        }
+                        None => None,
+                    }
+                }
             };
 
+            self.pending_paragraph_style_id = None;
             let kind = match self.pending_paragraph_classification.take() {
                 Some(crate::styles::StyleClassification::Heading { level }) => {
                     self.flush_list_stack();
@@ -1591,10 +1627,12 @@ impl DocumentReader {
                 }
                 _ => match list_classification {
                     None => {
-                        // Intentional: do NOT flush the list stack here. A plain paragraph
-                        // following a list item attaches as continuation content of the
-                        // open item. The list closes only at heading / block quote /
-                        // preformatted / table boundary / cell boundary / end of document.
+                        // Spec-compliant: a paragraph with no effective numPr (neither
+                        // direct <w:numPr> nor via the pStyle → basedOn chain) closes
+                        // any open list. The previous continuation-paragraph heuristic
+                        // was removed in favour of pStyle-chain numPr resolution
+                        // (see `styles::StyleList::resolve_num_pr`).
+                        self.flush_list_stack();
                         ParagraphBlockKind::Paragraph
                     }
                     Some((num_id, ilvl, is_ordered, style_type)) => {
@@ -3103,7 +3141,7 @@ mod tests {
     }
 
     #[test]
-    fn non_list_paragraph_between_list_items_attaches_as_continuation() {
+    fn non_list_paragraph_between_list_items_closes_and_reopens_list() {
         let body = format!(
             "{}{}{}",
             list_paragraph(1, 0, "one"),
@@ -3135,6 +3173,7 @@ mod tests {
                     content: "one".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartParagraph {
                     alignment: None,
                     id: None,
@@ -3143,7 +3182,6 @@ mod tests {
                     content: "plain".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
-                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartOrderedListItem {
                     id: Some("1".to_string()),
                     level: 0,
@@ -3542,7 +3580,7 @@ mod tests {
     }
 
     #[test]
-    fn multiple_continuation_paragraphs_attach_to_same_item() {
+    fn multiple_plain_paragraphs_after_list_item_are_siblings() {
         let body = format!(
             "{}{}{}{}",
             list_paragraph(1, 0, "one"),
@@ -3575,6 +3613,7 @@ mod tests {
                     content: "one".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartParagraph {
                     alignment: None,
                     id: None,
@@ -3591,7 +3630,6 @@ mod tests {
                     content: "second continuation".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
-                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartOrderedListItem {
                     id: Some("1".to_string()),
                     level: 0,
@@ -3613,7 +3651,7 @@ mod tests {
     }
 
     #[test]
-    fn trailing_continuation_paragraphs_close_with_list_at_document_end() {
+    fn trailing_plain_paragraphs_close_list_before_document_end() {
         let body = format!(
             "{}{}{}",
             list_paragraph(1, 0, "one"),
@@ -3645,6 +3683,7 @@ mod tests {
                     content: "one".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartParagraph {
                     alignment: None,
                     id: None,
@@ -3661,14 +3700,13 @@ mod tests {
                     content: "trailing second".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
-                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::EndDocument,
             ]
         );
     }
 
     #[test]
-    fn continuation_then_deeper_level_nests_under_continuation_owner() {
+    fn plain_paragraph_then_deeper_level_reopens_with_phantom_parent() {
         let body = format!(
             "{}{}{}",
             list_paragraph(1, 0, "outer"),
@@ -3700,6 +3738,7 @@ mod tests {
                     content: "outer".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartParagraph {
                     alignment: None,
                     id: None,
@@ -3708,6 +3747,12 @@ mod tests {
                     content: "continuation".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
+                docspec_core::Event::StartOrderedListItem {
+                    id: Some("1".to_string()),
+                    level: 0,
+                    start: None,
+                    style_type: ListStyleType::Decimal,
+                },
                 docspec_core::Event::StartOrderedListItem {
                     id: Some("1".to_string()),
                     level: 1,
@@ -3730,7 +3775,7 @@ mod tests {
     }
 
     #[test]
-    fn continuation_paragraph_inside_table_cell_attaches_then_cell_end_closes_list() {
+    fn plain_paragraph_inside_table_cell_closes_list_before_cell_end() {
         let body = format!(
             "<w:tbl><w:tr><w:tc>{}{}</w:tc></w:tr></w:tbl>",
             list_paragraph(1, 0, "cell item"),
@@ -3768,6 +3813,7 @@ mod tests {
                     content: "cell item".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartParagraph {
                     alignment: None,
                     id: None,
@@ -3776,7 +3822,6 @@ mod tests {
                     content: "continuation".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
-                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::EndTableCell,
                 docspec_core::Event::EndTableRow,
                 docspec_core::Event::EndTable,
@@ -3895,7 +3940,7 @@ mod tests {
     }
 
     #[test]
-    fn calibre_demo_continued_lists_pattern_produces_continuous_numbering() {
+    fn calibre_demo_interrupted_list_reopens_with_continuous_numbering() {
         let body = format!(
             "{}{}{}{}{}",
             list_paragraph(7, 0, "One"),
@@ -3955,6 +4000,7 @@ mod tests {
                     content: "Two".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
+                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartParagraph {
                     alignment: None,
                     id: None,
@@ -3963,7 +4009,6 @@ mod tests {
                     content: "An interruption in our regularly scheduled listing, for this essential and very relevant public service announcement.".to_string(),
                 },
                 docspec_core::Event::EndParagraph,
-                docspec_core::Event::EndOrderedListItem,
                 docspec_core::Event::StartOrderedListItem {
                     id: Some("7".to_string()),
                     level: 0,

--- a/crates/docspec-docx-reader/src/styles.rs
+++ b/crates/docspec-docx-reader/src/styles.rs
@@ -31,6 +31,13 @@ pub struct Style {
     kind: StyleType,
     name: Option<String>,
     based_on: Option<String>,
+    /// Paragraph numbering properties from `<w:pPr><w:numPr>`.
+    ///
+    /// Stored as `(num_id, ilvl)`. `Some((0, 0))` represents Word's explicit
+    /// numbering clear signal for `w:numId="0"`; the level is normalized to
+    /// zero because MS-OE376 §2.3.1.19 documents Word's deviation allowing
+    /// `<w:ilvl>` in style definitions.
+    pub num_pr: Option<(u32, u32)>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -125,7 +132,32 @@ impl StyleList {
             current = self.get_by_id(current.based_on.as_deref()?)?;
         }
     }
+
+    /// Walk the `pStyle` → `basedOn` chain to find the effective `numPr`.
+    ///
+    /// Returns the first style in the chain whose `num_pr` is `Some`. If that
+    /// style has `num_id == 0`, returns `Some((0, 0))` and stops because Word
+    /// uses `w:numId="0"` as an explicit numbering clear signal.
+    pub fn resolve_num_pr(&self, style_id: &str) -> Option<(u32, u32)> {
+        let mut visited: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        let mut current = self.get_by_id(style_id)?;
+        loop {
+            if !visited.insert(current.id.as_str()) {
+                return None;
+            }
+            if let Some((num_id, ilvl)) = current.num_pr {
+                return if num_id == 0 {
+                    Some((0, 0))
+                } else {
+                    Some((num_id, ilvl))
+                };
+            }
+            current = self.get_by_id(current.based_on.as_deref()?)?;
+        }
+    }
 }
+
+const _: fn(&StyleList, &str) -> Option<(u32, u32)> = StyleList::resolve_num_pr;
 
 fn parse_style_body<R: std::io::BufRead>(
     xml_reader: &mut quick_xml::Reader<R>,
@@ -135,6 +167,7 @@ fn parse_style_body<R: std::io::BufRead>(
 ) -> Result<Style> {
     let mut name: Option<String> = None;
     let mut based_on: Option<String> = None;
+    let mut num_pr: Option<(u32, u32)> = None;
 
     loop {
         match xml_reader.read_event_into(buf) {
@@ -146,6 +179,11 @@ fn parse_style_body<R: std::io::BufRead>(
             Ok(Event::Empty(elem)) if elem.local_name().as_ref() == b"basedOn" => {
                 if let Some(value) = get_attr(&elem, b"val")?.filter(|s| !s.is_empty()) {
                     based_on = Some(value);
+                }
+            }
+            Ok(Event::Start(elem)) if elem.local_name().as_ref() == b"pPr" => {
+                if let Some(value) = parse_ppr_body(xml_reader, buf)? {
+                    num_pr = Some(value);
                 }
             }
             Ok(Event::End(elem)) if elem.local_name().as_ref() == b"style" => break,
@@ -164,7 +202,107 @@ fn parse_style_body<R: std::io::BufRead>(
         kind,
         name,
         based_on,
+        num_pr,
     })
+}
+
+fn parse_ppr_body<R: std::io::BufRead>(
+    xml_reader: &mut quick_xml::Reader<R>,
+    buf: &mut Vec<u8>,
+) -> Result<Option<(u32, u32)>> {
+    let mut num_pr: Option<(u32, u32)> = None;
+
+    loop {
+        match xml_reader.read_event_into(buf) {
+            Ok(Event::Start(elem)) if elem.local_name().as_ref() == b"numPr" => {
+                if let Some(value) = parse_numpr_body(xml_reader, buf)? {
+                    num_pr = Some(value);
+                }
+            }
+            Ok(Event::Empty(elem)) if elem.local_name().as_ref() == b"numPr" => {}
+            Ok(Event::End(elem)) if elem.local_name().as_ref() == b"pPr" => break,
+            Ok(Event::Start(_)) => drain_element(xml_reader, buf)?,
+            Ok(Event::Eof) => {
+                return Err(parse_error("unexpected EOF inside <w:pPr>".to_string()));
+            }
+            Err(err) => {
+                return Err(parse_error(format!("malformed styles.xml: {err}")));
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+
+    Ok(num_pr)
+}
+
+fn parse_numpr_body<R: std::io::BufRead>(
+    xml_reader: &mut quick_xml::Reader<R>,
+    buf: &mut Vec<u8>,
+) -> Result<Option<(u32, u32)>> {
+    let mut num_id: Option<u32> = None;
+    let mut ilvl: Option<u32> = None;
+
+    loop {
+        match xml_reader.read_event_into(buf) {
+            Ok(Event::Empty(elem)) if elem.local_name().as_ref() == b"numId" => {
+                if let Some(value) = get_attr(&elem, b"val")? {
+                    if let Ok(parsed) = value.parse::<u32>() {
+                        num_id = Some(parsed);
+                    }
+                }
+            }
+            Ok(Event::Empty(elem)) if elem.local_name().as_ref() == b"ilvl" => {
+                if let Some(value) = get_attr(&elem, b"val")? {
+                    if let Ok(parsed) = value.parse::<u32>() {
+                        ilvl = Some(parsed);
+                    }
+                }
+            }
+            Ok(Event::End(elem)) if elem.local_name().as_ref() == b"numPr" => break,
+            Ok(Event::Start(_)) => drain_element(xml_reader, buf)?,
+            Ok(Event::Eof) => {
+                return Err(parse_error("unexpected EOF inside <w:numPr>".to_string()));
+            }
+            Err(err) => {
+                return Err(parse_error(format!("malformed styles.xml: {err}")));
+            }
+            Ok(_) => {}
+        }
+        buf.clear();
+    }
+
+    Ok(num_id.map(|id| {
+        if id == 0 {
+            (0, 0)
+        } else {
+            (id, ilvl.unwrap_or(0))
+        }
+    }))
+}
+
+fn drain_element<R: std::io::BufRead>(
+    xml_reader: &mut quick_xml::Reader<R>,
+    buf: &mut Vec<u8>,
+) -> Result<()> {
+    let mut depth: u32 = 1;
+
+    while depth > 0 {
+        buf.clear();
+        match xml_reader.read_event_into(buf) {
+            Ok(Event::Start(_)) => depth = depth.saturating_add(1),
+            Ok(Event::End(_)) => depth = depth.saturating_sub(1),
+            Ok(Event::Eof) => {
+                return Err(parse_error("unexpected EOF inside XML element".to_string()));
+            }
+            Err(err) => {
+                return Err(parse_error(format!("malformed styles.xml: {err}")));
+            }
+            Ok(_) => {}
+        }
+    }
+
+    Ok(())
 }
 
 fn get_attr(elem: &quick_xml::events::BytesStart<'_>, name: &[u8]) -> Result<Option<String>> {
@@ -235,6 +373,7 @@ mod tests {
                         kind: StyleType::Paragraph,
                         name: Some("Normal".to_string()),
                         based_on: None,
+                        num_pr: None,
                     }],
                 }
             ),
@@ -262,6 +401,7 @@ mod tests {
                         kind: StyleType::Paragraph,
                         name: Some("heading 1".to_string()),
                         based_on: Some("Normal".to_string()),
+                        num_pr: None,
                     }],
                 }
             ),
@@ -292,12 +432,14 @@ mod tests {
                             kind: StyleType::Character,
                             name: Some("Default Paragraph Font".to_string()),
                             based_on: None,
+                            num_pr: None,
                         },
                         Style {
                             id: "Normal".to_string(),
                             kind: StyleType::Paragraph,
                             name: Some("Normal".to_string()),
                             based_on: None,
+                            num_pr: None,
                         },
                     ],
                 }
@@ -312,6 +454,22 @@ mod tests {
             kind: StyleType::Paragraph,
             name: name.map(str::to_string),
             based_on: based_on.map(str::to_string),
+            num_pr: None,
+        }
+    }
+
+    fn paragraph_with_num_pr(
+        id: &str,
+        name: Option<&str>,
+        based_on: Option<&str>,
+        num_pr: Option<(u32, u32)>,
+    ) -> Style {
+        Style {
+            id: id.to_string(),
+            kind: StyleType::Paragraph,
+            name: name.map(str::to_string),
+            based_on: based_on.map(str::to_string),
+            num_pr,
         }
     }
 
@@ -321,6 +479,194 @@ mod tests {
             kind: StyleType::Character,
             name: name.map(str::to_string),
             based_on: based_on.map(str::to_string),
+            num_pr: None,
+        }
+    }
+
+    #[test]
+    fn test_style_with_numpr_stores_pair() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="ListParagraph">
+                 <w:pPr>
+                   <w:numPr>
+                     <w:numId w:val="3"/>
+                     <w:ilvl w:val="0"/>
+                   </w:numPr>
+                 </w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(
+                list.get_by_id("ListParagraph"),
+                Some(&paragraph_with_num_pr(
+                    "ListParagraph",
+                    None,
+                    None,
+                    Some((3, 0))
+                ))
+            ),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected style numPr pair"),
+        }
+    }
+
+    #[test]
+    fn test_style_with_numid_zero_and_ilvl_stores_zero_pair() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="ClearList">
+                 <w:pPr>
+                   <w:numPr>
+                     <w:numId w:val="0"/>
+                     <w:ilvl w:val="2"/>
+                   </w:numPr>
+                 </w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(
+                list.get_by_id("ClearList"),
+                Some(&paragraph_with_num_pr(
+                    "ClearList",
+                    None,
+                    None,
+                    Some((0, 0))
+                ))
+            ),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected numId zero clear"),
+        }
+    }
+
+    #[test]
+    fn test_style_with_numid_zero_no_ilvl_stores_zero_pair() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="ClearList">
+                 <w:pPr>
+                   <w:numPr>
+                     <w:numId w:val="0"/>
+                   </w:numPr>
+                 </w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(
+                list.get_by_id("ClearList"),
+                Some(&paragraph_with_num_pr(
+                    "ClearList",
+                    None,
+                    None,
+                    Some((0, 0))
+                ))
+            ),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected numId zero without ilvl"),
+        }
+    }
+
+    #[test]
+    fn test_style_with_numid_only_defaults_ilvl_to_zero() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="ListParagraph">
+                 <w:pPr>
+                   <w:numPr>
+                     <w:numId w:val="3"/>
+                   </w:numPr>
+                 </w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(
+                list.get_by_id("ListParagraph"),
+                Some(&paragraph_with_num_pr(
+                    "ListParagraph",
+                    None,
+                    None,
+                    Some((3, 0))
+                ))
+            ),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected default ilvl zero"),
+        }
+    }
+
+    #[test]
+    fn test_style_with_empty_numpr_stores_none() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="NoList">
+                 <w:pPr><w:numPr/></w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(
+                list.get_by_id("NoList"),
+                Some(&paragraph_with_num_pr("NoList", None, None, None))
+            ),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected empty numPr as none"),
+        }
+    }
+
+    #[test]
+    fn test_style_with_only_ilvl_stores_none() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="MalformedList">
+                 <w:pPr>
+                   <w:numPr><w:ilvl w:val="2"/></w:numPr>
+                 </w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(
+                list.get_by_id("MalformedList"),
+                Some(&paragraph_with_num_pr("MalformedList", None, None, None))
+            ),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected ilvl only as none"),
+        }
+    }
+
+    #[test]
+    fn test_parse_continues_after_unknown_nested_element() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="ListParagraph">
+                 <w:pPr>
+                   <w:numPr>
+                     <w:numId w:val="3"/>
+                     <w:unknown><w:child/></w:unknown>
+                     <w:ilvl w:val="1"/>
+                   </w:numPr>
+                 </w:pPr>
+               </w:style>
+               <w:style w:type="paragraph" w:styleId="NextStyle">
+                 <w:name w:val="Next Style"/>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(
+                list,
+                StyleList {
+                    styles: vec![
+                        paragraph_with_num_pr("ListParagraph", None, None, Some((3, 1))),
+                        paragraph("NextStyle", Some("Next Style"), None),
+                    ],
+                }
+            ),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected stream alignment"),
         }
     }
 
@@ -534,6 +880,110 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_no_pstyle_returns_none() {
+        assert_eq!(StyleList::default().resolve_num_pr("Missing"), None);
+    }
+
+    #[test]
+    fn test_resolve_style_with_direct_numpr_returns_pair() {
+        let list = StyleList {
+            styles: vec![paragraph_with_num_pr("List", None, None, Some((3, 1)))],
+        };
+
+        assert_eq!(list.resolve_num_pr("List"), Some((3, 1)));
+    }
+
+    #[test]
+    fn test_resolve_style_with_numid_zero_terminates_walk_returns_zero_pair() {
+        let list = StyleList {
+            styles: vec![
+                paragraph_with_num_pr("Base", None, None, Some((3, 1))),
+                paragraph_with_num_pr("Clear", None, Some("Base"), Some((0, 0))),
+            ],
+        };
+
+        assert_eq!(list.resolve_num_pr("Clear"), Some((0, 0)));
+    }
+
+    #[test]
+    fn test_resolve_basedon_has_numpr_returns_parent_numpr() {
+        let list = StyleList {
+            styles: vec![
+                paragraph_with_num_pr("Base", None, None, Some((4, 2))),
+                paragraph("Child", None, Some("Base")),
+            ],
+        };
+
+        assert_eq!(list.resolve_num_pr("Child"), Some((4, 2)));
+    }
+
+    #[test]
+    fn test_resolve_basedon_chain_depth_three_returns_deepest() {
+        let list = StyleList {
+            styles: vec![
+                paragraph_with_num_pr("Grandparent", None, None, Some((7, 3))),
+                paragraph("Parent", None, Some("Grandparent")),
+                paragraph("Child", None, Some("Parent")),
+            ],
+        };
+
+        assert_eq!(list.resolve_num_pr("Child"), Some((7, 3)));
+    }
+
+    #[test]
+    fn test_resolve_basedon_cycle_returns_none_no_panic() {
+        let list = StyleList {
+            styles: vec![
+                paragraph("A", None, Some("B")),
+                paragraph("B", None, Some("A")),
+            ],
+        };
+
+        assert_eq!(list.resolve_num_pr("A"), None);
+    }
+
+    #[test]
+    fn test_resolve_missing_style_id_returns_none() {
+        let list = StyleList {
+            styles: vec![paragraph_with_num_pr("Known", None, None, Some((3, 0)))],
+        };
+
+        assert_eq!(list.resolve_num_pr("Missing"), None);
+    }
+
+    #[test]
+    fn test_resolve_style_with_ilvl_only_returns_none() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="MalformedList">
+                 <w:pPr><w:numPr><w:ilvl w:val="2"/></w:numPr></w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(list.resolve_num_pr("MalformedList"), None),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected ilvl only style"),
+        }
+    }
+
+    #[test]
+    fn test_resolve_style_with_empty_numpr_returns_none() {
+        let xml = styles_xml(
+            r#"<w:style w:type="paragraph" w:styleId="NoList">
+                 <w:pPr><w:numPr/></w:pPr>
+               </w:style>"#,
+        );
+
+        let result = StyleList::parse(Cursor::new(xml.into_bytes()));
+
+        match result {
+            Ok(list) => assert_eq!(list.resolve_num_pr("NoList"), None),
+            Err(err) => assert_eq!(format!("{err:?}"), "expected empty numPr style"),
+        }
+    }
+
+    #[test]
     fn classify_returns_none_for_paragraph_style_named_html_preformatted() {
         let list = StyleList {
             styles: vec![paragraph(
@@ -579,12 +1029,14 @@ mod tests {
                             kind: StyleType::Paragraph,
                             name: Some("Normal".to_string()),
                             based_on: None,
+                            num_pr: None,
                         },
                         Style {
                             id: "Heading1".to_string(),
                             kind: StyleType::Paragraph,
                             name: Some("heading 1".to_string()),
                             based_on: Some("Normal".to_string()),
+                            num_pr: None,
                         },
                     ],
                 }

--- a/crates/docspec-docx-reader/tests/reader.rs
+++ b/crates/docspec-docx-reader/tests/reader.rs
@@ -1763,7 +1763,7 @@ mod events {
 
         assert_eq!(
             format!("{reader:?}"),
-            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, current_paragraph_block: Paragraph, pending_preformatted_close: false, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", hyperlink_map: {}, hyperlink_depth: 0, pending_link: None, list_stack: [], seen_lists: {}, pending_paragraph_list: None, in_numpr: false, pending_num_pr_id: None, pending_num_pr_ilvl: None, xml: \"<quick_xml::Reader>\", archive: \"<Arc<Mutex<ZipArchive>>>\", content_types: \"<Arc<ContentTypes>>\" } }"
+            "DocxReader { inner: DocumentReader { buf: [], denied_stack: [], in_paragraph: false, in_text: false, in_ppr: false, pending_paragraph_alignment: None, pending_paragraph_classification: None, pending_paragraph_style_id: None, current_paragraph_block: Paragraph, pending_preformatted_close: false, paragraph_started_emitted: false, in_rpr: false, pending_run_kinds: [], pending_run_text_color: None, pending_run_mark: None, pending_run_shade: None, pending_text: \"\", frozen_run_kinds: [], frozen_run_text_color: None, frozen_run_mark: None, pending_run_font: None, frozen_run_font: None, open_styles: [], phase: \"<phase>\", queue: [], run_content_emitted: false, data: \"<DocxData>\", hyperlink_map: {}, hyperlink_depth: 0, pending_link: None, list_stack: [], seen_lists: {}, pending_paragraph_list: None, in_numpr: false, pending_num_pr_id: None, pending_num_pr_ilvl: None, xml: \"<quick_xml::Reader>\", archive: \"<Arc<Mutex<ZipArchive>>>\", content_types: \"<Arc<ContentTypes>>\" } }"
         );
     }
 
@@ -7123,7 +7123,7 @@ mod cross_feature_lists {
     }
 
     #[test]
-    fn same_num_id_continuation_paragraph_attaches_and_second_item_keeps_start_none() {
+    fn same_num_id_continuation_paragraph_splits_list_and_second_item_keeps_start_none() {
         let document_xml = r#"<?xml version="1.0" encoding="UTF-8"?>
 <w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
   <w:body>
@@ -7143,10 +7143,10 @@ mod cross_feature_lists {
                 start_paragraph(),
                 text("one"),
                 Event::EndParagraph,
+                Event::EndOrderedListItem,
                 start_paragraph(),
                 text("break"),
                 Event::EndParagraph,
-                Event::EndOrderedListItem,
                 start_ordered("1", None),
                 start_paragraph(),
                 text("two"),

--- a/tests/fixtures/ATTRIBUTION.md
+++ b/tests/fixtures/ATTRIBUTION.md
@@ -19,6 +19,13 @@ indicated.
 | Fixture | Primary event coverage |
 |---------|------------------------|
 | `preformatted-boundaries.docx` | Consecutive code-styled paragraphs consolidated into one `StartPreformatted` / `EndPreformatted` block separated by `LineBreak` events; clean closure before regular paragraphs, headings, block quotes, list items, tables, and table cells; consecutive code paragraphs inside a table cell. |
+| `list_then_paragraph_same_style.docx` | Minimized synthetic reduction inspired by real-world DOCX upload 696c51d02b… — content scrubbed; structure preserved for regression testing of numPr resolution. |
+| `list_then_paragraph_style_change.docx` | Minimized synthetic reduction inspired by real-world DOCX upload e2b582ff09… — content scrubbed; structure preserved for regression testing of numPr resolution. |
+| `style_inherited_numpr.docx` | Synthetic fixture for testing style-inherited numPr resolution. |
+| `basedon_chain_numpr.docx` | Synthetic fixture for testing basedOn chain numPr resolution. |
+| `numid_zero_direct_clear.docx` | Synthetic fixture for testing numId=0 direct clear over style-inherited numPr. |
+| `numid_zero_style_chain.docx` | Synthetic fixture for testing numId=0 in style chain termination. |
+| `basedon_cycle.docx` | Synthetic fixture for testing basedOn cycle graceful degradation. |
 
 ## Pandoc DOCX Test Suite (`docx/pandoc/`)
 

--- a/tests/fixtures/docx/docspec/basedon_chain_numpr.docx
+++ b/tests/fixtures/docx/docspec/basedon_chain_numpr.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b0d03dc2071474466862e82cac36b6441146c37a1ad86011e333adc85ca9121
+size 2036

--- a/tests/fixtures/docx/docspec/basedon_cycle.docx
+++ b/tests/fixtures/docx/docspec/basedon_cycle.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3760a5d0d972a1685f4011da550a70302bd7b0887398e9d47786b06dec452c1f
+size 1616

--- a/tests/fixtures/docx/docspec/list_then_paragraph_same_style.docx
+++ b/tests/fixtures/docx/docspec/list_then_paragraph_same_style.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f234428f47728e28b54cfee075dc53b32e5dcebfa53f04af04cfb2da866fb152
+size 2035

--- a/tests/fixtures/docx/docspec/list_then_paragraph_style_change.docx
+++ b/tests/fixtures/docx/docspec/list_then_paragraph_style_change.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d8f803b252a8da2563993e1cf2bfa3f32530b4e654d5c2aae498c19b3de135c
+size 2052

--- a/tests/fixtures/docx/docspec/numid_zero_direct_clear.docx
+++ b/tests/fixtures/docx/docspec/numid_zero_direct_clear.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f145b3d6174cf2eefb07809f6fcc9c4a95e4db7624e3c1d2cb8a24139ea5bb0e
+size 2045

--- a/tests/fixtures/docx/docspec/numid_zero_style_chain.docx
+++ b/tests/fixtures/docx/docspec/numid_zero_style_chain.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d07a54b348ca0c23bc81033b2789f84d9885ce3577c21cbad8a2b6642f825661
+size 2046

--- a/tests/fixtures/docx/docspec/style_inherited_numpr.docx
+++ b/tests/fixtures/docx/docspec/style_inherited_numpr.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6b8221f9999c78476ad5f12106801f64c66509543e452789bec30ff9cff20851
+size 2015

--- a/tests/snapshots/docx/apache-tika/testWORD_numbered_list.docx.snap
+++ b/tests/snapshots/docx/apache-tika/testWORD_numbered_list.docx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
 expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
@@ -121,14 +122,14 @@ ReaderFixtureSnapshot {
      114: StartParagraph { alignment: None, id: None }
      115: Text { content: "baz" }
      116: EndParagraph
-     117: StartParagraph { alignment: None, id: None }
-     118: EndParagraph
-     119: StartParagraph { alignment: None, id: None }
-     120: Text { content: "This is another list" }
+     117: EndOrderedListItem
+     118: EndOrderedListItem
+     119: EndOrderedListItem
+     120: StartParagraph { alignment: None, id: None }
      121: EndParagraph
-     122: EndOrderedListItem
-     123: EndOrderedListItem
-     124: EndOrderedListItem
+     122: StartParagraph { alignment: None, id: None }
+     123: Text { content: "This is another list" }
+     124: EndParagraph
      125: StartOrderedListItem { id: Some("2"), level: 0, start: Some(1), style_type: UpperRoman }
      126: StartParagraph { alignment: None, id: None }
      127: Text { content: "yet" }
@@ -141,243 +142,247 @@ ReaderFixtureSnapshot {
      134: StartParagraph { alignment: None, id: None }
      135: Text { content: "list" }
      136: EndParagraph
-     137: StartParagraph { alignment: None, id: None }
-     138: EndParagraph
-     139: StartParagraph { alignment: None, id: None }
-     140: EndParagraph
-     141: StartParagraph { alignment: None, id: None }
-     142: Text { content: "Intervening paragraph" }
+     137: EndOrderedListItem
+     138: EndOrderedListItem
+     139: EndOrderedListItem
+     140: StartParagraph { alignment: None, id: None }
+     141: EndParagraph
+     142: StartParagraph { alignment: None, id: None }
      143: EndParagraph
      144: StartParagraph { alignment: None, id: None }
-     145: EndParagraph
-     146: EndOrderedListItem
-     147: StartOrderedListItem { id: Some("2"), level: 2, start: None, style_type: LowerRoman }
-     148: StartParagraph { alignment: None, id: None }
-     149: Text { content: "foo" }
-     150: EndParagraph
-     151: EndOrderedListItem
-     152: EndOrderedListItem
-     153: EndOrderedListItem
-     154: StartOrderedListItem { id: Some("2"), level: 0, start: None, style_type: UpperRoman }
-     155: StartParagraph { alignment: None, id: None }
-     156: Text { content: "bar" }
-     157: EndParagraph
-     158: StartOrderedListItem { id: Some("2"), level: 1, start: None, style_type: LowerAlpha }
+     145: Text { content: "Intervening paragraph" }
+     146: EndParagraph
+     147: StartParagraph { alignment: None, id: None }
+     148: EndParagraph
+     149: StartOrderedListItem { id: Some("2"), level: 0, start: None, style_type: Decimal }
+     150: StartOrderedListItem { id: Some("2"), level: 1, start: None, style_type: Decimal }
+     151: StartOrderedListItem { id: Some("2"), level: 2, start: None, style_type: LowerRoman }
+     152: StartParagraph { alignment: None, id: None }
+     153: Text { content: "foo" }
+     154: EndParagraph
+     155: EndOrderedListItem
+     156: EndOrderedListItem
+     157: EndOrderedListItem
+     158: StartOrderedListItem { id: Some("2"), level: 0, start: None, style_type: UpperRoman }
      159: StartParagraph { alignment: None, id: None }
-     160: Text { content: "baz" }
+     160: Text { content: "bar" }
      161: EndParagraph
-     162: StartOrderedListItem { id: Some("2"), level: 2, start: None, style_type: Decimal }
-     163: StartOrderedListItem { id: Some("2"), level: 3, start: None, style_type: Decimal }
-     164: StartParagraph { alignment: None, id: None }
-     165: Text { content: "baq" }
-     166: EndParagraph
-     167: StartParagraph { alignment: None, id: None }
-     168: EndParagraph
-     169: StartParagraph { alignment: None, id: None }
+     162: StartOrderedListItem { id: Some("2"), level: 1, start: None, style_type: LowerAlpha }
+     163: StartParagraph { alignment: None, id: None }
+     164: Text { content: "baz" }
+     165: EndParagraph
+     166: StartOrderedListItem { id: Some("2"), level: 2, start: None, style_type: Decimal }
+     167: StartOrderedListItem { id: Some("2"), level: 3, start: None, style_type: Decimal }
+     168: StartParagraph { alignment: None, id: None }
+     169: Text { content: "baq" }
      170: EndParagraph
-     171: StartParagraph { alignment: None, id: None }
-     172: EndParagraph
-     173: StartParagraph { alignment: None, id: None }
-     174: Text { content: "This is a new list that starts at 6" }
-     175: Text { content: ", with a custom change of b. -> e." }
+     171: EndOrderedListItem
+     172: EndOrderedListItem
+     173: EndOrderedListItem
+     174: EndOrderedListItem
+     175: StartParagraph { alignment: None, id: None }
      176: EndParagraph
-     177: EndOrderedListItem
-     178: EndOrderedListItem
-     179: EndOrderedListItem
-     180: EndOrderedListItem
-     181: StartOrderedListItem { id: Some("5"), level: 0, start: Some(1), style_type: Decimal }
-     182: StartParagraph { alignment: None, id: None }
-     183: Text { content: "six" }
+     177: StartParagraph { alignment: None, id: None }
+     178: EndParagraph
+     179: StartParagraph { alignment: None, id: None }
+     180: EndParagraph
+     181: StartParagraph { alignment: None, id: None }
+     182: Text { content: "This is a new list that starts at 6" }
+     183: Text { content: ", with a custom change of b. -> e." }
      184: EndParagraph
-     185: EndOrderedListItem
-     186: StartOrderedListItem { id: Some("5"), level: 0, start: None, style_type: Decimal }
-     187: StartParagraph { alignment: None, id: None }
-     188: Text { content: "seven" }
-     189: EndParagraph
-     190: StartOrderedListItem { id: Some("5"), level: 1, start: None, style_type: LowerAlpha }
+     185: StartOrderedListItem { id: Some("5"), level: 0, start: Some(1), style_type: Decimal }
+     186: StartParagraph { alignment: None, id: None }
+     187: Text { content: "six" }
+     188: EndParagraph
+     189: EndOrderedListItem
+     190: StartOrderedListItem { id: Some("5"), level: 0, start: None, style_type: Decimal }
      191: StartParagraph { alignment: None, id: None }
-     192: Text { content: "seven a" }
+     192: Text { content: "seven" }
      193: EndParagraph
-     194: EndOrderedListItem
-     195: EndOrderedListItem
-     196: StartOrderedListItem { id: Some("6"), level: 0, start: Some(1), style_type: LowerAlpha }
-     197: StartParagraph { alignment: None, id: None }
-     198: Text { content: "seven e" }
-     199: EndParagraph
-     200: EndOrderedListItem
-     201: StartOrderedListItem { id: Some("6"), level: 0, start: None, style_type: LowerAlpha }
-     202: StartParagraph { alignment: None, id: None }
-     203: Text { content: "seven f" }
-     204: EndParagraph
-     205: StartParagraph { alignment: None, id: None }
-     206: EndParagraph
-     207: StartParagraph { alignment: None, id: None }
+     194: StartOrderedListItem { id: Some("5"), level: 1, start: None, style_type: LowerAlpha }
+     195: StartParagraph { alignment: None, id: None }
+     196: Text { content: "seven a" }
+     197: EndParagraph
+     198: EndOrderedListItem
+     199: EndOrderedListItem
+     200: StartOrderedListItem { id: Some("6"), level: 0, start: Some(1), style_type: LowerAlpha }
+     201: StartParagraph { alignment: None, id: None }
+     202: Text { content: "seven e" }
+     203: EndParagraph
+     204: EndOrderedListItem
+     205: StartOrderedListItem { id: Some("6"), level: 0, start: None, style_type: LowerAlpha }
+     206: StartParagraph { alignment: None, id: None }
+     207: Text { content: "seven f" }
      208: EndParagraph
-     209: StartParagraph { alignment: None, id: None }
-     210: EndParagraph
-     211: StartParagraph { alignment: None, id: None }
-     212: EndParagraph
-     213: StartParagraph { alignment: None, id: None }
-     214: EndParagraph
-     215: StartParagraph { alignment: None, id: None }
-     216: EndParagraph
-     217: StartParagraph { alignment: None, id: None }
-     218: EndParagraph
-     219: StartParagraph { alignment: None, id: None }
-     220: EndParagraph
-     221: StartParagraph { alignment: None, id: None }
-     222: EndParagraph
-     223: StartParagraph { alignment: None, id: None }
-     224: EndParagraph
-     225: StartParagraph { alignment: None, id: None }
-     226: EndParagraph
-     227: StartParagraph { alignment: None, id: None }
-     228: EndParagraph
-     229: StartParagraph { alignment: None, id: None }
-     230: EndParagraph
-     231: StartParagraph { alignment: None, id: None }
-     232: Text { content: "How about a list over a section break" }
+     209: EndOrderedListItem
+     210: StartParagraph { alignment: None, id: None }
+     211: EndParagraph
+     212: StartParagraph { alignment: None, id: None }
+     213: EndParagraph
+     214: StartParagraph { alignment: None, id: None }
+     215: EndParagraph
+     216: StartParagraph { alignment: None, id: None }
+     217: EndParagraph
+     218: StartParagraph { alignment: None, id: None }
+     219: EndParagraph
+     220: StartParagraph { alignment: None, id: None }
+     221: EndParagraph
+     222: StartParagraph { alignment: None, id: None }
+     223: EndParagraph
+     224: StartParagraph { alignment: None, id: None }
+     225: EndParagraph
+     226: StartParagraph { alignment: None, id: None }
+     227: EndParagraph
+     228: StartParagraph { alignment: None, id: None }
+     229: EndParagraph
+     230: StartParagraph { alignment: None, id: None }
+     231: EndParagraph
+     232: StartParagraph { alignment: None, id: None }
      233: EndParagraph
-     234: EndOrderedListItem
-     235: StartOrderedListItem { id: Some("10"), level: 0, start: Some(1), style_type: Decimal }
+     234: StartParagraph { alignment: None, id: None }
+     235: EndParagraph
      236: StartParagraph { alignment: None, id: None }
-     237: Text { content: "list 1" }
+     237: Text { content: "How about a list over a section break" }
      238: EndParagraph
-     239: EndOrderedListItem
-     240: StartOrderedListItem { id: Some("10"), level: 0, start: None, style_type: Decimal }
-     241: StartParagraph { alignment: None, id: None }
-     242: Text { content: "list 2" }
-     243: EndParagraph
-     244: StartParagraph { alignment: None, id: None }
-     245: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     246: LineBreak
-     247: EndTextStyle
-     248: EndParagraph
+     239: StartOrderedListItem { id: Some("10"), level: 0, start: Some(1), style_type: Decimal }
+     240: StartParagraph { alignment: None, id: None }
+     241: Text { content: "list 1" }
+     242: EndParagraph
+     243: EndOrderedListItem
+     244: StartOrderedListItem { id: Some("10"), level: 0, start: None, style_type: Decimal }
+     245: StartParagraph { alignment: None, id: None }
+     246: Text { content: "list 2" }
+     247: EndParagraph
+     248: EndOrderedListItem
      249: StartParagraph { alignment: None, id: None }
-     250: EndParagraph
-     251: StartParagraph { alignment: None, id: None }
-     252: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     253: Text { content: "Finally" }
-     254: EndTextStyle
-     255: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     256: Text { content: " some missing items" }
-     257: EndTextStyle
-     258: EndParagraph
-     259: EndOrderedListItem
-     260: StartOrderedListItem { id: Some("11"), level: 0, start: Some(1), style_type: UpperAlpha }
-     261: StartParagraph { alignment: None, id: None }
-     262: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     263: Text { content: "A" }
-     264: EndTextStyle
-     265: EndParagraph
-     266: StartOrderedListItem { id: Some("11"), level: 1, start: None, style_type: Decimal }
-     267: StartOrderedListItem { id: Some("11"), level: 2, start: None, style_type: LowerRoman }
-     268: StartParagraph { alignment: None, id: None }
-     269: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     270: Text { content: "A i" }
-     271: EndTextStyle
-     272: EndParagraph
-     273: EndOrderedListItem
-     274: StartOrderedListItem { id: Some("11"), level: 2, start: None, style_type: LowerRoman }
-     275: StartParagraph { alignment: None, id: None }
-     276: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     277: Text { content: "A ii" }
-     278: EndTextStyle
-     279: EndParagraph
-     280: StartOrderedListItem { id: Some("11"), level: 3, start: None, style_type: Decimal }
-     281: StartOrderedListItem { id: Some("11"), level: 4, start: None, style_type: LowerAlpha }
-     282: StartParagraph { alignment: None, id: None }
-     283: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     284: Text { content: "A ii a" }
-     285: EndTextStyle
-     286: EndParagraph
-     287: EndOrderedListItem
-     288: StartOrderedListItem { id: Some("11"), level: 4, start: None, style_type: LowerAlpha }
-     289: StartParagraph { alignment: None, id: None }
-     290: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     291: Text { content: "A ii b" }
-     292: EndTextStyle
-     293: EndParagraph
-     294: EndOrderedListItem
-     295: EndOrderedListItem
-     296: StartOrderedListItem { id: Some("11"), level: 3, start: None, style_type: Decimal }
-     297: StartParagraph { alignment: None, id: None }
-     298: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
-     299: Text { content: "A ii 2" }
-     300: EndTextStyle
-     301: EndParagraph
-     302: StartParagraph { alignment: None, id: None }
-     303: EndParagraph
-     304: EndOrderedListItem
-     305: EndOrderedListItem
+     250: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     251: LineBreak
+     252: EndTextStyle
+     253: EndParagraph
+     254: StartParagraph { alignment: None, id: None }
+     255: EndParagraph
+     256: StartParagraph { alignment: None, id: None }
+     257: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     258: Text { content: "Finally" }
+     259: EndTextStyle
+     260: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     261: Text { content: " some missing items" }
+     262: EndTextStyle
+     263: EndParagraph
+     264: StartOrderedListItem { id: Some("11"), level: 0, start: Some(1), style_type: UpperAlpha }
+     265: StartParagraph { alignment: None, id: None }
+     266: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     267: Text { content: "A" }
+     268: EndTextStyle
+     269: EndParagraph
+     270: StartOrderedListItem { id: Some("11"), level: 1, start: None, style_type: Decimal }
+     271: StartOrderedListItem { id: Some("11"), level: 2, start: None, style_type: LowerRoman }
+     272: StartParagraph { alignment: None, id: None }
+     273: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     274: Text { content: "A i" }
+     275: EndTextStyle
+     276: EndParagraph
+     277: EndOrderedListItem
+     278: StartOrderedListItem { id: Some("11"), level: 2, start: None, style_type: LowerRoman }
+     279: StartParagraph { alignment: None, id: None }
+     280: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     281: Text { content: "A ii" }
+     282: EndTextStyle
+     283: EndParagraph
+     284: StartOrderedListItem { id: Some("11"), level: 3, start: None, style_type: Decimal }
+     285: StartOrderedListItem { id: Some("11"), level: 4, start: None, style_type: LowerAlpha }
+     286: StartParagraph { alignment: None, id: None }
+     287: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     288: Text { content: "A ii a" }
+     289: EndTextStyle
+     290: EndParagraph
+     291: EndOrderedListItem
+     292: StartOrderedListItem { id: Some("11"), level: 4, start: None, style_type: LowerAlpha }
+     293: StartParagraph { alignment: None, id: None }
+     294: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     295: Text { content: "A ii b" }
+     296: EndTextStyle
+     297: EndParagraph
+     298: EndOrderedListItem
+     299: EndOrderedListItem
+     300: StartOrderedListItem { id: Some("11"), level: 3, start: None, style_type: Decimal }
+     301: StartParagraph { alignment: None, id: None }
+     302: StartTextStyle { kind: Mark(Rgb { b: 192, g: 192, r: 192 }), id: None }
+     303: Text { content: "A ii 2" }
+     304: EndTextStyle
+     305: EndParagraph
      306: EndOrderedListItem
      307: EndOrderedListItem
-     308: StartOrderedListItem { id: Some("10"), level: 0, start: None, style_type: Decimal }
-     309: StartParagraph { alignment: None, id: None }
-     310: Text { content: "page break " }
-     311: Text { content: "list 3" }
-     312: EndParagraph
+     308: EndOrderedListItem
+     309: EndOrderedListItem
+     310: StartParagraph { alignment: None, id: None }
+     311: EndParagraph
+     312: StartOrderedListItem { id: Some("10"), level: 0, start: None, style_type: Decimal }
      313: StartParagraph { alignment: None, id: None }
-     314: EndParagraph
-     315: StartParagraph { alignment: None, id: None }
+     314: Text { content: "page break " }
+     315: Text { content: "list 3" }
      316: EndParagraph
      317: EndOrderedListItem
-     318: StartOrderedListItem { id: Some("12"), level: 0, start: Some(1), style_type: Decimal }
-     319: StartParagraph { alignment: None, id: None }
-     320: Text { content: "Greek numbering with crazy format - alpha" }
+     318: StartParagraph { alignment: None, id: None }
+     319: EndParagraph
+     320: StartParagraph { alignment: None, id: None }
      321: EndParagraph
-     322: EndOrderedListItem
-     323: StartOrderedListItem { id: Some("12"), level: 0, start: None, style_type: Decimal }
-     324: StartParagraph { alignment: None, id: None }
-     325: Text { content: "Greek numbering with crazy format - beta" }
-     326: EndParagraph
-     327: StartParagraph { alignment: None, id: None }
-     328: EndParagraph
-     329: StartParagraph { alignment: None, id: None }
+     322: StartOrderedListItem { id: Some("12"), level: 0, start: Some(1), style_type: Decimal }
+     323: StartParagraph { alignment: None, id: None }
+     324: Text { content: "Greek numbering with crazy format - alpha" }
+     325: EndParagraph
+     326: EndOrderedListItem
+     327: StartOrderedListItem { id: Some("12"), level: 0, start: None, style_type: Decimal }
+     328: StartParagraph { alignment: None, id: None }
+     329: Text { content: "Greek numbering with crazy format - beta" }
      330: EndParagraph
-     331: StartParagraph { alignment: None, id: None }
-     332: EndParagraph
-     333: StartParagraph { alignment: None, id: None }
-     334: EndParagraph
-     335: EndOrderedListItem
-     336: StartOrderedListItem { id: Some("13"), level: 0, start: Some(1), style_type: Decimal }
-     337: StartParagraph { alignment: None, id: None }
-     338: Text { content: "1" }
+     331: EndOrderedListItem
+     332: StartParagraph { alignment: None, id: None }
+     333: EndParagraph
+     334: StartParagraph { alignment: None, id: None }
+     335: EndParagraph
+     336: StartParagraph { alignment: None, id: None }
+     337: EndParagraph
+     338: StartParagraph { alignment: None, id: None }
      339: EndParagraph
-     340: StartOrderedListItem { id: Some("13"), level: 1, start: None, style_type: Decimal }
-     341: StartOrderedListItem { id: Some("13"), level: 2, start: None, style_type: Decimal }
-     342: StartParagraph { alignment: None, id: None }
-     343: Text { content: "1.1.1" }
-     344: EndParagraph
-     345: EndOrderedListItem
-     346: EndOrderedListItem
-     347: StartOrderedListItem { id: Some("14"), level: 1, start: Some(1), style_type: Decimal }
-     348: StartParagraph { alignment: None, id: None }
-     349: Text { content: "1.2" }
-     350: Text { content: "->1.1" }
-     351: Text { content: "  //set the value to 1 and “start new list”" }
-     352: EndParagraph
-     353: EndOrderedListItem
-     354: StartOrderedListItem { id: Some("14"), level: 1, start: None, style_type: Decimal }
-     355: StartParagraph { alignment: None, id: None }
-     356: Text { content: "1.3" }
-     357: Text { content: " -> 1.2" }
-     358: EndParagraph
-     359: EndOrderedListItem
-     360: EndOrderedListItem
-     361: StartOrderedListItem { id: Some("14"), level: 0, start: None, style_type: Decimal }
-     362: StartParagraph { alignment: None, id: None }
-     363: Text { content: "2." }
-     364: EndParagraph
-     365: StartOrderedListItem { id: Some("14"), level: 1, start: None, style_type: Decimal }
+     340: StartOrderedListItem { id: Some("13"), level: 0, start: Some(1), style_type: Decimal }
+     341: StartParagraph { alignment: None, id: None }
+     342: Text { content: "1" }
+     343: EndParagraph
+     344: StartOrderedListItem { id: Some("13"), level: 1, start: None, style_type: Decimal }
+     345: StartOrderedListItem { id: Some("13"), level: 2, start: None, style_type: Decimal }
+     346: StartParagraph { alignment: None, id: None }
+     347: Text { content: "1.1.1" }
+     348: EndParagraph
+     349: EndOrderedListItem
+     350: EndOrderedListItem
+     351: StartOrderedListItem { id: Some("14"), level: 1, start: Some(1), style_type: Decimal }
+     352: StartParagraph { alignment: None, id: None }
+     353: Text { content: "1.2" }
+     354: Text { content: "->1.1" }
+     355: Text { content: "  //set the value to 1 and “start new list”" }
+     356: EndParagraph
+     357: EndOrderedListItem
+     358: StartOrderedListItem { id: Some("14"), level: 1, start: None, style_type: Decimal }
+     359: StartParagraph { alignment: None, id: None }
+     360: Text { content: "1.3" }
+     361: Text { content: " -> 1.2" }
+     362: EndParagraph
+     363: EndOrderedListItem
+     364: EndOrderedListItem
+     365: StartOrderedListItem { id: Some("14"), level: 0, start: None, style_type: Decimal }
      366: StartParagraph { alignment: None, id: None }
-     367: Text { content: "2.1" }
+     367: Text { content: "2." }
      368: EndParagraph
-     369: StartParagraph { alignment: None, id: None }
-     370: EndParagraph
-     371: EndOrderedListItem
-     372: EndOrderedListItem
-     373: EndDocument
+     369: StartOrderedListItem { id: Some("14"), level: 1, start: None, style_type: Decimal }
+     370: StartParagraph { alignment: None, id: None }
+     371: Text { content: "2.1" }
+     372: EndParagraph
+     373: EndOrderedListItem
+     374: EndOrderedListItem
+     375: StartParagraph { alignment: None, id: None }
+     376: EndParagraph
+     377: EndDocument
   ],
   terminal: Ok,
 }

--- a/tests/snapshots/docx/apache-tika/testWORD_override_list_numbering.docx.snap
+++ b/tests/snapshots/docx/apache-tika/testWORD_override_list_numbering.docx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
 expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
@@ -109,19 +110,19 @@ ReaderFixtureSnapshot {
      102: StartParagraph { alignment: None, id: None }
      103: Text { content: "5th" }
      104: EndParagraph
-     105: StartParagraph { alignment: None, id: None }
-     106: EndParagraph
-     107: StartParagraph { alignment: None, id: None }
-     108: StartTextStyle { kind: Bold, id: None }
-     109: Text { content: "Test 2:" }
-     110: EndTextStyle
-     111: Text { content: " List with " }
-     112: Text { content: "restartAt" }
-     113: Text { content: " modified and skipped levels" }
-     114: EndParagraph
-     115: StartParagraph { alignment: None, id: None }
-     116: EndParagraph
-     117: EndOrderedListItem
+     105: EndOrderedListItem
+     106: StartParagraph { alignment: None, id: None }
+     107: EndParagraph
+     108: StartParagraph { alignment: None, id: None }
+     109: StartTextStyle { kind: Bold, id: None }
+     110: Text { content: "Test 2:" }
+     111: EndTextStyle
+     112: Text { content: " List with " }
+     113: Text { content: "restartAt" }
+     114: Text { content: " modified and skipped levels" }
+     115: EndParagraph
+     116: StartParagraph { alignment: None, id: None }
+     117: EndParagraph
      118: StartOrderedListItem { id: Some("6"), level: 0, start: Some(1), style_type: Decimal }
      119: StartParagraph { alignment: None, id: None }
      120: Text { content: "1" }
@@ -172,23 +173,23 @@ ReaderFixtureSnapshot {
      165: StartParagraph { alignment: None, id: None }
      166: Text { content: "2.b" }
      167: EndParagraph
-     168: StartParagraph { alignment: None, id: None }
-     169: EndParagraph
+     168: EndOrderedListItem
+     169: EndOrderedListItem
      170: StartParagraph { alignment: None, id: None }
-     171: StartTextStyle { kind: Bold, id: None }
-     172: Text { content: "Test 3:" }
-     173: EndTextStyle
-     174: Text { content: " List with " }
-     175: Text { content: "LegalNumbering" }
-     176: Text { content: " and " }
-     177: Text { content: "modified " }
-     178: Text { content: "startAt" }
-     179: Text { content: " value" }
-     180: EndParagraph
-     181: StartParagraph { alignment: None, id: None }
+     171: EndParagraph
+     172: StartParagraph { alignment: None, id: None }
+     173: StartTextStyle { kind: Bold, id: None }
+     174: Text { content: "Test 3:" }
+     175: EndTextStyle
+     176: Text { content: " List with " }
+     177: Text { content: "LegalNumbering" }
+     178: Text { content: " and " }
+     179: Text { content: "modified " }
+     180: Text { content: "startAt" }
+     181: Text { content: " value" }
      182: EndParagraph
-     183: EndOrderedListItem
-     184: EndOrderedListItem
+     183: StartParagraph { alignment: None, id: None }
+     184: EndParagraph
      185: StartOrderedListItem { id: Some("9"), level: 0, start: Some(1), style_type: Decimal }
      186: StartParagraph { alignment: None, id: None }
      187: Text { content: "(1))" }
@@ -228,18 +229,18 @@ ReaderFixtureSnapshot {
      221: StartParagraph { alignment: None, id: None }
      222: Text { content: "2" }
      223: EndParagraph
-     224: StartParagraph { alignment: None, id: None }
-     225: EndParagraph
-     226: StartParagraph { alignment: None, id: None }
-     227: StartTextStyle { kind: Bold, id: None }
-     228: Text { content: "Test 4:" }
-     229: EndTextStyle
-     230: Text { content: " " }
-     231: Text { content: "ListFormatOverride" }
-     232: EndParagraph
-     233: StartParagraph { alignment: None, id: None }
-     234: EndParagraph
-     235: EndOrderedListItem
+     224: EndOrderedListItem
+     225: StartParagraph { alignment: None, id: None }
+     226: EndParagraph
+     227: StartParagraph { alignment: None, id: None }
+     228: StartTextStyle { kind: Bold, id: None }
+     229: Text { content: "Test 4:" }
+     230: EndTextStyle
+     231: Text { content: " " }
+     232: Text { content: "ListFormatOverride" }
+     233: EndParagraph
+     234: StartParagraph { alignment: None, id: None }
+     235: EndParagraph
      236: StartOrderedListItem { id: Some("19"), level: 0, start: Some(1), style_type: Decimal }
      237: StartParagraph { alignment: None, id: None }
      238: Text { content: "1" }
@@ -269,14 +270,14 @@ ReaderFixtureSnapshot {
      262: StartParagraph { alignment: None, id: None }
      263: Text { content: "4" }
      264: EndParagraph
-     265: StartParagraph { alignment: None, id: None }
-     266: EndParagraph
-     267: StartParagraph { alignment: None, id: None }
-     268: Text { content: "Test 5: More formatting variants" }
-     269: EndParagraph
-     270: StartParagraph { alignment: None, id: None }
-     271: EndParagraph
-     272: EndOrderedListItem
+     265: EndOrderedListItem
+     266: StartParagraph { alignment: None, id: None }
+     267: EndParagraph
+     268: StartParagraph { alignment: None, id: None }
+     269: Text { content: "Test 5: More formatting variants" }
+     270: EndParagraph
+     271: StartParagraph { alignment: None, id: None }
+     272: EndParagraph
      273: StartOrderedListItem { id: Some("31"), level: 0, start: Some(1), style_type: Decimal }
      274: StartParagraph { alignment: None, id: None }
      275: Text { content: "00" }
@@ -286,26 +287,28 @@ ReaderFixtureSnapshot {
      279: StartParagraph { alignment: None, id: None }
      280: Text { content: "01" }
      281: EndParagraph
-     282: StartParagraph { alignment: None, id: None }
-     283: Text { content: "01." }
-     284: EndParagraph
-     285: StartParagraph { alignment: None, id: None }
-     286: Text { content: "01." }
-     287: EndParagraph
-     288: StartOrderedListItem { id: Some("31"), level: 1, start: None, style_type: Decimal }
-     289: StartOrderedListItem { id: Some("31"), level: 2, start: None, style_type: Decimal }
-     290: StartParagraph { alignment: None, id: None }
-     291: Text { content: "01..1" }
-     292: EndParagraph
-     293: EndOrderedListItem
-     294: EndOrderedListItem
+     282: EndOrderedListItem
+     283: StartParagraph { alignment: None, id: None }
+     284: Text { content: "01." }
+     285: EndParagraph
+     286: StartParagraph { alignment: None, id: None }
+     287: Text { content: "01." }
+     288: EndParagraph
+     289: StartOrderedListItem { id: Some("31"), level: 0, start: None, style_type: Decimal }
+     290: StartOrderedListItem { id: Some("31"), level: 1, start: None, style_type: Decimal }
+     291: StartOrderedListItem { id: Some("31"), level: 2, start: None, style_type: Decimal }
+     292: StartParagraph { alignment: None, id: None }
+     293: Text { content: "01..1" }
+     294: EndParagraph
      295: EndOrderedListItem
-     296: StartOrderedListItem { id: Some("31"), level: 0, start: None, style_type: Decimal }
-     297: StartParagraph { alignment: None, id: None }
-     298: Text { content: "02" }
-     299: EndParagraph
-     300: EndOrderedListItem
-     301: EndDocument
+     296: EndOrderedListItem
+     297: EndOrderedListItem
+     298: StartOrderedListItem { id: Some("31"), level: 0, start: None, style_type: Decimal }
+     299: StartParagraph { alignment: None, id: None }
+     300: Text { content: "02" }
+     301: EndParagraph
+     302: EndOrderedListItem
+     303: EndDocument
   ],
   terminal: Ok,
 }

--- a/tests/snapshots/docx/apache-tika/testWORD_template.docx.snap
+++ b/tests/snapshots/docx/apache-tika/testWORD_template.docx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
 expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
@@ -28,35 +29,41 @@ ReaderFixtureSnapshot {
       21: StartParagraph { alignment: None, id: None }
       22: Text { content: "Guitarist" }
       23: EndParagraph
-      24: StartParagraph { alignment: None, id: None }
-      25: Text { content: "Slept with one eye open gripping my pillow tight" }
-      26: EndParagraph
-      27: StartParagraph { alignment: None, id: None }
-      28: Text { content: "E" }
-      29: Text { content: "ducation" }
-      30: EndParagraph
-      31: StartParagraph { alignment: None, id: None }
-      32: Text { content: "[Dates From - To]" }
-      33: EndParagraph
-      34: StartParagraph { alignment: None, id: None }
-      35: Text { content: "[School Name, Location]" }
-      36: EndParagraph
-      37: StartParagraph { alignment: None, id: None }
-      38: Text { content: "[Degree]" }
-      39: EndParagraph
-      40: StartParagraph { alignment: None, id: None }
-      41: Text { content: "Click here to enter text." }
-      42: EndParagraph
+      24: StartUnorderedListItem { id: Some("4"), level: 0, style_type: Disc }
+      25: StartParagraph { alignment: None, id: None }
+      26: Text { content: "Slept with one eye open gripping my pillow tight" }
+      27: EndParagraph
+      28: EndUnorderedListItem
+      29: StartParagraph { alignment: None, id: None }
+      30: Text { content: "E" }
+      31: Text { content: "ducation" }
+      32: EndParagraph
+      33: StartParagraph { alignment: None, id: None }
+      34: Text { content: "[Dates From - To]" }
+      35: EndParagraph
+      36: StartParagraph { alignment: None, id: None }
+      37: Text { content: "[School Name, Location]" }
+      38: EndParagraph
+      39: StartParagraph { alignment: None, id: None }
+      40: Text { content: "[Degree]" }
+      41: EndParagraph
+      42: StartUnorderedListItem { id: Some("4"), level: 0, style_type: Disc }
       43: StartParagraph { alignment: None, id: None }
-      44: Text { content: "Click here to enter text" }
+      44: Text { content: "Click here to enter text." }
       45: EndParagraph
-      46: StartParagraph { alignment: None, id: None }
-      47: Text { content: "References" }
-      48: EndParagraph
-      49: StartParagraph { alignment: None, id: None }
-      50: Text { content: "References are available upon request." }
-      51: EndParagraph
-      52: EndDocument
+      46: EndUnorderedListItem
+      47: StartUnorderedListItem { id: Some("4"), level: 0, style_type: Disc }
+      48: StartParagraph { alignment: None, id: None }
+      49: Text { content: "Click here to enter text" }
+      50: EndParagraph
+      51: EndUnorderedListItem
+      52: StartParagraph { alignment: None, id: None }
+      53: Text { content: "References" }
+      54: EndParagraph
+      55: StartParagraph { alignment: None, id: None }
+      56: Text { content: "References are available upon request." }
+      57: EndParagraph
+      58: EndDocument
   ],
   terminal: Ok,
 }

--- a/tests/snapshots/docx/apache-tika/testWORD_various.docx.snap
+++ b/tests/snapshots/docx/apache-tika/testWORD_various.docx.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
 expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
@@ -105,10 +106,10 @@ ReaderFixtureSnapshot {
       98: StartParagraph { alignment: None, id: None }
       99: Text { content: "Bullet 3" }
      100: EndParagraph
-     101: StartParagraph { alignment: None, id: None }
-     102: Text { content: "Here is a numbered list:" }
-     103: EndParagraph
-     104: EndUnorderedListItem
+     101: EndUnorderedListItem
+     102: StartParagraph { alignment: None, id: None }
+     103: Text { content: "Here is a numbered list:" }
+     104: EndParagraph
      105: StartOrderedListItem { id: Some("2"), level: 0, start: Some(1), style_type: Decimal }
      106: StartParagraph { alignment: None, id: None }
      107: Text { content: "Number bullet 1" }
@@ -123,28 +124,28 @@ ReaderFixtureSnapshot {
      116: StartParagraph { alignment: None, id: None }
      117: Text { content: "Number bullet 3" }
      118: EndParagraph
-     119: StartParagraph { alignment: None, id: None }
-     120: EndParagraph
-     121: StartParagraph { alignment: None, id: None }
-     122: Text { content: " " }
-     123: Text { content: "Keyword1 Keyword2" }
-     124: EndParagraph
-     125: StartParagraph { alignment: None, id: None }
-     126: EndParagraph
-     127: StartParagraph { alignment: None, id: None }
-     128: StartLink { href: "http://tika.apache.org/", id: None, title: None }
-     129: Text { content: "This is a hyperlink" }
-     130: EndLink
-     131: EndParagraph
-     132: StartParagraph { alignment: None, id: None }
-     133: EndParagraph
-     134: StartParagraph { alignment: None, id: None }
-     135: Text { content: " " }
-     136: Text { content: "Subject is here" }
-     137: EndParagraph
-     138: StartParagraph { alignment: None, id: None }
-     139: EndParagraph
-     140: EndOrderedListItem
+     119: EndOrderedListItem
+     120: StartParagraph { alignment: None, id: None }
+     121: EndParagraph
+     122: StartParagraph { alignment: None, id: None }
+     123: Text { content: " " }
+     124: Text { content: "Keyword1 Keyword2" }
+     125: EndParagraph
+     126: StartParagraph { alignment: None, id: None }
+     127: EndParagraph
+     128: StartParagraph { alignment: None, id: None }
+     129: StartLink { href: "http://tika.apache.org/", id: None, title: None }
+     130: Text { content: "This is a hyperlink" }
+     131: EndLink
+     132: EndParagraph
+     133: StartParagraph { alignment: None, id: None }
+     134: EndParagraph
+     135: StartParagraph { alignment: None, id: None }
+     136: Text { content: " " }
+     137: Text { content: "Subject is here" }
+     138: EndParagraph
+     139: StartParagraph { alignment: None, id: None }
+     140: EndParagraph
      141: StartTable { id: None }
      142: StartTableRow { id: None }
      143: StartTableCell { colspan: None, id: None, rowspan: None }

--- a/tests/snapshots/docx/docspec/basedon_chain_numpr.docx.snap
+++ b/tests/snapshots/docx/docspec/basedon_chain_numpr.docx.snap
@@ -1,0 +1,17 @@
+---
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
+---
+ReaderFixtureSnapshot {
+  events: [
+       0: StartDocument { id: None, language: None, metadata: None }
+       1: StartUnorderedListItem { id: Some("2"), level: 0, style_type: Disc }
+       2: StartParagraph { alignment: None, id: None }
+       3: Text { content: "Chain inherited list item." }
+       4: EndParagraph
+       5: EndUnorderedListItem
+       6: EndDocument
+  ],
+  terminal: Ok,
+}

--- a/tests/snapshots/docx/docspec/basedon_cycle.docx.snap
+++ b/tests/snapshots/docx/docspec/basedon_cycle.docx.snap
@@ -1,0 +1,15 @@
+---
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
+---
+ReaderFixtureSnapshot {
+  events: [
+       0: StartDocument { id: None, language: None, metadata: None }
+       1: StartParagraph { alignment: None, id: None }
+       2: Text { content: "Plain text with cyclic style chain." }
+       3: EndParagraph
+       4: EndDocument
+  ],
+  terminal: Ok,
+}

--- a/tests/snapshots/docx/docspec/list_then_paragraph_same_style.docx.snap
+++ b/tests/snapshots/docx/docspec/list_then_paragraph_same_style.docx.snap
@@ -1,0 +1,32 @@
+---
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
+---
+ReaderFixtureSnapshot {
+  events: [
+       0: StartDocument { id: None, language: None, metadata: None }
+       1: StartUnorderedListItem { id: Some("43"), level: 0, style_type: Disc }
+       2: StartParagraph { alignment: None, id: None }
+       3: Text { content: "Item one" }
+       4: EndParagraph
+       5: EndUnorderedListItem
+       6: StartUnorderedListItem { id: Some("43"), level: 0, style_type: Disc }
+       7: StartParagraph { alignment: None, id: None }
+       8: Text { content: "Item two" }
+       9: EndParagraph
+      10: EndUnorderedListItem
+      11: StartUnorderedListItem { id: Some("43"), level: 0, style_type: Disc }
+      12: StartParagraph { alignment: None, id: None }
+      13: Text { content: "Item three" }
+      14: EndParagraph
+      15: EndUnorderedListItem
+      16: StartParagraph { alignment: None, id: None }
+      17: EndParagraph
+      18: StartParagraph { alignment: None, id: None }
+      19: Text { content: "Body text after the list." }
+      20: EndParagraph
+      21: EndDocument
+  ],
+  terminal: Ok,
+}

--- a/tests/snapshots/docx/docspec/list_then_paragraph_style_change.docx.snap
+++ b/tests/snapshots/docx/docspec/list_then_paragraph_style_change.docx.snap
@@ -1,0 +1,36 @@
+---
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
+---
+ReaderFixtureSnapshot {
+  events: [
+       0: StartDocument { id: None, language: None, metadata: None }
+       1: StartUnorderedListItem { id: Some("9"), level: 0, style_type: Disc }
+       2: StartParagraph { alignment: None, id: None }
+       3: Text { content: "List item one" }
+       4: EndParagraph
+       5: EndUnorderedListItem
+       6: StartUnorderedListItem { id: Some("9"), level: 0, style_type: Disc }
+       7: StartParagraph { alignment: None, id: None }
+       8: Text { content: "List item two" }
+       9: EndParagraph
+      10: EndUnorderedListItem
+      11: StartUnorderedListItem { id: Some("9"), level: 0, style_type: Disc }
+      12: StartParagraph { alignment: None, id: None }
+      13: Text { content: "List item three" }
+      14: EndParagraph
+      15: EndUnorderedListItem
+      16: StartParagraph { alignment: None, id: None }
+      17: Text { content: "Body paragraph one." }
+      18: EndParagraph
+      19: StartParagraph { alignment: None, id: None }
+      20: Text { content: "Body paragraph two." }
+      21: EndParagraph
+      22: StartParagraph { alignment: None, id: None }
+      23: Text { content: "Body paragraph three." }
+      24: EndParagraph
+      25: EndDocument
+  ],
+  terminal: Ok,
+}

--- a/tests/snapshots/docx/docspec/numid_zero_direct_clear.docx.snap
+++ b/tests/snapshots/docx/docspec/numid_zero_direct_clear.docx.snap
@@ -1,0 +1,15 @@
+---
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
+---
+ReaderFixtureSnapshot {
+  events: [
+       0: StartDocument { id: None, language: None, metadata: None }
+       1: StartParagraph { alignment: None, id: None }
+       2: Text { content: "Not a list item despite the style." }
+       3: EndParagraph
+       4: EndDocument
+  ],
+  terminal: Ok,
+}

--- a/tests/snapshots/docx/docspec/numid_zero_style_chain.docx.snap
+++ b/tests/snapshots/docx/docspec/numid_zero_style_chain.docx.snap
@@ -1,0 +1,15 @@
+---
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
+---
+ReaderFixtureSnapshot {
+  events: [
+       0: StartDocument { id: None, language: None, metadata: None }
+       1: StartParagraph { alignment: None, id: None }
+       2: Text { content: "Plain text despite parent having numPr." }
+       3: EndParagraph
+       4: EndDocument
+  ],
+  terminal: Ok,
+}

--- a/tests/snapshots/docx/docspec/style_inherited_numpr.docx.snap
+++ b/tests/snapshots/docx/docspec/style_inherited_numpr.docx.snap
@@ -1,0 +1,17 @@
+---
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
+---
+ReaderFixtureSnapshot {
+  events: [
+       0: StartDocument { id: None, language: None, metadata: None }
+       1: StartUnorderedListItem { id: Some("1"), level: 0, style_type: Disc }
+       2: StartParagraph { alignment: None, id: None }
+       3: Text { content: "Inherited list item." }
+       4: EndParagraph
+       5: EndUnorderedListItem
+       6: EndDocument
+  ],
+  terminal: Ok,
+}

--- a/tests/snapshots/docx/pandoc/dummy_item_after_list_item.docx.snap
+++ b/tests/snapshots/docx/pandoc/dummy_item_after_list_item.docx.snap
@@ -1,20 +1,23 @@
 ---
-source: crates/docspec-docx-reader/tests/pandoc_corpus.rs
-expression: snapshot
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
   events: [
        0: StartDocument { id: None, language: None, metadata: None }
-       1: StartParagraph { alignment: None, id: None }
-       2: Text { content: "One" }
-       3: EndParagraph
-       4: StartParagraph { alignment: None, id: None }
-       5: Text { content: "Two" }
-       6: LineBreak
-       7: LineBreak
-       8: Text { content: "Three" }
-       9: EndParagraph
-      10: EndDocument
+       1: StartOrderedListItem { id: Some("7"), level: 0, start: Some(1), style_type: Decimal }
+       2: StartParagraph { alignment: None, id: None }
+       3: Text { content: "One" }
+       4: EndParagraph
+       5: EndOrderedListItem
+       6: StartParagraph { alignment: None, id: None }
+       7: Text { content: "Two" }
+       8: LineBreak
+       9: LineBreak
+      10: Text { content: "Three" }
+      11: EndParagraph
+      12: EndDocument
   ],
   terminal: Ok,
 }

--- a/tests/snapshots/docx/pandoc/german_styled_lists.docx.snap
+++ b/tests/snapshots/docx/pandoc/german_styled_lists.docx.snap
@@ -1,56 +1,61 @@
 ---
-source: crates/docspec-docx-reader/tests/pandoc_corpus.rs
-expression: snapshot
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
   events: [
        0: StartDocument { id: None, language: None, metadata: None }
-       1: StartParagraph { alignment: None, id: None }
-       2: Text { content: "One" }
-       3: Text { content: " " }
-       4: Text { content: "level" }
-       5: Text { content: " " }
-       6: Text { content: "of" }
-       7: Text { content: " " }
-       8: Text { content: "the" }
-       9: Text { content: " " }
-      10: Text { content: "list" }
-      11: Text { content: "." }
-      12: EndParagraph
-      13: StartParagraph { alignment: None, id: None }
-      14: Text { content: "Second " }
-      15: Text { content: "level" }
-      16: Text { content: " " }
-      17: Text { content: "of" }
-      18: Text { content: " " }
-      19: Text { content: "the" }
-      20: Text { content: " " }
-      21: Text { content: "list" }
-      22: Text { content: "." }
-      23: EndParagraph
-      24: StartUnorderedListItem { id: Some("1"), level: 0, style_type: Disc }
-      25: StartUnorderedListItem { id: Some("1"), level: 1, style_type: Disc }
-      26: StartParagraph { alignment: None, id: None }
-      27: Text { content: "Next " }
-      28: Text { content: "level" }
-      29: Text { content: " " }
-      30: Text { content: "of" }
+       1: StartUnorderedListItem { id: Some("1"), level: 0, style_type: Disc }
+       2: StartParagraph { alignment: None, id: None }
+       3: Text { content: "One" }
+       4: Text { content: " " }
+       5: Text { content: "level" }
+       6: Text { content: " " }
+       7: Text { content: "of" }
+       8: Text { content: " " }
+       9: Text { content: "the" }
+      10: Text { content: " " }
+      11: Text { content: "list" }
+      12: Text { content: "." }
+      13: EndParagraph
+      14: EndUnorderedListItem
+      15: StartUnorderedListItem { id: Some("1"), level: 0, style_type: Disc }
+      16: StartParagraph { alignment: None, id: None }
+      17: Text { content: "Second " }
+      18: Text { content: "level" }
+      19: Text { content: " " }
+      20: Text { content: "of" }
+      21: Text { content: " " }
+      22: Text { content: "the" }
+      23: Text { content: " " }
+      24: Text { content: "list" }
+      25: Text { content: "." }
+      26: EndParagraph
+      27: StartUnorderedListItem { id: Some("1"), level: 1, style_type: Disc }
+      28: StartParagraph { alignment: None, id: None }
+      29: Text { content: "Next " }
+      30: Text { content: "level" }
       31: Text { content: " " }
-      32: Text { content: "the" }
+      32: Text { content: "of" }
       33: Text { content: " " }
-      34: Text { content: "list" }
-      35: EndParagraph
-      36: StartParagraph { alignment: None, id: None }
-      37: Text { content: "Back " }
-      38: Text { content: "to" }
-      39: Text { content: " t" }
-      40: Text { content: "he top " }
-      41: Text { content: "level" }
-      42: Text { content: "." }
-      43: EndParagraph
-      44: EndUnorderedListItem
-      45: EndUnorderedListItem
-      46: EndDocument
+      34: Text { content: "the" }
+      35: Text { content: " " }
+      36: Text { content: "list" }
+      37: EndParagraph
+      38: EndUnorderedListItem
+      39: EndUnorderedListItem
+      40: StartUnorderedListItem { id: Some("1"), level: 0, style_type: Disc }
+      41: StartParagraph { alignment: None, id: None }
+      42: Text { content: "Back " }
+      43: Text { content: "to" }
+      44: Text { content: " t" }
+      45: Text { content: "he top " }
+      46: Text { content: "level" }
+      47: Text { content: "." }
+      48: EndParagraph
+      49: EndUnorderedListItem
+      50: EndDocument
   ],
   terminal: Ok,
 }

--- a/tests/snapshots/docx/pandoc/lists.docx.snap
+++ b/tests/snapshots/docx/pandoc/lists.docx.snap
@@ -1,6 +1,7 @@
 ---
-source: crates/docspec-docx-reader/tests/pandoc_corpus.rs
-expression: snapshot
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
   events: [
@@ -45,12 +46,12 @@ ReaderFixtureSnapshot {
       38: StartParagraph { alignment: None, id: None }
       39: Text { content: "four" }
       40: EndParagraph
-      41: StartParagraph { alignment: None, id: None }
-      42: Text { content: "Sub paragraph" }
-      43: EndParagraph
-      44: EndUnorderedListItem
-      45: EndUnorderedListItem
-      46: EndUnorderedListItem
+      41: EndUnorderedListItem
+      42: EndUnorderedListItem
+      43: EndUnorderedListItem
+      44: StartParagraph { alignment: None, id: None }
+      45: Text { content: "Sub paragraph" }
+      46: EndParagraph
       47: StartUnorderedListItem { id: Some("4"), level: 0, style_type: Disc }
       48: StartParagraph { alignment: None, id: None }
       49: Text { content: "Same list" }

--- a/tests/snapshots/docx/pandoc/lists_continuing.docx.snap
+++ b/tests/snapshots/docx/pandoc/lists_continuing.docx.snap
@@ -1,6 +1,7 @@
 ---
-source: crates/docspec-docx-reader/tests/pandoc_corpus.rs
-expression: snapshot
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
   events: [
@@ -29,14 +30,14 @@ ReaderFixtureSnapshot {
       22: Text { content: "\t" }
       23: Text { content: "Baz" }
       24: EndParagraph
-      25: StartParagraph { alignment: None, id: None }
-      26: Text { content: "\t" }
+      25: EndOrderedListItem
+      26: StartParagraph { alignment: None, id: None }
       27: Text { content: "\t" }
-      28: EndParagraph
-      29: StartParagraph { alignment: Some(Justify), id: None }
-      30: Text { content: "Interruption." }
-      31: EndParagraph
-      32: EndOrderedListItem
+      28: Text { content: "\t" }
+      29: EndParagraph
+      30: StartParagraph { alignment: Some(Justify), id: None }
+      31: Text { content: "Interruption." }
+      32: EndParagraph
       33: StartOrderedListItem { id: Some("1"), level: 0, start: None, style_type: Decimal }
       34: StartParagraph { alignment: None, id: None }
       35: Text { content: "\t" }

--- a/tests/snapshots/docx/pandoc/lists_level_override.docx.snap
+++ b/tests/snapshots/docx/pandoc/lists_level_override.docx.snap
@@ -1,6 +1,7 @@
 ---
-source: crates/docspec-docx-reader/tests/pandoc_corpus.rs
-expression: snapshot
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
   events: [
@@ -21,102 +22,102 @@ ReaderFixtureSnapshot {
       14: Text { content: "State of Documentation " }
       15: EndTextStyle
       16: EndParagraph
-      17: StartParagraph { alignment: None, id: None }
-      18: StartTextStyle { kind: Bold, id: None }
-      19: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
-      20: Text { content: "Goal:         Baseline and ongoing metrics tracking doc usefulness and completeness." }
-      21: EndTextStyle
+      17: EndOrderedListItem
+      18: StartParagraph { alignment: None, id: None }
+      19: StartTextStyle { kind: Bold, id: None }
+      20: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
+      21: Text { content: "Goal:         Baseline and ongoing metrics tracking doc usefulness and completeness." }
       22: EndTextStyle
-      23: EndParagraph
-      24: StartParagraph { alignment: None, id: None }
-      25: Text { content: "\u{a0}" }
-      26: EndParagraph
-      27: EndOrderedListItem
+      23: EndTextStyle
+      24: EndParagraph
+      25: StartParagraph { alignment: None, id: None }
+      26: Text { content: "\u{a0}" }
+      27: EndParagraph
       28: StartOrderedListItem { id: Some("2"), level: 0, start: Some(1), style_type: Decimal }
       29: StartParagraph { alignment: None, id: None }
       30: StartTextStyle { kind: TextColor(Rgb { b: 181, g: 117, r: 46 }), id: None }
       31: Text { content: "Content Migration " }
       32: EndTextStyle
       33: EndParagraph
-      34: StartParagraph { alignment: None, id: None }
-      35: Text { content: "Goal: Content is accessible to new employees and is better organized/archived." }
-      36: EndParagraph
-      37: StartParagraph { alignment: None, id: None }
-      38: Text { content: "\u{a0}" }
-      39: EndParagraph
-      40: EndOrderedListItem
+      34: EndOrderedListItem
+      35: StartParagraph { alignment: None, id: None }
+      36: Text { content: "Goal: Content is accessible to new employees and is better organized/archived." }
+      37: EndParagraph
+      38: StartParagraph { alignment: None, id: None }
+      39: Text { content: "\u{a0}" }
+      40: EndParagraph
       41: StartOrderedListItem { id: Some("3"), level: 0, start: Some(1), style_type: Decimal }
       42: StartParagraph { alignment: None, id: None }
       43: StartTextStyle { kind: TextColor(Rgb { b: 181, g: 117, r: 46 }), id: None }
       44: Text { content: "Wiki (xl)" }
       45: EndTextStyle
       46: EndParagraph
-      47: StartParagraph { alignment: None, id: None }
-      48: StartTextStyle { kind: Bold, id: None }
-      49: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
-      50: Text { content: "Goal:         Useful documentation that is archived, searchable and easy to create" }
-      51: EndTextStyle
+      47: EndOrderedListItem
+      48: StartParagraph { alignment: None, id: None }
+      49: StartTextStyle { kind: Bold, id: None }
+      50: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
+      51: Text { content: "Goal:         Useful documentation that is archived, searchable and easy to create" }
       52: EndTextStyle
-      53: EndParagraph
-      54: StartParagraph { alignment: None, id: None }
-      55: Text { content: "\u{a0}\u{a0}" }
-      56: EndParagraph
-      57: EndOrderedListItem
+      53: EndTextStyle
+      54: EndParagraph
+      55: StartParagraph { alignment: None, id: None }
+      56: Text { content: "\u{a0}\u{a0}" }
+      57: EndParagraph
       58: StartOrderedListItem { id: Some("4"), level: 0, start: Some(1), style_type: Decimal }
       59: StartParagraph { alignment: None, id: None }
       60: StartTextStyle { kind: TextColor(Rgb { b: 181, g: 117, r: 46 }), id: None }
       61: Text { content: "XL Code Autoreview Bot (XLCRBot). " }
       62: EndTextStyle
       63: EndParagraph
-      64: StartParagraph { alignment: None, id: None }
-      65: StartTextStyle { kind: Bold, id: None }
-      66: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
-      67: Text { content: "Goal:         Feedback on basic violations in seconds or minutes at most in either VS or Codeflow." }
-      68: EndTextStyle
+      64: EndOrderedListItem
+      65: StartParagraph { alignment: None, id: None }
+      66: StartTextStyle { kind: Bold, id: None }
+      67: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
+      68: Text { content: "Goal:         Feedback on basic violations in seconds or minutes at most in either VS or Codeflow." }
       69: EndTextStyle
-      70: EndParagraph
-      71: StartParagraph { alignment: None, id: None }
-      72: EndParagraph
-      73: EndOrderedListItem
+      70: EndTextStyle
+      71: EndParagraph
+      72: StartParagraph { alignment: None, id: None }
+      73: EndParagraph
       74: StartOrderedListItem { id: Some("5"), level: 0, start: Some(1), style_type: Decimal }
       75: StartParagraph { alignment: None, id: None }
       76: StartTextStyle { kind: TextColor(Rgb { b: 181, g: 117, r: 46 }), id: None }
       77: Text { content: "Code documentation" }
       78: EndTextStyle
       79: EndParagraph
-      80: StartParagraph { alignment: None, id: None }
-      81: StartTextStyle { kind: Bold, id: None }
-      82: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
-      83: Text { content: "Goal:        Useful, consistent, tool supported comments " }
-      84: EndTextStyle
+      80: EndOrderedListItem
+      81: StartParagraph { alignment: None, id: None }
+      82: StartTextStyle { kind: Bold, id: None }
+      83: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
+      84: Text { content: "Goal:        Useful, consistent, tool supported comments " }
       85: EndTextStyle
-      86: EndParagraph
-      87: StartParagraph { alignment: None, id: None }
-      88: StartTextStyle { kind: Bold, id: None }
-      89: Text { content: "\u{a0}" }
-      90: EndTextStyle
-      91: Text { content: "\u{a0}" }
-      92: EndParagraph
-      93: EndOrderedListItem
+      86: EndTextStyle
+      87: EndParagraph
+      88: StartParagraph { alignment: None, id: None }
+      89: StartTextStyle { kind: Bold, id: None }
+      90: Text { content: "\u{a0}" }
+      91: EndTextStyle
+      92: Text { content: "\u{a0}" }
+      93: EndParagraph
       94: StartOrderedListItem { id: Some("6"), level: 0, start: Some(1), style_type: Decimal }
       95: StartParagraph { alignment: None, id: None }
       96: StartTextStyle { kind: TextColor(Rgb { b: 181, g: 117, r: 46 }), id: None }
       97: Text { content: "Education efforts" }
       98: EndTextStyle
       99: EndParagraph
-     100: StartParagraph { alignment: None, id: None }
-     101: StartTextStyle { kind: Bold, id: None }
-     102: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
-     103: Text { content: "Goal:        Broad, discoverable channels for updates and news" }
-     104: EndTextStyle
+     100: EndOrderedListItem
+     101: StartParagraph { alignment: None, id: None }
+     102: StartTextStyle { kind: Bold, id: None }
+     103: StartTextStyle { kind: TextColor(Rgb { b: 213, g: 155, r: 91 }), id: None }
+     104: Text { content: "Goal:        Broad, discoverable channels for updates and news" }
      105: EndTextStyle
-     106: EndParagraph
-     107: StartParagraph { alignment: None, id: None }
-     108: StartTextStyle { kind: Bold, id: None }
-     109: Text { content: "\u{a0}" }
-     110: EndTextStyle
-     111: EndParagraph
-     112: EndOrderedListItem
+     106: EndTextStyle
+     107: EndParagraph
+     108: StartParagraph { alignment: None, id: None }
+     109: StartTextStyle { kind: Bold, id: None }
+     110: Text { content: "\u{a0}" }
+     111: EndTextStyle
+     112: EndParagraph
      113: EndDocument
   ],
   terminal: Ok,

--- a/tests/snapshots/docx/pandoc/lists_restarting.docx.snap
+++ b/tests/snapshots/docx/pandoc/lists_restarting.docx.snap
@@ -1,6 +1,7 @@
 ---
-source: crates/docspec-docx-reader/tests/pandoc_corpus.rs
-expression: snapshot
+source: crates/docspec-docx-reader/tests/snapshots.rs
+assertion_line: 56
+expression: from_reader_snapshot
 ---
 ReaderFixtureSnapshot {
   events: [
@@ -22,17 +23,17 @@ ReaderFixtureSnapshot {
       15: Text { content: "\t" }
       16: Text { content: "Baz" }
       17: EndParagraph
-      18: StartParagraph { alignment: None, id: None }
-      19: Text { content: "\t" }
-      20: EndParagraph
-      21: StartParagraph { alignment: None, id: None }
-      22: Text { content: "\t" }
-      23: Text { content: "Interruption" }
-      24: EndParagraph
-      25: StartParagraph { alignment: None, id: None }
-      26: Text { content: "\t" }
-      27: EndParagraph
-      28: EndOrderedListItem
+      18: EndOrderedListItem
+      19: StartParagraph { alignment: None, id: None }
+      20: Text { content: "\t" }
+      21: EndParagraph
+      22: StartParagraph { alignment: None, id: None }
+      23: Text { content: "\t" }
+      24: Text { content: "Interruption" }
+      25: EndParagraph
+      26: StartParagraph { alignment: None, id: None }
+      27: Text { content: "\t" }
+      28: EndParagraph
       29: StartOrderedListItem { id: Some("5"), level: 0, start: Some(1), style_type: Decimal }
       30: StartParagraph { alignment: None, id: None }
       31: Text { content: "\t" }


### PR DESCRIPTION
Fixes false-nesting of body content under list items.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of list numbering in documents where paragraphs reference styles containing numbering properties.
  * Lists now properly close when interrupted by paragraphs without list assignments, preventing incorrect list continuation across non-list content.

* **Tests**
  * Expanded test coverage for list numbering behavior, style-based list resolution, and paragraph style handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->