### PR TITLE
fix(http): remove default 2 MiB request body cap

### DIFF
--- a/crates/docspec-http/src/router.rs
+++ b/crates/docspec-http/src/router.rs
@@ -25,6 +25,7 @@ impl MakeRequestId for EchoOnly {
 #[inline]
 pub fn router() -> Router {
     use axum::body::Body;
+    use axum::extract::DefaultBodyLimit;
     use axum::http::header::HeaderName;
     use axum::middleware::{self, Next};
     use axum::routing::{get, post};
@@ -85,6 +86,12 @@ pub fn router() -> Router {
         .fallback(not_found)
         .layer(
             ServiceBuilder::new()
+                // Reason: axum's `Bytes`/`String`/`Json` extractors silently
+                // cap request bodies at 2 MiB by default. The README pledges
+                // `Body size: No limit ... DoS risk is accepted.`, so we
+                // disable the cap globally. Without this layer the
+                // `/conversion` handler would 413 on bodies >2 MiB.
+                .layer(DefaultBodyLimit::disable())
                 .layer(SetRequestIdLayer::new(
                     x_request_id.clone(),
                     MakeRequestUuid,

--- a/crates/docspec-http/tests/http_integration.rs
+++ b/crates/docspec-http/tests/http_integration.rs
@@ -181,6 +181,32 @@ async fn post_conversion_empty_body() {
 }
 
 #[tokio::test]
+async fn post_conversion_accepts_body_over_axum_default_limit() {
+    // Reason: axum's `Bytes` extractor caps request bodies at
+    // `const DEFAULT_LIMIT: usize = 2_097_152;` (2 MiB) by default. The
+    // router disables this via `DefaultBodyLimit::disable()` to honor the
+    // README's `Body size: No limit` pledge. A body of 2 MiB + 1 byte
+    // would 413 before this fix — verifying 200 OK here is the regression
+    // guard.
+    const TWO_MIB: usize = 2 * 1024 * 1024;
+    let large_body = "a".repeat(TWO_MIB + 1);
+
+    let response = app()
+        .oneshot(post_markdown(large_body))
+        .await
+        .expect("request succeeds");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .expect("content-type present"),
+        OUTPUT_MIME
+    );
+}
+
+#[tokio::test]
 async fn post_conversion_missing_content_type() {
     let request = common::request("POST", "/conversion", &[], Body::from("# Hello"));
 


### PR DESCRIPTION
Disables axum's default `Bytes` extractor cap so `/conversion` accepts bodies >2 MiB, matching the README's "no limit" pledge. +1 regression test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the app’s accepted request size so large conversion requests are no longer rejected with a 413 error.
  * Confirmed that conversion responses still return successfully for requests larger than the previous default limit.

* **Tests**
  * Added coverage to prevent regressions for large request bodies in the conversion flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->