### PR TITLE
Unified lift policy — emit nested blocks, lift cell content to nearest ancestor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,6 +544,7 @@ version = "1.18.2"
 dependencies = [
  "base64",
  "docspec-core",
+ "docspec-docx-reader",
  "docspec-json",
  "docspec-test-utils",
  "paste",

--- a/crates/docspec-blocknote-writer/Cargo.toml
+++ b/crates/docspec-blocknote-writer/Cargo.toml
@@ -16,6 +16,9 @@ docspec-json = { workspace = true }
 
 [dev-dependencies]
 docspec-test-utils = { workspace = true }
+# Used only in the sample.docx end-to-end integration test (sample_docx_lifts_list_from_requirements_cell).
+# A dev-only dep keeps it out of the published crate's runtime dependency graph.
+docspec-docx-reader = { path = "../docspec-docx-reader" }
 paste = "1"
 serde_json = "1"
 

--- a/crates/docspec-blocknote-writer/README.md
+++ b/crates/docspec-blocknote-writer/README.md
@@ -125,19 +125,25 @@ let json = String::from_utf8(buf)?;
 
 ## Limitations
 
-**Table cell content**: BlockNote's `tableCell.content` is `InlineContent[]` and cannot hold block-level types. Block-level events inside a cell are handled as follows:
+### Table cell content
 
-- `StartParagraph` / `EndParagraph` boundaries are absorbed silently (adjacent paragraphs concatenate without separator)
-- `Text` and `LineBreak` are preserved
-- Headings, code blocks, blockquotes, and list items are dropped silently
-- Images are lifted: each `Image` event encountered inside a cell is buffered and replayed as a top-level sibling block immediately after the enclosing outermost table closes, preserving document order with any other lifted content from the same table. Inline text adjacent to a lifted image in the same cell stays in that cell — only the image moves out.
-- Nested tables are lifted: their events are buffered between the inner `StartTable` and matching `EndTable`, then replayed as top-level sibling blocks immediately after the enclosing outermost table closes. Deep nesting (`A` containing `B` containing `C`) flattens to a top-level sequence (`A, B, C`) in document order. Inline text adjacent to a nested table in the same outer cell stays in that outer cell. Images inside a nested cell lift through the recursive drain — they emit as siblings of the already-lifted nested table.
+BlockNote's `tableCell.content` is `InlineContent[]` and cannot hold block-level types. Block-level events inside a cell — headings, lists, blockquotes, code blocks, dividers, images, nested tables — are buffered and **lifted and replayed as siblings** of the enclosing table.
 
-**Non-paragraph children inside list items**: headings, images, code blocks, and blockquotes that appear as children of a list item are dropped. The first paragraph's inline content populates the item's `content[]` array; each subsequent paragraph becomes a child `paragraph` block in `children[]`.
+Lift destination: the buffered blocks are drained into the nearest still-open ancestor that accepts block children — a list item or blockquote when one is open, otherwise document root. List item levels are rebased during drain to preserve nesting consistency.
 
-**Blockquote + list interaction**: a list item encountered while inside a blockquote force-closes the blockquote and emits the list item at the top level as a sibling.
+Inline text adjacent to lifted content stays in the cell. Paragraph boundaries are absorbed silently.
 
-**Image-in-link**: BlockNote does not allow block-level images inside inline links. The reader closes the link before emitting the image as a sibling block, and the writer serialises that sequence directly. Content preceding the image stays inside the link; the image becomes a sibling block after the link closes; content following the image appears outside the link, losing its link wrapper. The link is empty only when the image is the sole link label, e.g. `[![alt](img.png)](url)`. All variants are lossy mappings of the original "image-inside-link" structure.
+### List item children
+
+Headings, blockquotes, code blocks, tables, dividers, images, and nested lists inside a list item are emitted as blocks in the item's `children[]` array. The first paragraph's inline content populates the item's `content[]`; subsequent paragraphs become child `paragraph` blocks in `children[]`.
+
+### Blockquote children
+
+Headings, lists, code blocks, images, dividers, and nested quotes inside a blockquote are emitted as blocks in the quote's `children[]` array. Inline content (text, formatted runs) populates `content[]` until a block child arrives, at which point the writer transitions to children-only mode.
+
+### Image in links
+
+Images inside a link span are emitted as plain text using the alt-text of the image. This is a BlockNote limitation: BlockNote's inline content cannot contain image nodes.
 
 ## API Documentation
 

--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -158,7 +158,7 @@ pub mod palette;
 use std::io::Write;
 
 use docspec_core::{
-    Depth, Error, Event, EventSink, ImageSource, Result, TextAlignment, TextStyleKind,
+    BlockKind, Depth, Error, Event, EventSink, ImageSource, Result, TextAlignment, TextStyleKind,
 };
 use docspec_json::{JsonEmitter, Null, StrusonBackend};
 
@@ -169,32 +169,6 @@ macro_rules! close_text_block {
         $writer.context.in_text_block = false;
         Ok(())
     }};
-}
-
-macro_rules! return_if_table_cell {
-    ($writer:expr) => {
-        if $writer.context.in_table_cell {
-            return Ok(());
-        }
-    };
-}
-
-macro_rules! drop_block_in_list_start {
-    ($writer:expr) => {
-        if $writer.in_any_list_item() || $writer.drop_inside_list_depth.is_positive() {
-            $writer.drop_inside_list_depth.inc();
-            return Ok(());
-        }
-    };
-}
-
-macro_rules! drop_block_in_list_end {
-    ($writer:expr) => {
-        if $writer.drop_inside_list_depth.is_positive() {
-            $writer.drop_inside_list_depth.dec();
-            return Ok(());
-        }
-    };
 }
 
 /// Represents the kind of list (ordered or unordered).
@@ -212,6 +186,68 @@ enum ListContentState {
     Open,
     Closed,
 }
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Default)]
+enum BlockquoteContentState {
+    /// Quote is open but no content has been emitted yet.
+    /// The writer has NOT yet decided whether to open `"content": [` or `"children": [`.
+    #[default]
+    Pending,
+    /// `"content": [` is open and we're emitting inline content into it.
+    InContent,
+    /// `"content": []` has been written and closed; `"children": [` is open
+    /// and we're emitting block children into it.
+    InChildren,
+}
+
+#[derive(Debug)]
+enum DrainDestination {
+    DocumentRoot,
+    Ancestor {
+        ancestor_index: usize,
+        kind: BlockKind,
+    },
+}
+
+/// Block-level events that are leaves (no Start/End counterpart) in the `DocSpec` stream.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum BlockLeafKind {
+    Image,
+    Divider,
+}
+
+/// Represents a potential child block kind for the `blocknote_accepts_child` predicate.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum ChildKind {
+    Container(BlockKind),
+    Leaf(BlockLeafKind),
+}
+
+/// Returns true iff `BlockNote`'s default schema allows `child` to appear inside `parent`.
+/// Captures the schema constraint, NOT writer policy (drop/lift is the policy layer).
+fn blocknote_accepts_child(parent: Option<BlockKind>, child: ChildKind) -> bool {
+    match parent {
+        None => true,
+        Some(
+            BlockKind::Blockquote
+            | BlockKind::Heading
+            | BlockKind::OrderedListItem
+            | BlockKind::UnorderedListItem,
+        ) => !matches!(
+            child,
+            ChildKind::Container(
+                BlockKind::TableRow | BlockKind::TableCell | BlockKind::TableHeader
+            )
+        ),
+        Some(_) => false,
+    }
+}
+
+const _: BlockLeafKind = BlockLeafKind::Image;
+const _: BlockLeafKind = BlockLeafKind::Divider;
+const _: ChildKind = ChildKind::Container(BlockKind::Paragraph);
+const _: ChildKind = ChildKind::Leaf(BlockLeafKind::Image);
+const _: fn(Option<BlockKind>, ChildKind) -> bool = blocknote_accepts_child;
 
 /// Represents a single entry in the list stack, tracking list nesting state.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -256,34 +292,39 @@ fn non_default_alignment_value(alignment: Option<&TextAlignment>) -> Option<&'st
 /// * `W` - Any type implementing [`Write`]
 pub struct BlockNoteWriter<W: Write> {
     blockquote_depth: Depth,
-    blockquote_force_closed_count: Depth,
+    /// Per-blockquote content state stack. One entry is pushed on each `StartBlockQuote` and
+    /// popped on the matching `EndBlockQuote`. Tracks whether the current blockquote has opened
+    /// its `"content": [` array (inline content), its `"children": [` array (block children),
+    /// or neither yet (pending).
+    blockquote_content_states: Vec<BlockquoteContentState>,
     context: BlockContext,
-    drop_inside_list_depth: Depth,
-    dropped_list_depth: Depth,
     /// Whether the writer is currently inside an open link inline container.
     in_link: bool,
     json: JsonEmitter<StrusonBackend<W>>,
     /// Whether at least one `StyledText` has been emitted into the current link's content array.
     link_emitted_styled_text: bool,
     /// Events deferred for replay at the outermost `EndTable` as top-level siblings:
-    /// nested-table substreams and in-cell `Image` events. Both are illegal inside
-    /// `BlockNote`'s `tableCell.content`; co-buffering preserves their document order.
+    /// nested-table substreams, in-cell `Image` events, and block-level events started
+    /// inside a table cell. All are illegal inside `BlockNote`'s `tableCell.content`;
+    /// co-buffering preserves their document order.
     lifted_nested_events: Vec<Event>,
+    /// Tracks nesting depth of non-table block-level subtrees currently being buffered
+    /// for lift (e.g. a heading or blockquote that started inside a table cell). Increments
+    /// on each non-table block-level start event while buffering; decrements on the
+    /// matching end. Zero means we are not currently inside such a subtree.
+    lifted_subtree_depth: Depth,
     list_stack: Vec<ListStackEntry>,
+    /// Ordered stack of open block containers in emission order.
+    /// Pushed when an outer container is opened in the EMITTED output (not while buffering).
+    /// Used to compute the nearest valid drain destination for lifted events.
+    /// Contains: `Blockquote`, `OrderedListItem`, `UnorderedListItem`, `Table` (tables listed for
+    /// completeness but never serve as drain destinations per predicate).
+    open_block_ancestors: Vec<BlockKind>,
     open_styles: Vec<TextStyleKind>,
     table_depth: Depth,
 }
 
 impl<W: Write> BlockNoteWriter<W> {
-    fn close_blockquote_for_sibling(&mut self) -> Result<()> {
-        self.close_open_link_if_any()?;
-        self.close_content_block()?;
-        self.blockquote_depth.dec();
-        self.blockquote_force_closed_count.inc();
-        self.context.in_text_block = self.blockquote_depth.is_positive();
-        Ok(())
-    }
-
     fn close_content_block(&mut self) -> Result<()> {
         self.json.close_array()?;
         self.json.key("children").array(|_| Ok(()))?;
@@ -300,6 +341,10 @@ impl<W: Write> BlockNoteWriter<W> {
         }
         let popped_entry = self.list_stack.pop();
         if let Some(list_entry) = popped_entry {
+            let ancestor_kind = match list_entry.kind {
+                ListKind::Ordered => BlockKind::OrderedListItem,
+                ListKind::Unordered => BlockKind::UnorderedListItem,
+            };
             if list_entry.content_state == ListContentState::Open {
                 self.close_open_link_if_any()?;
                 self.json.close_array()?;
@@ -310,6 +355,7 @@ impl<W: Write> BlockNoteWriter<W> {
                 self.json.key("children").array(|_| Ok(()))?;
             }
             self.json.close_object()?;
+            self.pop_ancestor(ancestor_kind);
         }
         Ok(())
     }
@@ -319,7 +365,7 @@ impl<W: Write> BlockNoteWriter<W> {
             self.close_open_list_items()?;
         }
         if self.blockquote_depth.is_positive() {
-            return self.close_blockquote_for_sibling();
+            return self.prepare_blockquote_children();
         }
         if self.context.in_text_block {
             self.close_open_link_if_any()?;
@@ -352,10 +398,46 @@ impl<W: Write> BlockNoteWriter<W> {
         self.json.open_object()?;
         self.json.key("type").value("quote")?;
         self.write_id(id)?;
-        self.json.key("content").open_array()?;
         self.blockquote_depth.inc();
+        self.blockquote_content_states
+            .push(BlockquoteContentState::Pending);
+        self.open_block_ancestors.push(BlockKind::Blockquote);
         self.context.blockquote_has_content = false;
-        self.context.in_text_block = true;
+        Ok(())
+    }
+
+    fn prepare_blockquote_inline_content(&mut self) -> Result<()> {
+        if self.blockquote_content_states.last() == Some(&BlockquoteContentState::Pending) {
+            self.json.key("content").open_array()?;
+            if let Some(state) = self.blockquote_content_states.last_mut() {
+                *state = BlockquoteContentState::InContent;
+            }
+            self.context.in_text_block = true;
+        }
+        Ok(())
+    }
+
+    fn prepare_blockquote_children(&mut self) -> Result<()> {
+        match self.blockquote_content_states.last().copied() {
+            Some(BlockquoteContentState::Pending) => {
+                self.json.key("content").open_array()?;
+                self.json.close_array()?;
+                self.json.key("children").open_array()?;
+                if let Some(state) = self.blockquote_content_states.last_mut() {
+                    *state = BlockquoteContentState::InChildren;
+                }
+            }
+            Some(BlockquoteContentState::InContent) => {
+                self.close_open_link_if_any()?;
+                self.json.close_array()?;
+                self.context.in_text_block = false;
+                self.json.key("children").open_array()?;
+                if let Some(state) = self.blockquote_content_states.last_mut() {
+                    *state = BlockquoteContentState::InChildren;
+                }
+            }
+            Some(BlockquoteContentState::InChildren) | None => {}
+        }
         Ok(())
     }
 
@@ -394,10 +476,6 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_end_list_item(&mut self) -> Result<()> {
-        if self.dropped_list_depth.is_positive() {
-            self.dropped_list_depth.dec();
-            return Ok(());
-        }
         if self.list_stack.is_empty() {
             return Ok(());
         }
@@ -405,10 +483,10 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_end_paragraph(&mut self) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() || self.dropped_list_depth.is_positive() {
-            return Ok(());
-        }
+        let in_current_blockquote_list_item =
+            self.blockquote_depth.is_positive() && self.current_blockquote_contains_list_item();
         if !self.list_stack.is_empty()
+            && (self.blockquote_depth.is_zero() || in_current_blockquote_list_item)
             && self
                 .list_stack
                 .last()
@@ -421,6 +499,15 @@ impl<W: Write> BlockNoteWriter<W> {
             self.json.close_object()?;
             self.context.in_text_block = false;
             return Ok(());
+        }
+        if self.blockquote_depth.is_positive()
+            && self.context.in_text_block
+            && self
+                .blockquote_content_states
+                .last()
+                .is_some_and(|state| *state == BlockquoteContentState::InChildren)
+        {
+            return close_text_block!(self);
         }
         if self.in_list_item_content() {
             if let Some(entry) = self.list_stack.last_mut() {
@@ -438,7 +525,6 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_end_table(&mut self) -> Result<()> {
-        drop_block_in_list_end!(self);
         if self.table_depth.is_zero() {
             return Ok(());
         }
@@ -446,14 +532,12 @@ impl<W: Write> BlockNoteWriter<W> {
         self.json.close_object()?;
         self.json.key("children").array(|_| Ok(()))?;
         self.json.close_object()?;
-        self.table_depth.reset();
+        self.pop_ancestor(BlockKind::Table);
+        self.table_depth.dec();
         Ok(())
     }
 
     fn handle_end_table_cell(&mut self) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() {
-            return Ok(());
-        }
         self.close_open_link_if_any()?;
         self.json.close_array()?;
         self.json.close_object()?;
@@ -462,27 +546,40 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_end_table_row(&mut self) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() {
-            return Ok(());
-        }
         self.json.close_array()?;
         self.json.close_object()
     }
 
     fn handle_end_blockquote(&mut self) -> Result<()> {
-        drop_block_in_list_end!(self);
-        return_if_table_cell!(self);
-        if self.blockquote_force_closed_count.is_positive() {
-            self.blockquote_force_closed_count.dec();
+        if self.blockquote_depth.is_zero() {
             return Ok(());
         }
-        if self.blockquote_depth.is_zero() || !self.context.in_text_block {
-            return Ok(());
+        let state = self.blockquote_content_states.pop().unwrap_or_default();
+        match state {
+            BlockquoteContentState::Pending => {
+                self.json.key("content").open_array()?;
+                self.json.close_array()?;
+                self.json.key("children").open_array()?;
+                self.json.close_array()?;
+            }
+            BlockquoteContentState::InContent => {
+                self.close_open_link_if_any()?;
+                self.json.close_array()?;
+                self.context.in_text_block = false;
+                self.json.key("children").open_array()?;
+                self.json.close_array()?;
+            }
+            BlockquoteContentState::InChildren => {
+                self.json.close_array()?;
+            }
         }
-        self.close_open_link_if_any()?;
-        self.close_content_block()?;
+        self.pop_ancestor(BlockKind::Blockquote);
         self.blockquote_depth.dec();
-        self.context.in_text_block = self.blockquote_depth.is_positive();
+        self.context.in_text_block = self
+            .blockquote_content_states
+            .last()
+            .is_some_and(|s| *s == BlockquoteContentState::InContent);
+        self.json.close_object()?;
         Ok(())
     }
 
@@ -504,13 +601,7 @@ impl<W: Write> BlockNoteWriter<W> {
         alt: Option<String>,
         id: Option<&str>,
     ) -> Result<()> {
-        if self.context.in_table_cell || self.drop_inside_list_depth.is_positive() {
-            return Ok(());
-        }
-        if self.in_any_list_item() {
-            return Ok(());
-        }
-        self.close_for_block_sibling()?;
+        self.prepare_for_child_block()?;
         let caption = alt.unwrap_or_default();
 
         match source {
@@ -561,9 +652,6 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_line_break(&mut self) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() {
-            return Ok(());
-        }
         if self.context.in_text_block || self.context.in_table_cell || self.in_list_item_content() {
             self.handle_text("\n")
         } else {
@@ -580,15 +668,13 @@ impl<W: Write> BlockNoteWriter<W> {
         if self.context.in_table_cell {
             return Ok(());
         }
-        // Paragraphs nested inside a dropped block must not mutate list state or emit JSON;
-        // they are absorbed along with the surrounding dropped block.
-        if self.drop_inside_list_depth.is_positive() || self.dropped_list_depth.is_positive() {
-            return Ok(());
-        }
+        let in_current_blockquote_list_item =
+            self.blockquote_depth.is_positive() && self.current_blockquote_contains_list_item();
         // Second and subsequent paragraphs inside a list item dispatch as child paragraph blocks
         // in the item's children[] array (T11). Must be checked before in_list_item_content()
         // because content may still be open when first_paragraph_consumed is set.
         if !self.list_stack.is_empty()
+            && (self.blockquote_depth.is_zero() || in_current_blockquote_list_item)
             && self
                 .list_stack
                 .last()
@@ -621,14 +707,30 @@ impl<W: Write> BlockNoteWriter<W> {
             self.context.in_text_block = true;
             return Ok(());
         }
-        if !self.list_stack.is_empty() {
+        if !self.list_stack.is_empty()
+            && (self.blockquote_depth.is_zero() || in_current_blockquote_list_item)
+        {
             self.initialize_current_list_item_content(alignment)?;
             return Ok(());
         }
         if self.blockquote_depth.is_positive() {
+            if self
+                .blockquote_content_states
+                .last()
+                .is_some_and(|state| *state == BlockquoteContentState::InChildren)
+            {
+                self.json.open_object()?;
+                self.write_id(id)?;
+                self.json.key("type").value("paragraph")?;
+                self.write_paragraph_props(alignment)?;
+                self.json.key("content").open_array()?;
+                self.context.in_text_block = true;
+                return Ok(());
+            }
             if self.context.blockquote_has_content {
                 self.handle_text("\n\n")?;
             }
+            self.prepare_blockquote_inline_content()?;
             return Ok(());
         }
         self.json.open_object()?;
@@ -667,9 +769,6 @@ impl<W: Write> BlockNoteWriter<W> {
     ///
     /// Drops `title` and `id` — `BlockNote`'s inline link schema has no slot for these.
     fn handle_start_link(&mut self, href: &str) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() || self.dropped_list_depth.is_positive() {
-            return Ok(());
-        }
         if self.list_stack.last().is_some_and(|entry| {
             entry.content_state == ListContentState::Pending && !entry.first_paragraph_consumed
         }) {
@@ -712,6 +811,25 @@ impl<W: Write> BlockNoteWriter<W> {
         Ok(())
     }
 
+    fn current_blockquote_contains_list_item(&self) -> bool {
+        let Some(blockquote_index) = self
+            .open_block_ancestors
+            .iter()
+            .rposition(|kind| *kind == BlockKind::Blockquote)
+        else {
+            return false;
+        };
+        self.open_block_ancestors
+            .iter()
+            .skip(blockquote_index.saturating_add(1))
+            .any(|kind| {
+                matches!(
+                    kind,
+                    BlockKind::OrderedListItem | BlockKind::UnorderedListItem
+                )
+            })
+    }
+
     fn handle_start_list_item(
         &mut self,
         kind: ListKind,
@@ -719,12 +837,12 @@ impl<W: Write> BlockNoteWriter<W> {
         level: u32,
         start: Option<u64>,
     ) -> Result<()> {
-        if self.context.in_table_cell || self.drop_inside_list_depth.is_positive() {
-            self.dropped_list_depth.inc();
-            return Ok(());
-        }
         if self.blockquote_depth.is_positive() {
-            self.close_blockquote_for_sibling()?;
+            self.prepare_blockquote_children()?;
+            if !self.current_blockquote_contains_list_item() {
+                self.open_list_item_object(kind, id, level, start)?;
+                return Ok(());
+            }
         }
         if self.list_stack.is_empty() {
             self.close_for_block_sibling()?;
@@ -773,8 +891,7 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_start_table(&mut self, id: Option<&str>) -> Result<()> {
-        drop_block_in_list_start!(self);
-        self.close_for_block_sibling()?;
+        self.prepare_for_child_block()?;
         self.json.open_object()?;
         self.json.key("type").value("table")?;
         self.write_id(id)?;
@@ -783,14 +900,12 @@ impl<W: Write> BlockNoteWriter<W> {
         self.json.key("columnWidths").array(|_| Ok(()))?;
         self.json.key("rows").open_array()?;
         self.table_depth.inc();
+        self.open_block_ancestors.push(BlockKind::Table);
         self.context.in_text_block = false;
         Ok(())
     }
 
     fn handle_start_table_row(&mut self, id: Option<&str>) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() {
-            return Ok(());
-        }
         self.json.open_object()?;
         self.write_id(id)?;
         self.json.key("cells").open_array()
@@ -820,9 +935,6 @@ impl<W: Write> BlockNoteWriter<W> {
         colspan: Option<u32>,
         rowspan: Option<u32>,
     ) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() {
-            return Ok(());
-        }
         self.json.open_object()?;
         self.json.key("type").value("tableCell")?;
         self.write_id(id)?;
@@ -844,11 +956,9 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_text(&mut self, content: &str) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive()
-            || self.dropped_list_depth.is_positive()
-            || (!self.context.in_text_block
-                && !self.context.in_table_cell
-                && !self.in_list_item_content())
+        if !self.context.in_text_block
+            && !self.context.in_table_cell
+            && !self.in_list_item_content()
         {
             return Ok(());
         }
@@ -922,14 +1032,14 @@ impl<W: Write> BlockNoteWriter<W> {
     }
 
     fn handle_text_event(&mut self, content: &str) -> Result<()> {
-        if self.drop_inside_list_depth.is_positive() || self.dropped_list_depth.is_positive() {
-            return Ok(());
-        }
         // Auto-open paragraph for orphan text (e.g., text after image closed paragraph)
         if self.list_stack.last().is_some_and(|entry| {
             entry.content_state == ListContentState::Pending && !entry.first_paragraph_consumed
         }) {
             self.initialize_current_list_item_content(None)?;
+        }
+        if self.blockquote_depth.is_positive() && !self.context.in_text_block {
+            self.prepare_blockquote_inline_content()?;
         }
         if !self.context.in_text_block
             && self.blockquote_depth.is_zero()
@@ -939,17 +1049,6 @@ impl<W: Write> BlockNoteWriter<W> {
             self.handle_paragraph(None, None)?;
         }
         self.handle_text(content)
-    }
-
-    /// Returns true when any list item is currently open on the stack, regardless of whether
-    /// its `content[]` or `children[]` array is the active emission target. Drop trigger for
-    /// non-paragraph block events that must be suppressed anywhere inside a list item per the
-    /// module-level policy (headings, images, code blocks, blockquotes, tables, thematic
-    /// breaks). Broader than `in_list_item_content`, which is true only while `content[]` is
-    /// open — `in_any_list_item` also returns true after a multi-paragraph or nested-list
-    /// transition has moved emission into `children[]`.
-    fn in_any_list_item(&self) -> bool {
-        !self.list_stack.is_empty()
     }
 
     fn in_list_item_content(&self) -> bool {
@@ -968,17 +1067,60 @@ impl<W: Write> BlockNoteWriter<W> {
     pub fn new(writer: W) -> Self {
         Self {
             blockquote_depth: Depth::default(),
-            blockquote_force_closed_count: Depth::default(),
+            blockquote_content_states: Vec::new(),
             context: BlockContext::default(),
-            drop_inside_list_depth: Depth::default(),
-            dropped_list_depth: Depth::default(),
             in_link: false,
             json: JsonEmitter::new(StrusonBackend::new(writer)),
             lifted_nested_events: Vec::new(),
+            lifted_subtree_depth: Depth::default(),
             link_emitted_styled_text: false,
             list_stack: Vec::new(),
+            open_block_ancestors: Vec::new(),
             open_styles: Vec::new(),
             table_depth: Depth::default(),
+        }
+    }
+
+    fn current_drain_destination(&self) -> DrainDestination {
+        for (idx, kind) in self.open_block_ancestors.iter().enumerate().rev() {
+            if blocknote_accepts_child(Some(*kind), ChildKind::Container(BlockKind::Heading)) {
+                return DrainDestination::Ancestor {
+                    ancestor_index: idx,
+                    kind: *kind,
+                };
+            }
+        }
+        DrainDestination::DocumentRoot
+    }
+
+    fn compute_rebase_offset(&self, buffered: &[Event]) -> u32 {
+        let min_buffered_level = buffered
+            .iter()
+            .filter_map(|event| match event {
+                Event::StartOrderedListItem { level, .. }
+                | Event::StartUnorderedListItem { level, .. } => Some(*level),
+                _ => None,
+            })
+            .min();
+
+        let Some(min_level) = min_buffered_level else {
+            return 0;
+        };
+
+        let required_min_level = self
+            .list_stack
+            .last()
+            .map_or(0, |entry| entry.level.saturating_add(1));
+        required_min_level.saturating_sub(min_level)
+    }
+
+    fn pop_ancestor(&mut self, kind: BlockKind) {
+        if let Some(pos) = self
+            .open_block_ancestors
+            .iter()
+            .rposition(|entry| *entry == kind)
+        {
+            self.open_block_ancestors.remove(pos);
         }
     }
 
@@ -1048,6 +1190,26 @@ impl<W: Write> BlockNoteWriter<W> {
         Ok(())
     }
 
+    fn prepare_list_item_children(&mut self) -> Result<()> {
+        self.open_current_list_item_children()
+    }
+
+    fn prepare_for_child_block(&mut self) -> Result<()> {
+        match self.current_drain_destination() {
+            DrainDestination::Ancestor {
+                kind: BlockKind::Blockquote,
+                ..
+            } => self.prepare_blockquote_children(),
+            DrainDestination::Ancestor {
+                kind: BlockKind::OrderedListItem | BlockKind::UnorderedListItem,
+                ..
+            } => self.prepare_list_item_children(),
+            DrainDestination::Ancestor { .. } | DrainDestination::DocumentRoot => {
+                self.close_for_block_sibling()
+            }
+        }
+    }
+
     fn open_list_item_object(
         &mut self,
         kind: ListKind,
@@ -1077,6 +1239,11 @@ impl<W: Write> BlockNoteWriter<W> {
             level,
             start: checked_start,
         });
+        let ancestor_kind = match kind {
+            ListKind::Ordered => BlockKind::OrderedListItem,
+            ListKind::Unordered => BlockKind::UnorderedListItem,
+        };
+        self.open_block_ancestors.push(ancestor_kind);
         Ok(())
     }
 
@@ -1099,11 +1266,19 @@ impl<W: Write> BlockNoteWriter<W> {
     fn omit_future_text_style(_style: &TextStyleKind) {}
 
     fn should_buffer_for_lift(&self, event: &Event) -> bool {
-        match event {
-            Event::StartTable { .. } => self.table_depth.is_positive(),
-            Event::Image { .. } if self.context.in_table_cell => true,
-            _ => self.table_depth.get() >= 2,
+        if self.table_depth.get() >= 2 || self.lifted_subtree_depth.is_positive() {
+            return true;
         }
+        if self.context.in_table_cell && Self::is_block_level_start(event) {
+            return true;
+        }
+        if matches!(event, Event::Image { .. }) && self.context.in_table_cell {
+            return true;
+        }
+        if matches!(event, Event::StartTable { .. }) && self.table_depth.is_positive() {
+            return true;
+        }
+        false
     }
 
     fn update_lift_depth(&mut self, event: &Event) {
@@ -1111,6 +1286,19 @@ impl<W: Write> BlockNoteWriter<W> {
             Event::StartTable { .. } => self.table_depth.inc(),
             Event::EndTable => self.table_depth.dec(),
             _ => {}
+        }
+        let non_leaf_block_start =
+            Self::is_block_level_start(event) && !matches!(event, Event::ThematicBreak { .. });
+        let non_leaf_block_end =
+            Self::is_block_level_end(event) && !matches!(event, Event::ThematicBreak { .. });
+        if non_leaf_block_start
+            && ((self.context.in_table_cell && self.table_depth.get() == 1)
+                || self.lifted_subtree_depth.is_positive())
+        {
+            self.lifted_subtree_depth.inc();
+        }
+        if non_leaf_block_end && self.lifted_subtree_depth.is_positive() {
+            self.lifted_subtree_depth.dec();
         }
     }
 
@@ -1120,10 +1308,94 @@ impl<W: Write> BlockNoteWriter<W> {
 
     fn drain_lifted_nested_events(&mut self) -> Result<()> {
         let buffered = core::mem::take(&mut self.lifted_nested_events);
+        if buffered.is_empty() {
+            return Ok(());
+        }
+        match self.current_drain_destination() {
+            DrainDestination::Ancestor {
+                ancestor_index,
+                kind: BlockKind::Blockquote,
+            } => {
+                let _ = ancestor_index;
+                self.prepare_blockquote_children()?;
+            }
+            DrainDestination::Ancestor {
+                ancestor_index,
+                kind: BlockKind::OrderedListItem | BlockKind::UnorderedListItem,
+            } => {
+                let _ = ancestor_index;
+                self.prepare_list_item_children()?;
+            }
+            DrainDestination::Ancestor { ancestor_index, .. } => {
+                let _ = ancestor_index;
+                self.close_for_block_sibling()?;
+            }
+            DrainDestination::DocumentRoot => {
+                self.close_for_block_sibling()?;
+            }
+        }
+        let rebase_offset = match self.current_drain_destination() {
+            DrainDestination::Ancestor {
+                kind: BlockKind::OrderedListItem | BlockKind::UnorderedListItem,
+                ..
+            } => self.compute_rebase_offset(&buffered),
+            DrainDestination::Ancestor { .. } | DrainDestination::DocumentRoot => 0,
+        };
         for ev in buffered {
-            self.handle_event(ev)?;
+            let rebased_event = if rebase_offset > 0 {
+                match ev {
+                    Event::StartOrderedListItem {
+                        id,
+                        level,
+                        start,
+                        style_type,
+                    } => Event::StartOrderedListItem {
+                        id,
+                        level: level.saturating_add(rebase_offset),
+                        start,
+                        style_type,
+                    },
+                    Event::StartUnorderedListItem {
+                        id,
+                        level,
+                        style_type,
+                    } => Event::StartUnorderedListItem {
+                        id,
+                        level: level.saturating_add(rebase_offset),
+                        style_type,
+                    },
+                    other => other,
+                }
+            } else {
+                ev
+            };
+            self.handle_event(rebased_event)?;
         }
         Ok(())
+    }
+
+    fn is_block_level_start(event: &Event) -> bool {
+        matches!(
+            event,
+            Event::StartHeading { .. }
+                | Event::StartBlockQuote { .. }
+                | Event::StartPreformatted { .. }
+                | Event::StartOrderedListItem { .. }
+                | Event::StartUnorderedListItem { .. }
+                | Event::ThematicBreak { .. }
+        )
+    }
+
+    fn is_block_level_end(event: &Event) -> bool {
+        matches!(
+            event,
+            Event::EndHeading
+                | Event::EndBlockQuote
+                | Event::EndPreformatted
+                | Event::EndOrderedListItem
+                | Event::EndUnorderedListItem
+                | Event::ThematicBreak { .. }
+        )
     }
 }
 
@@ -1145,21 +1417,10 @@ impl<W: Write> EventSink for BlockNoteWriter<W> {
             Event::StartDocument { .. } => self.json.open_array(),
             Event::EndDocument => self.handle_end_document(),
             Event::StartHeading { level, id, .. } => {
-                return_if_table_cell!(self);
-                drop_block_in_list_start!(self);
-                self.close_for_block_sibling()?;
+                self.prepare_for_child_block()?;
                 self.handle_heading(level, id.as_deref())
             }
-            Event::EndHeading => {
-                drop_block_in_list_end!(self);
-                if !self.context.in_text_block {
-                    return Ok(());
-                }
-                close_text_block!(self)
-            }
-            Event::EndPreformatted => {
-                drop_block_in_list_end!(self);
-                return_if_table_cell!(self);
+            Event::EndHeading | Event::EndPreformatted => {
                 if !self.context.in_text_block {
                     return Ok(());
                 }
@@ -1170,24 +1431,16 @@ impl<W: Write> EventSink for BlockNoteWriter<W> {
             }
             Event::EndParagraph => self.handle_end_paragraph(),
             Event::StartBlockQuote { id, .. } => {
-                return_if_table_cell!(self);
-                drop_block_in_list_start!(self);
-                self.close_for_block_sibling()?;
+                self.prepare_for_child_block()?;
                 self.handle_blockquote(id.as_deref())
             }
             Event::EndBlockQuote => self.handle_end_blockquote(),
             Event::StartPreformatted { id, syntax, .. } => {
-                return_if_table_cell!(self);
-                drop_block_in_list_start!(self);
-                self.close_for_block_sibling()?;
+                self.prepare_for_child_block()?;
                 self.handle_preformatted(id.as_deref(), syntax.as_deref())
             }
             Event::ThematicBreak { id, .. } => {
-                return_if_table_cell!(self);
-                if self.in_any_list_item() || self.drop_inside_list_depth.is_positive() {
-                    return Ok(());
-                }
-                self.close_for_block_sibling()?;
+                self.prepare_for_child_block()?;
                 self.handle_divider(id.as_deref())
             }
             Event::Text { content } => self.handle_text_event(&content),
@@ -1247,6 +1500,148 @@ mod tests {
     }
 
     #[test]
+    fn blockquote_state_stack_empty_after_new() {
+        let mut buf = Vec::new();
+        let writer = BlockNoteWriter::new(&mut buf);
+        assert!(writer.blockquote_content_states.is_empty());
+    }
+
+    #[test]
+    fn current_drain_destination_unit_walks_stack_top_to_bottom() {
+        let mut buf = Vec::new();
+        let mut writer = BlockNoteWriter::new(&mut buf);
+
+        writer.open_block_ancestors.push(BlockKind::OrderedListItem);
+        writer.open_block_ancestors.push(BlockKind::Table);
+        writer.open_block_ancestors.push(BlockKind::Blockquote);
+
+        assert!(matches!(
+            writer.current_drain_destination(),
+            DrainDestination::Ancestor {
+                ancestor_index: 2,
+                kind: BlockKind::Blockquote,
+            }
+        ));
+    }
+
+    #[test]
+    fn current_drain_destination_skips_table_to_document_root() {
+        let mut buf = Vec::new();
+        let mut writer = BlockNoteWriter::new(&mut buf);
+        writer.open_block_ancestors.push(BlockKind::Table);
+
+        assert!(matches!(
+            writer.current_drain_destination(),
+            DrainDestination::DocumentRoot
+        ));
+    }
+
+    #[test]
+    fn compute_rebase_offset_without_list_items_is_zero() {
+        let mut buf = Vec::new();
+        let writer = BlockNoteWriter::new(&mut buf);
+
+        assert_eq!(
+            writer.compute_rebase_offset(&[Event::StartParagraph {
+                alignment: None,
+                id: None,
+            }]),
+            0
+        );
+    }
+
+    #[test]
+    fn compute_rebase_offset_without_destination_list_is_zero_for_level_zero() {
+        let mut buf = Vec::new();
+        let writer = BlockNoteWriter::new(&mut buf);
+
+        assert_eq!(
+            writer.compute_rebase_offset(&[Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            }]),
+            0
+        );
+    }
+
+    #[test]
+    fn compute_rebase_offset_uses_current_list_stack_level() {
+        let mut buf = Vec::new();
+        let mut writer = BlockNoteWriter::new(&mut buf);
+        writer.list_stack.push(ListStackEntry {
+            children_array_open: true,
+            content_state: ListContentState::Closed,
+            first_paragraph_consumed: true,
+            kind: ListKind::Unordered,
+            level: 2,
+            start: None,
+        });
+
+        assert_eq!(
+            writer.compute_rebase_offset(&[
+                Event::StartOrderedListItem {
+                    id: None,
+                    level: 4,
+                    start: Some(1),
+                    style_type: docspec_core::ListStyleType::Decimal,
+                },
+                Event::StartUnorderedListItem {
+                    id: None,
+                    level: 0,
+                    style_type: docspec_core::ListStyleType::Disc,
+                },
+            ]),
+            3
+        );
+    }
+
+    #[test]
+    fn compute_rebase_offset_does_not_lower_already_nested_items() {
+        let mut buf = Vec::new();
+        let mut writer = BlockNoteWriter::new(&mut buf);
+        writer.list_stack.push(ListStackEntry {
+            children_array_open: true,
+            content_state: ListContentState::Closed,
+            first_paragraph_consumed: true,
+            kind: ListKind::Unordered,
+            level: 1,
+            start: None,
+        });
+
+        assert_eq!(
+            writer.compute_rebase_offset(&[Event::StartUnorderedListItem {
+                id: None,
+                level: 4,
+                style_type: docspec_core::ListStyleType::Disc,
+            }]),
+            0
+        );
+    }
+
+    #[test]
+    fn close_for_block_sibling_with_open_blockquote_prepares_children() {
+        let mut buf = Vec::new();
+        let mut writer = BlockNoteWriter::new(&mut buf);
+        assert!(writer
+            .handle_event(Event::StartDocument {
+                id: None,
+                language: None,
+                metadata: None,
+            })
+            .is_ok());
+        assert!(writer
+            .handle_event(Event::StartBlockQuote { id: None })
+            .is_ok());
+
+        assert!(writer.close_for_block_sibling().is_ok());
+        assert_eq!(
+            writer.blockquote_content_states.last(),
+            Some(&BlockquoteContentState::InChildren)
+        );
+    }
+
+    #[test]
     fn close_for_block_sibling_with_nonempty_list_stack_closes_all_items() {
         // Drives close_open_list_items call inside close_for_block_sibling (line 264).
         // After opening a list item, list_stack is non-empty; calling the private
@@ -1278,5 +1673,543 @@ mod tests {
         );
         assert!(writer.handle_event(Event::EndDocument).is_ok());
         assert!(writer.finish().is_ok());
+    }
+}
+
+#[cfg(test)]
+mod accepts_child_tests {
+    #![allow(clippy::bool_assert_comparison)]
+    use super::*;
+    use docspec_core::BlockKind;
+
+    #[test]
+    fn document_root_accepts_all_block_kinds() {
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Blockquote)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Caption)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::DefinitionDetail)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::DefinitionList)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::DefinitionTerm)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Document)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Footnote)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Heading)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Link)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::OrderedListItem)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Paragraph)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Preformatted)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::Table)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::TableCell)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::TableHeader)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::TableRow)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Container(BlockKind::UnorderedListItem)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Leaf(BlockLeafKind::Image)),
+            true
+        );
+        assert_eq!(
+            blocknote_accepts_child(None, ChildKind::Leaf(BlockLeafKind::Divider)),
+            true
+        );
+    }
+
+    #[test]
+    fn heading_accepts_paragraph_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Heading),
+                ChildKind::Container(BlockKind::Paragraph),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn list_item_accepts_heading_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::OrderedListItem),
+                ChildKind::Container(BlockKind::Heading),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn blockquote_accepts_list_item_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Blockquote),
+                ChildKind::Container(BlockKind::UnorderedListItem),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn table_cell_rejects_heading() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::TableCell),
+                ChildKind::Container(BlockKind::Heading),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn table_cell_rejects_list_item() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::TableCell),
+                ChildKind::Container(BlockKind::OrderedListItem),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn code_block_rejects_heading() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Preformatted),
+                ChildKind::Container(BlockKind::Heading),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn paragraph_rejects_blocks() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Paragraph),
+                ChildKind::Container(BlockKind::Blockquote),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn heading_rejects_table_row_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Heading),
+                ChildKind::Container(BlockKind::TableRow),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn heading_rejects_table_cell_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Heading),
+                ChildKind::Container(BlockKind::TableCell),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn heading_rejects_table_header_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Heading),
+                ChildKind::Container(BlockKind::TableHeader),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn heading_accepts_image_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Heading),
+                ChildKind::Leaf(BlockLeafKind::Image)
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn heading_accepts_divider_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Heading),
+                ChildKind::Leaf(BlockLeafKind::Divider),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn blockquote_accepts_heading_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Blockquote),
+                ChildKind::Container(BlockKind::Heading),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn blockquote_accepts_table_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Blockquote),
+                ChildKind::Container(BlockKind::Table),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn blockquote_rejects_table_row_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Blockquote),
+                ChildKind::Container(BlockKind::TableRow),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn blockquote_rejects_table_cell_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Blockquote),
+                ChildKind::Container(BlockKind::TableCell),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn blockquote_rejects_table_header_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Blockquote),
+                ChildKind::Container(BlockKind::TableHeader),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn ordered_list_item_accepts_image_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::OrderedListItem),
+                ChildKind::Leaf(BlockLeafKind::Image),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn ordered_list_item_rejects_table_row_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::OrderedListItem),
+                ChildKind::Container(BlockKind::TableRow),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn ordered_list_item_rejects_table_cell_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::OrderedListItem),
+                ChildKind::Container(BlockKind::TableCell),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn ordered_list_item_rejects_table_header_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::OrderedListItem),
+                ChildKind::Container(BlockKind::TableHeader),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn unordered_list_item_accepts_preformatted_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::UnorderedListItem),
+                ChildKind::Container(BlockKind::Preformatted),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn unordered_list_item_accepts_divider_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::UnorderedListItem),
+                ChildKind::Leaf(BlockLeafKind::Divider),
+            ),
+            true
+        );
+    }
+
+    #[test]
+    fn unordered_list_item_rejects_table_row_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::UnorderedListItem),
+                ChildKind::Container(BlockKind::TableRow),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn unordered_list_item_rejects_table_cell_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::UnorderedListItem),
+                ChildKind::Container(BlockKind::TableCell),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn unordered_list_item_rejects_table_header_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::UnorderedListItem),
+                ChildKind::Container(BlockKind::TableHeader),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn caption_rejects_paragraph_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Caption),
+                ChildKind::Container(BlockKind::Paragraph),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn definition_list_rejects_definition_term_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::DefinitionList),
+                ChildKind::Container(BlockKind::DefinitionTerm),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn definition_term_rejects_paragraph_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::DefinitionTerm),
+                ChildKind::Container(BlockKind::Paragraph),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn definition_detail_rejects_paragraph_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::DefinitionDetail),
+                ChildKind::Container(BlockKind::Paragraph),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn footnote_rejects_paragraph_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Footnote),
+                ChildKind::Container(BlockKind::Paragraph),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn link_rejects_paragraph_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Link),
+                ChildKind::Container(BlockKind::Paragraph),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn document_container_rejects_paragraph_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Document),
+                ChildKind::Container(BlockKind::Paragraph),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn preformatted_rejects_image_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Preformatted),
+                ChildKind::Leaf(BlockLeafKind::Image),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn paragraph_rejects_divider_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Paragraph),
+                ChildKind::Leaf(BlockLeafKind::Divider),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn table_rejects_table_row_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Table),
+                ChildKind::Container(BlockKind::TableRow),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn table_rejects_image_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::Table),
+                ChildKind::Leaf(BlockLeafKind::Image)
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn table_row_rejects_table_cell_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::TableRow),
+                ChildKind::Container(BlockKind::TableCell),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn table_row_rejects_heading_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::TableRow),
+                ChildKind::Container(BlockKind::Heading),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn table_header_rejects_heading_child() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::TableHeader),
+                ChildKind::Container(BlockKind::Heading),
+            ),
+            false
+        );
+    }
+
+    #[test]
+    fn table_header_rejects_divider_leaf() {
+        assert_eq!(
+            blocknote_accepts_child(
+                Some(BlockKind::TableHeader),
+                ChildKind::Leaf(BlockLeafKind::Divider),
+            ),
+            false
+        );
     }
 }

--- a/crates/docspec-blocknote-writer/tests/fixtures/sample.docx
+++ b/crates/docspec-blocknote-writer/tests/fixtures/sample.docx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1aeb4d3a75bbda0d9e5cfa66e0673b34d44213ca6a339d213973cec909bca7cf
+size 18789

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -1,6 +1,11 @@
 //! Integration tests for `BlockNoteWriter`.
 
-#![allow(clippy::expect_used, clippy::redundant_test_prefix)]
+#![allow(
+    clippy::expect_used,
+    clippy::redundant_test_prefix,
+    clippy::items_after_statements,
+    clippy::indexing_slicing
+)]
 
 #[cfg(test)]
 mod tests {
@@ -1766,7 +1771,7 @@ mod tests {
     }
 
     #[test]
-    fn image_in_blockquote_emits_sibling() {
+    fn image_in_blockquote_emits_as_child() {
         let mut buf = Vec::<u8>::new();
         let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 
@@ -1791,17 +1796,15 @@ mod tests {
         let json = String::from_utf8(buf).expect("output should be valid UTF-8");
         assert_eq!(
             json,
-            r#"[{"type":"quote","content":[],"children":[]},{"type":"image","props":{"url":"https://example.com/logo.png","caption":"logo"},"content":null,"children":[]}]"#
+            r#"[{"type":"quote","content":[],"children":[{"type":"image","props":{"url":"https://example.com/logo.png","caption":"logo"},"content":null,"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn nested_blockquote_emits_sibling() {
+    fn nested_blockquote_emits_as_child() {
         let mut buf = Vec::<u8>::new();
         let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 
-        // Test actual nesting: send StartBlockQuote while another is open
-        // Sibling emission should close outer quote and emit inner as sibling
         assert!(writer.handle_event(start_document()).is_ok());
         assert!(writer.handle_event(start_blockquote()).is_ok());
         assert!(writer.handle_event(start_paragraph()).is_ok());
@@ -1813,19 +1816,68 @@ mod tests {
         assert!(writer.handle_event(text("inner")).is_ok());
         assert!(writer.handle_event(Event::EndParagraph).is_ok());
         assert!(writer.handle_event(Event::EndBlockQuote).is_ok());
-        // Outer was force-closed by sibling emission, so only close inner
+        // StackTrackingSink auto-closes outer blockquote on EndDocument
         assert!(writer.handle_event(Event::EndDocument).is_ok());
         assert!(writer.finish().is_ok());
 
         let json = String::from_utf8(buf).expect("output should be valid UTF-8");
         assert_eq!(
             json,
-            r#"[{"type":"quote","content":[{"type":"text","text":"outer","styles":{}}],"children":[]},{"type":"quote","content":[{"type":"text","text":"inner","styles":{}}],"children":[]}]"#
+            r#"[{"type":"quote","content":[{"type":"text","text":"outer","styles":{}}],"children":[{"type":"quote","content":[{"type":"text","text":"inner","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn heading_in_blockquote_emits_sibling() {
+    fn blockquote_with_inline_then_block_child_transitions_state() {
+        let mut buf = Vec::<u8>::new();
+        let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
+
+        // > inline text
+        // > ## block heading
+        assert!(writer.handle_event(start_document()).is_ok());
+        assert!(writer.handle_event(start_blockquote()).is_ok());
+        assert!(writer.handle_event(start_paragraph()).is_ok());
+        assert!(writer.handle_event(text("inline")).is_ok());
+        assert!(writer.handle_event(Event::EndParagraph).is_ok());
+        assert!(writer.handle_event(start_heading(2)).is_ok());
+        assert!(writer.handle_event(text("block")).is_ok());
+        assert!(writer.handle_event(Event::EndHeading).is_ok());
+        assert!(writer.handle_event(Event::EndBlockQuote).is_ok());
+        assert!(writer.handle_event(Event::EndDocument).is_ok());
+        assert!(writer.finish().is_ok());
+
+        let json = String::from_utf8(buf).expect("output should be valid UTF-8");
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[{"type":"text","text":"inline","styles":{}}],"children":[{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"block","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn blockquote_with_inline_heading_then_paragraph_keeps_paragraph_child() {
+        let json = run_events(&[
+            start_document(),
+            start_blockquote(),
+            start_paragraph(),
+            text("inline"),
+            Event::EndParagraph,
+            start_heading(2),
+            text("heading"),
+            Event::EndHeading,
+            start_paragraph(),
+            text("after"),
+            Event::EndParagraph,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[{"type":"text","text":"inline","styles":{}}],"children":[{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"heading","styles":{}}],"children":[]},{"type":"paragraph","content":[{"type":"text","text":"after","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn heading_in_blockquote_emits_as_child() {
         let mut buf = Vec::<u8>::new();
         let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 
@@ -1842,12 +1894,12 @@ mod tests {
         let json = String::from_utf8(buf).expect("output should be valid UTF-8");
         assert_eq!(
             json,
-            r#"[{"type":"quote","content":[],"children":[]},{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"Title","styles":{}}],"children":[]}]"#
+            r#"[{"type":"quote","content":[],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"Title","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn code_block_in_blockquote_emits_sibling() {
+    fn code_block_in_blockquote_emits_as_child() {
         let mut buf = Vec::<u8>::new();
         let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 
@@ -1866,7 +1918,7 @@ mod tests {
         let json = String::from_utf8(buf).expect("output should be valid UTF-8");
         assert_eq!(
             json,
-            r#"[{"type":"quote","content":[],"children":[]},{"type":"codeBlock","props":{"language":"rust"},"content":[{"type":"text","text":"fn main() {}","styles":{}}],"children":[]}]"#
+            r#"[{"type":"quote","content":[],"children":[{"type":"codeBlock","props":{"language":"rust"},"content":[{"type":"text","text":"fn main() {}","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -1900,7 +1952,7 @@ mod tests {
     }
 
     #[test]
-    fn thematic_break_in_blockquote_emits_sibling() {
+    fn thematic_break_in_blockquote_emits_as_child() {
         let mut buf = Vec::<u8>::new();
         let mut writer = StackTrackingSink::new(BlockNoteWriter::new(&mut buf));
 
@@ -1917,7 +1969,7 @@ mod tests {
         let json = String::from_utf8(buf).expect("output should be valid UTF-8");
         assert_eq!(
             json,
-            r#"[{"type":"quote","content":[],"children":[]},{"type":"divider"}]"#
+            r#"[{"type":"quote","content":[],"children":[{"type":"divider"}]}]"#
         );
     }
 
@@ -2733,7 +2785,7 @@ mod tests {
     }
 
     #[test]
-    fn outer_table_inside_list_item_drops_table_and_nested_table_alike() {
+    fn outer_table_inside_list_item_with_nested_table_lifts_into_outer_list_item_children() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -2761,7 +2813,281 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"bullet","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"bullet","styles":{}}],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"dropped","styles":{}}]}]}]},"children":[]},{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"also dropped","styles":{}}]}]}]},"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn list_inside_table_cell_inside_list_item_lifts_into_outer_list_item_children() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("lifted"),
+            Event::EndUnorderedListItem,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"lifted","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn lifted_list_under_list_item_does_not_close_outer_item() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("outer"),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("lifted"),
+            Event::EndUnorderedListItem,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            start_paragraph(),
+            text("after"),
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"outer","styles":{}}],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"lifted","styles":{}}],"children":[]},{"type":"paragraph","content":[{"type":"text","text":"after","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn lifted_nested_list_rebases_minimum_level_correctly() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("level 0"),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("level 1"),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 2,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("level 2"),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::StartOrderedListItem {
+                id: None,
+                level: 0,
+                start: Some(4),
+                style_type: docspec_core::ListStyleType::Decimal,
+            },
+            text("lifted 0"),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 1,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("lifted 1"),
+            Event::EndUnorderedListItem,
+            Event::EndOrderedListItem,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"level 0","styles":{}}],"children":[{"type":"bulletListItem","content":[{"type":"text","text":"level 1","styles":{}}],"children":[{"type":"bulletListItem","content":[{"type":"text","text":"level 2","styles":{}}],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"numberedListItem","props":{"start":4},"content":[{"type":"text","text":"lifted 0","styles":{}}],"children":[{"type":"bulletListItem","content":[{"type":"text","text":"lifted 1","styles":{}}],"children":[]}]}]}]}]}]"#
+        );
+    }
+
+    #[test]
+    fn lifted_list_into_blockquote_no_rebasing() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("outer"),
+            start_blockquote(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("quoted lifted"),
+            Event::EndUnorderedListItem,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndBlockQuote,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"outer","styles":{}}],"children":[{"type":"quote","content":[],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"quoted lifted","styles":{}}],"children":[]}]}]}]"#
+        );
+    }
+
+    #[test]
+    fn heading_inside_table_cell_inside_blockquote_lifts_into_blockquote_children() {
+        let json = run_events(&[
+            start_document(),
+            start_blockquote(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            start_heading(2),
+            text("lifted heading"),
+            Event::EndHeading,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"lifted heading","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn image_inside_cell_inside_blockquote_inside_list_item_lifts_into_blockquote() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            start_blockquote(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/in-quote.png".to_string(),
+                },
+                alt: Some("in quote".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndBlockQuote,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"quote","content":[],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/in-quote.png","caption":"in quote"},"content":null,"children":[]}]}]}]"#
+        );
+    }
+
+    #[test]
+    fn image_inside_cell_inside_list_item_inside_blockquote_lifts_into_list_item() {
+        let json = run_events(&[
+            start_document(),
+            start_blockquote(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::Image {
+                source: ImageSource::Uri {
+                    uri: "https://example.com/in-list.png".to_string(),
+                },
+                alt: Some("in list".to_string()),
+                title: None,
+                decorative: false,
+                id: None,
+            },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndUnorderedListItem,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[],"children":[{"type":"bulletListItem","content":[],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"image","props":{"url":"https://example.com/in-list.png","caption":"in list"},"content":null,"children":[]}]}]}]"#
+        );
+    }
+
+    #[test]
+    fn blockquote_inside_table_cell_inside_list_item_lifts_into_outer_list_item_children() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            start_blockquote(),
+            text("lifted quote"),
+            Event::EndBlockQuote,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"quote","content":[{"type":"text","text":"lifted quote","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -3282,36 +3608,32 @@ mod tests {
     }
 
     #[test]
-    fn list_inside_table_cell_is_dropped() {
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(start_table_row()).is_ok());
-        assert!(writer.handle_event(start_table_cell()).is_ok());
-        assert!(writer
-            .handle_event(Event::StartUnorderedListItem {
+    fn list_inside_table_cell_lifts_after_table() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::StartUnorderedListItem {
                 id: None,
                 level: 0,
                 style_type: docspec_core::ListStyleType::Disc,
-            })
-            .is_ok());
-        assert!(writer.handle_event(text("dropped")).is_ok());
-        assert!(writer.handle_event(Event::EndUnorderedListItem).is_ok());
-        assert!(writer.handle_event(Event::EndTableCell).is_ok());
-        assert!(writer.handle_event(Event::EndTableRow).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        assert!(writer.finish().is_ok());
-        let json = String::from_utf8(buf).expect("output should be valid UTF-8");
+            },
+            text("dropped"),
+            Event::EndUnorderedListItem,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"dropped","styles":{}}],"children":[]}]"#
         );
     }
 
     #[test]
-    fn list_inside_blockquote_emits_sibling() {
+    fn list_inside_blockquote_emits_as_child() {
         let json = run_events(&[
             start_document(),
             start_blockquote(),
@@ -3327,12 +3649,39 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"quote","content":[],"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"quoted bullet","styles":{}}],"children":[]}]"#
+            r#"[{"type":"quote","content":[],"children":[{"type":"bulletListItem","content":[{"type":"text","text":"quoted bullet","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn nested_table_with_list_in_cell_lifts_table_drops_list() {
+    fn consecutive_same_level_list_items_inside_blockquote_are_siblings() {
+        let json = run_events(&[
+            start_document(),
+            start_blockquote(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("first"),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            text("second"),
+            Event::EndUnorderedListItem,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[],"children":[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn nested_table_with_list_in_cell_lifts_table_and_list_after_outer_table() {
         let json = run_events(&[
             start_document(),
             start_table(),
@@ -3359,7 +3708,7 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"outer","styles":{}}]}]}]},"children":[]},{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"outer","styles":{}}]}]}]},"children":[]},{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"inner dropped","styles":{}}],"children":[]}]"#
         );
     }
 
@@ -3649,7 +3998,7 @@ mod tests {
     }
 
     #[test]
-    fn heading_inside_list_item_is_dropped() {
+    fn heading_inside_list_item_emits_as_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3666,12 +4015,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"item","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"h","styles":{}}],"children":[]},{"type":"paragraph","content":[{"type":"text","text":"item","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn image_inside_list_item_is_dropped() {
+    fn image_inside_list_item_emits_as_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3693,12 +4042,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"image","props":{"url":"https://example.com/img.png","caption":""},"content":null,"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn code_block_inside_list_item_is_dropped() {
+    fn code_block_inside_list_item_emits_as_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3714,12 +4063,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"codeBlock","content":[{"type":"text","text":"code","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn nested_blockquote_inside_list_item_is_dropped() {
+    fn nested_blockquote_inside_list_item_emits_as_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3735,12 +4084,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"quote","content":[{"type":"text","text":"q","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn divider_inside_list_item_is_dropped() {
+    fn divider_inside_list_item_emits_as_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3754,12 +4103,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"divider"}]}]"#
         );
     }
 
     #[test]
-    fn table_inside_list_item_is_dropped() {
+    fn table_inside_list_item_emits_as_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3779,12 +4128,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"cell","styles":{}}]}]}]},"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn text_after_dropped_block_in_list_item_is_preserved() {
+    fn text_after_block_child_in_list_item_appears_after_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3802,35 +4151,7 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"before","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"after","styles":{}}],"children":[]}]}]"#
-        );
-    }
-
-    #[test]
-    fn drop_counter_returns_to_zero_after_end() {
-        let json = run_events(&[
-            start_document(),
-            Event::StartUnorderedListItem {
-                id: None,
-                level: 0,
-                style_type: docspec_core::ListStyleType::Disc,
-            },
-            start_heading(1),
-            text("dropped"),
-            Event::EndHeading,
-            Event::EndUnorderedListItem,
-            Event::StartUnorderedListItem {
-                id: None,
-                level: 0,
-                style_type: docspec_core::ListStyleType::Disc,
-            },
-            text("second"),
-            Event::EndUnorderedListItem,
-            Event::EndDocument,
-        ]);
-        assert_eq!(
-            json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"before","styles":{}}],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"dropped","styles":{}}],"children":[]},{"type":"paragraph","content":[{"type":"text","text":"after","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -3839,11 +4160,7 @@ mod tests {
     // ============================================================================
 
     #[test]
-    fn heading_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! returning early in the StartHeading match arm
-        // (the in_table_cell=true case). EndHeading with in_text_block=false is also
-        // driven (the !in_text_block guard fires). Heading text is flattened into the
-        // cell's inline content — only the heading *structure* is dropped.
+    fn heading_inside_table_cell_lifts_after_table() {
         let json = run_events(&[
             start_document(),
             start_table(),
@@ -3857,18 +4174,14 @@ mod tests {
             Event::EndTable,
             Event::EndDocument,
         ]);
-        // Text is flattened into cell inline content (BlockNote cell flattening policy).
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"h","styles":{}}]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"h","styles":{}}],"children":[]}]"#
         );
     }
 
     #[test]
-    fn blockquote_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! returning early in both the StartBlockQuote and
-        // EndBlockQuote match arms. blockquote_depth is never incremented; text is
-        // flattened into the cell's inline content.
+    fn blockquote_inside_table_cell_lifts_after_table() {
         let json = run_events(&[
             start_document(),
             start_table(),
@@ -3884,15 +4197,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"q","styles":{}}]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"quote","content":[{"type":"text","text":"q","styles":{}}],"children":[]}]"#
         );
     }
 
     #[test]
-    fn preformatted_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! returning early in both the StartPreformatted and
-        // EndPreformatted match arms. Code-block structure is never emitted; text is
-        // flattened into the cell's inline content.
+    fn preformatted_inside_table_cell_lifts_after_table() {
         let json = run_events(&[
             start_document(),
             start_table(),
@@ -3908,16 +4218,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"code","styles":{}}]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"codeBlock","content":[{"type":"text","text":"code","styles":{}}],"children":[]}]"#
         );
     }
 
     #[test]
-    fn line_break_inside_dropped_heading_in_list_is_dropped() {
-        // Drives handle_line_break when drop_inside_list_depth > 0.
-        // A LineBreak inside a heading that is itself inside a list item is silently
-        // discarded — neither the line break nor any surrounding text from the dropped
-        // block appears in the output.
+    fn line_break_inside_heading_in_list_item_preserved_in_child() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -3936,7 +4242,7 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"item","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"head","styles":{}},{"type":"text","text":"\n","styles":{}},{"type":"text","text":"more","styles":{}}],"children":[]},{"type":"paragraph","content":[{"type":"text","text":"item","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -4091,53 +4397,6 @@ mod tests {
     }
 
     #[test]
-    fn start_heading_inside_table_cell_is_silently_dropped() {
-        // Drives return_if_table_cell! return branch in the StartHeading arm (line 843).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(start_table_row()).is_ok());
-        assert!(writer.handle_event(start_table_cell()).is_ok());
-        assert!(writer.handle_event(start_heading(1)).is_ok());
-        assert!(writer.handle_event(Event::EndTableCell).is_ok());
-        assert!(writer.handle_event(Event::EndTableRow).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
-        assert_eq!(
-            json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
-        );
-    }
-
-    #[test]
-    fn start_heading_inside_list_hits_drop_block_macro() {
-        // Drives drop_block_in_list_start! return branch in StartHeading arm (line 844)
-        // and drop_block_in_list_end! return branch in EndHeading arm (line 849).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer
-            .handle_event(Event::StartUnorderedListItem {
-                id: None,
-                level: 0,
-                style_type: docspec_core::ListStyleType::Disc,
-            })
-            .is_ok());
-        assert!(writer.handle_event(start_heading(1)).is_ok());
-        assert!(writer.handle_event(Event::EndHeading).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
-        assert_eq!(
-            json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
-        );
-    }
-
-    #[test]
     fn end_heading_closes_open_heading_block() {
         // Drives close_text_block! in the EndHeading arm (line 853) via raw BlockNoteWriter.
         let mut buf = Vec::<u8>::new();
@@ -4152,53 +4411,6 @@ mod tests {
         assert_eq!(
             json,
             r#"[{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"Heading text","styles":{}}],"children":[]}]"#
-        );
-    }
-
-    #[test]
-    fn end_preformatted_inside_list_hits_drop_macro() {
-        // Drives drop_block_in_list_start! in StartPreformatted arm (line 886) and
-        // drop_block_in_list_end! in EndPreformatted arm (line 856).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer
-            .handle_event(Event::StartUnorderedListItem {
-                id: None,
-                level: 0,
-                style_type: docspec_core::ListStyleType::Disc,
-            })
-            .is_ok());
-        assert!(writer.handle_event(start_preformatted(None)).is_ok());
-        assert!(writer.handle_event(Event::EndPreformatted).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
-        assert_eq!(
-            json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
-        );
-    }
-
-    #[test]
-    fn end_preformatted_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! return branch in EndPreformatted arm (line 857).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(start_table_row()).is_ok());
-        assert!(writer.handle_event(start_table_cell()).is_ok());
-        assert!(writer.handle_event(Event::EndPreformatted).is_ok());
-        assert!(writer.handle_event(Event::EndTableCell).is_ok());
-        assert!(writer.handle_event(Event::EndTableRow).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
-        assert_eq!(
-            json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
         );
     }
 
@@ -4223,142 +4435,95 @@ mod tests {
     }
 
     #[test]
-    fn start_blockquote_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! return branch in StartBlockQuote arm (line 866).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(start_table_row()).is_ok());
-        assert!(writer.handle_event(start_table_cell()).is_ok());
-        assert!(writer.handle_event(start_blockquote()).is_ok());
-        assert!(writer.handle_event(Event::EndTableCell).is_ok());
-        assert!(writer.handle_event(Event::EndTableRow).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
+    fn thematic_break_inside_table_cell_lifts_after_table() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            Event::ThematicBreak { id: None },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"divider"}]"#
         );
     }
 
     #[test]
-    fn start_blockquote_inside_list_hits_drop_block_macro() {
-        // Drives drop_block_in_list_start! in StartBlockQuote arm (line 867) and
-        // drop_block_in_list_end! in EndBlockQuote arm (line 872).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer
-            .handle_event(Event::StartUnorderedListItem {
+    fn multiple_block_kinds_in_same_cell_all_lift_in_order() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            start_heading(1),
+            text("H"),
+            Event::EndHeading,
+            Event::StartUnorderedListItem {
                 id: None,
                 level: 0,
                 style_type: docspec_core::ListStyleType::Disc,
-            })
-            .is_ok());
-        assert!(writer.handle_event(start_blockquote()).is_ok());
-        assert!(writer.handle_event(Event::EndBlockQuote).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
+            },
+            text("item"),
+            Event::EndUnorderedListItem,
+            start_blockquote(),
+            text("Q"),
+            Event::EndBlockQuote,
+            Event::ThematicBreak { id: None },
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"H","styles":{}}],"children":[]},{"type":"bulletListItem","content":[{"type":"text","text":"item","styles":{}}],"children":[]},{"type":"quote","content":[{"type":"text","text":"Q","styles":{}}],"children":[]},{"type":"divider"}]"#
         );
     }
 
     #[test]
-    fn end_blockquote_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! return branch in EndBlockQuote arm (line 873).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(start_table_row()).is_ok());
-        assert!(writer.handle_event(start_table_cell()).is_ok());
-        assert!(writer.handle_event(Event::EndBlockQuote).is_ok());
-        assert!(writer.handle_event(Event::EndTableCell).is_ok());
-        assert!(writer.handle_event(Event::EndTableRow).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
+    fn cell_with_only_lifted_content_has_empty_content_array() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            start_heading(2),
+            text("title"),
+            Event::EndHeading,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"title","styles":{}}],"children":[]}]"#
         );
     }
 
     #[test]
-    fn start_preformatted_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! return branch in StartPreformatted arm (line 885).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(start_table_row()).is_ok());
-        assert!(writer.handle_event(start_table_cell()).is_ok());
-        assert!(writer.handle_event(start_preformatted(None)).is_ok());
-        assert!(writer.handle_event(Event::EndTableCell).is_ok());
-        assert!(writer.handle_event(Event::EndTableRow).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
+    fn text_inside_lifted_heading_in_cell_preserved_after_lift() {
+        let json = run_events(&[
+            start_document(),
+            start_table(),
+            start_table_row(),
+            start_table_cell(),
+            start_heading(2),
+            text("Inner"),
+            Event::EndHeading,
+            Event::EndTableCell,
+            Event::EndTableRow,
+            Event::EndTable,
+            Event::EndDocument,
+        ]);
         assert_eq!(
             json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
-        );
-    }
-
-    #[test]
-    fn thematic_break_inside_table_cell_is_dropped() {
-        // Drives return_if_table_cell! return branch in ThematicBreak arm (line 891).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(start_table_row()).is_ok());
-        assert!(writer.handle_event(start_table_cell()).is_ok());
-        assert!(writer
-            .handle_event(Event::ThematicBreak { id: None })
-            .is_ok());
-        assert!(writer.handle_event(Event::EndTableCell).is_ok());
-        assert!(writer.handle_event(Event::EndTableRow).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
-        assert_eq!(
-            json,
-            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]}]"#
-        );
-    }
-
-    #[test]
-    fn end_table_inside_list_hits_drop_macro() {
-        // Drives drop_block_in_list_start! in StartTable arm (line 604) and
-        // drop_block_in_list_end! in EndTable arm (line 348).
-        let mut buf = Vec::<u8>::new();
-        let mut writer = BlockNoteWriter::new(&mut buf);
-        assert!(writer.handle_event(start_document()).is_ok());
-        assert!(writer
-            .handle_event(Event::StartUnorderedListItem {
-                id: None,
-                level: 0,
-                style_type: docspec_core::ListStyleType::Disc,
-            })
-            .is_ok());
-        assert!(writer.handle_event(start_table()).is_ok());
-        assert!(writer.handle_event(Event::EndTable).is_ok());
-        assert!(writer.handle_event(Event::EndDocument).is_ok());
-        writer.finish().expect("writer should finish fixture");
-        let json = String::from_utf8(buf).expect("BlockNoteWriter output should be valid UTF-8");
-        assert_eq!(
-            json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[]}]}]},"children":[]},{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"Inner","styles":{}}],"children":[]}]"#
         );
     }
 
@@ -4590,9 +4755,7 @@ mod tests {
     }
 
     #[test]
-    fn all_block_types_inside_list_item_are_dropped() {
-        // Exercises drop_block_in_list_start! and drop_block_in_list_end! for all block types
-        // inside a list item: heading, preformatted, blockquote, table, thematic break
+    fn all_block_types_inside_list_item_emit_as_children() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -4601,28 +4764,23 @@ mod tests {
                 style_type: docspec_core::ListStyleType::Disc,
             },
             text("before"),
-            // Heading inside list item → dropped
             start_heading(1),
             text("heading"),
             Event::EndHeading,
-            // Preformatted inside list item → dropped
             start_preformatted(None),
             text("code"),
             Event::EndPreformatted,
-            // BlockQuote inside list item → dropped
             start_blockquote(),
             text("quote"),
             Event::EndBlockQuote,
-            // ThematicBreak inside list item → dropped
             Event::ThematicBreak { id: None },
             text("after"),
             Event::EndUnorderedListItem,
             Event::EndDocument,
         ]);
-        // Only "before" and "after" should appear; all block content dropped
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"before","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"after","styles":{}}],"children":[]}]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"before","styles":{}}],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"heading","styles":{}}],"children":[]},{"type":"codeBlock","content":[{"type":"text","text":"code","styles":{}}],"children":[]},{"type":"quote","content":[{"type":"text","text":"quote","styles":{}}],"children":[]},{"type":"divider"},{"type":"paragraph","content":[{"type":"text","text":"after","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -4648,7 +4806,7 @@ mod tests {
     }
 
     #[test]
-    fn image_after_children_transition_inside_list_item_is_dropped() {
+    fn image_after_children_transition_inside_list_item_emits_as_child() {
         let json = list_item_with_children_transition_then(vec![Event::Image {
             source: ImageSource::Uri {
                 uri: "https://example.com/leaked.png".to_string(),
@@ -4660,21 +4818,21 @@ mod tests {
         }]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]},{"type":"image","props":{"url":"https://example.com/leaked.png","caption":"leaked"},"content":null,"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn thematic_break_after_children_transition_inside_list_item_is_dropped() {
+    fn thematic_break_after_children_transition_inside_list_item_emits_as_child() {
         let json = list_item_with_children_transition_then(vec![Event::ThematicBreak { id: None }]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]},{"type":"divider"}]}]"#
         );
     }
 
     #[test]
-    fn heading_after_children_transition_inside_list_item_is_dropped() {
+    fn heading_after_children_transition_inside_list_item_emits_as_child() {
         let json = list_item_with_children_transition_then(vec![
             start_heading(2),
             text("leaked-heading"),
@@ -4682,12 +4840,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]},{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"leaked-heading","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn blockquote_after_children_transition_inside_list_item_is_dropped() {
+    fn blockquote_after_children_transition_inside_list_item_emits_as_child() {
         let json = list_item_with_children_transition_then(vec![
             start_blockquote(),
             text("leaked-quote"),
@@ -4695,12 +4853,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]},{"type":"quote","content":[{"type":"text","text":"leaked-quote","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn preformatted_after_children_transition_inside_list_item_is_dropped() {
+    fn preformatted_after_children_transition_inside_list_item_emits_as_child() {
         let json = list_item_with_children_transition_then(vec![
             start_preformatted(None),
             text("leaked-code"),
@@ -4708,12 +4866,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]},{"type":"codeBlock","content":[{"type":"text","text":"leaked-code","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn table_after_children_transition_inside_list_item_is_dropped() {
+    fn table_after_children_transition_inside_list_item_emits_as_child() {
         let json = list_item_with_children_transition_then(vec![
             start_table(),
             start_table_row(),
@@ -4725,7 +4883,36 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]}]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]},{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","content":[{"type":"text","text":"leaked-cell","styles":{}}]}]}]},"children":[]}]}]"#
+        );
+    }
+
+    #[test]
+    fn list_item_with_multiple_block_children_emits_all_in_order() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            start_heading(2),
+            text("a"),
+            Event::EndHeading,
+            start_paragraph(),
+            text("b"),
+            Event::EndParagraph,
+            start_blockquote(),
+            start_paragraph(),
+            text("c"),
+            Event::EndParagraph,
+            Event::EndBlockQuote,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"heading","props":{"level":2},"content":[{"type":"text","text":"a","styles":{}}],"children":[]},{"type":"paragraph","content":[{"type":"text","text":"b","styles":{}}],"children":[]},{"type":"quote","content":[{"type":"text","text":"c","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -4833,7 +5020,7 @@ mod tests {
     }
 
     #[test]
-    fn start_list_item_inside_dropped_block_in_list_item_is_silently_dropped() {
+    fn list_item_inside_blockquote_child_of_list_item_nests_in_blockquote() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -4856,12 +5043,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"outer","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"outer","styles":{}}],"children":[{"type":"quote","content":[],"children":[{"type":"bulletListItem","content":[{"type":"text","text":"inner","styles":{}}],"children":[]}]}]}]"#
         );
     }
 
     #[test]
-    fn paragraph_events_inside_dropped_block_in_list_item_are_fully_absorbed() {
+    fn paragraph_inside_blockquote_child_of_list_item_renders_in_blockquote() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -4871,7 +5058,7 @@ mod tests {
             },
             start_blockquote(),
             start_paragraph(),
-            text("dropped"),
+            text("quoted"),
             Event::EndParagraph,
             Event::EndBlockQuote,
             start_paragraph(),
@@ -4882,7 +5069,7 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"real","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"quote","content":[{"type":"text","text":"quoted","styles":{}}],"children":[]},{"type":"paragraph","content":[{"type":"text","text":"real","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -4948,7 +5135,7 @@ mod tests {
     }
 
     #[test]
-    fn dropped_heading_before_first_aligned_list_paragraph_does_not_steal_alignment() {
+    fn heading_child_before_aligned_paragraph_child_in_list_item() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -4967,12 +5154,12 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","props":{"textAlignment":"center"},"content":[{"type":"text","text":"real","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"text","text":"dropped","styles":{}}],"children":[]},{"type":"paragraph","props":{"textAlignment":"center"},"content":[{"type":"text","text":"real","styles":{}}],"children":[]}]}]"#
         );
     }
 
     #[test]
-    fn dropped_link_before_first_aligned_list_paragraph_does_not_steal_alignment() {
+    fn heading_child_with_link_before_aligned_paragraph_child_in_list_item() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -4997,7 +5184,7 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","props":{"textAlignment":"right"},"content":[{"type":"text","text":"real","styles":{}}],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"link","href":"https://dropped.example","content":[{"type":"text","text":"dropped","styles":{}}]}],"children":[]},{"type":"paragraph","props":{"textAlignment":"right"},"content":[{"type":"text","text":"real","styles":{}}],"children":[]}]}]"#
         );
     }
 
@@ -5304,7 +5491,7 @@ mod tests {
     }
 
     #[test]
-    fn link_in_dropped_heading_inside_list_emits_no_link() {
+    fn link_in_heading_child_of_list_item_emits_in_heading_content() {
         let json = run_events(&[
             start_document(),
             Event::StartUnorderedListItem {
@@ -5326,7 +5513,7 @@ mod tests {
         ]);
         assert_eq!(
             json,
-            r#"[{"type":"bulletListItem","content":[],"children":[]}]"#
+            r#"[{"type":"bulletListItem","content":[],"children":[{"type":"heading","props":{"level":1},"content":[{"type":"link","href":"https://x","content":[{"type":"text","text":"hidden","styles":{}}]}],"children":[]}]}]"#
         );
     }
 
@@ -5395,6 +5582,48 @@ mod tests {
             counting.total_writes > 64,
             "expected many small writes for 1MB payload; got {} writes",
             counting.total_writes
+        );
+    }
+
+    #[test]
+    fn sample_docx_lifts_list_from_requirements_cell() {
+        let bytes = std::fs::read("tests/fixtures/sample.docx").expect("fixture file");
+        let reader = docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes))
+            .expect("reader creation");
+        let mut buf = Vec::<u8>::new();
+        let writer = BlockNoteWriter::new(&mut buf);
+        let sink = StackTrackingSink::new(writer);
+        docspec_core::pipe(reader, sink).expect("pipe");
+        let actual_json = String::from_utf8(buf).expect("valid utf-8");
+        const EXPECTED_JSON: &str = r#"[{"type":"table","content":{"type":"tableContent","columnWidths":[],"rows":[{"cells":[{"type":"tableCell","props":{"colspan":2},"content":[{"type":"text","text":"Project properties","styles":{"bold":true}},{"type":"text","text":" ","styles":{"bold":true}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Title","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"Mapping hybrid governance ","styles":{}},{"type":"text","text":"for sustainable global value chains","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Group","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"PAP","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Project type","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"Master thesis ","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Credits","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"18-24","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Supervisor(s)","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"Dr.","styles":{}},{"type":"text","text":" Otto. Hospes","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Examiner(s)","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"Prof.","styles":{}},{"type":"text","text":" Katrien Termeer and ","styles":{}},{"type":"text","text":"Dr.","styles":{}},{"type":"text","text":" Otto Hospes","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Contact info","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"Dr.","styles":{}},{"type":"text","text":" Otto Hospes","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Begin date","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"asap","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"End date","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"November 2016","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Description","styles":{"bold":true}}]},{"type":"tableCell","content":[{"type":"text","text":"This master thesis project is part of a larger (PhD) project that examines the potential for developing synergies between public and private governance for sustainable global value chains (GVCs). A central aim of the PhD project is to develop innovative governance arrangements with public authorities in both producing/exporting and importing countries.  ","styles":{}},{"type":"text","text":"Private governance initiatives are considered more effective than state-led initiatives in addressing environmental and social problems in global value chains. However, these private initiatives are increasingly criticised for their limitations in addressing land conflicts and smallholder concerns, their bias towards a single-commodity approach and their lack of area-based governance. These criticisms are paralleled by an increasing role of public actors in developing public sustainability schemes or quasi-accreditation policies for private standards. While currently these public and private initiatives often exist next to each other or even compete, there is great potential for synergies because public and private actors can complement each other’s roles in GVCs. ","styles":{}},{"type":"text","text":"The first objective of the master thesis project is to map different forms of h","styles":{}},{"type":"text","text":"ybrid governance of global value chains. ","styles":{}},{"type":"text","text":"For this purpose the following preliminary classification can be tested and adjusted: a) private certification programmes with government involvement through official recognition of the standard; b) social-private partnerships (roundtables) for specific commodities with limited government involvement through subsidies; c) public-private partnerships with direct involvement of public authorities; d) public-private value chain initiatives with explicit linkages with area-based public policies in the producing country. The second objective is to ","styles":{}},{"type":"text","text":"make an inventory and classification of ","styles":{}},{"type":"text","text":"different scientific concepts that are used ","styles":{}},{"type":"text","text":"by scholars ","styles":{}},{"type":"text","text":"to understand and analyse hybrid governance forms, arrangements and interactions  involving public and private actors.","styles":{}},{"type":"text","text":" ","styles":{}},{"type":"text","text":"The third objective is to conduct a quick scan of the underlying motives and perceived challenges and obstacles for organizing synergies between private and public forms of governance. ","styles":{}},{"type":"text","text":"Data collection and methods consists of three steps: ","styles":{}},{"type":"text","text":"1. ","styles":{}},{"type":"text","text":"systematic literature review","styles":{}},{"type":"text","text":"; 2. ","styles":{}},{"type":"text","text":"analysis of  professional reports of public and private actors involved in certification programmes, social-private partnerships or public-private partnerships; ","styles":{}},{"type":"text","text":"3. ","styles":{}},{"type":"text","text":"interviews with stakeholders that are involved in the larger (PhD) project. ","styles":{}}]}]},{"cells":[{"type":"tableCell","content":[{"type":"text","text":"Requirements","styles":{"bold":true}},{"type":"text","text":" and skills","styles":{"bold":true}}]},{"type":"tableCell","content":[]}]}]},"children":[]},{"id":"2","type":"bulletListItem","props":{"textAlignment":"justify"},"content":[{"type":"text","text":"Bachelor BIN or BEB; enrolled in master program MID or MME ","styles":{}}],"children":[]},{"id":"2","type":"bulletListItem","content":[{"type":"text","text":"Ambition to develop a master thesis that can serve as a basis for ","styles":{}},{"type":"text","text":"writing and publishing ","styles":{}},{"type":"text","text":"a scientific article","styles":{}}],"children":[]},{"id":"2","type":"bulletListItem","props":{"textAlignment":"justify"},"content":[{"type":"text","text":"Skills: 1. Good English writing; 2. Experience with organizing Endnote libraries 3. ","styles":{}},{"type":"text","text":"Experience with organizing search queries through Scopus, google advanced search, and other search machines. ","styles":{}}],"children":[]},{"type":"paragraph","content":[],"children":[]},{"type":"paragraph","content":[],"children":[]},{"type":"paragraph","content":[],"children":[]},{"type":"paragraph","content":[],"children":[]}]"#;
+        assert_eq!(actual_json, EXPECTED_JSON);
+    }
+
+    #[test]
+    fn sample_docx_table_cell_with_lift_is_empty() {
+        let bytes = std::fs::read("tests/fixtures/sample.docx").expect("fixture file");
+        let reader = docspec_docx_reader::DocxReader::from_reader(std::io::Cursor::new(bytes))
+            .expect("reader creation");
+        let mut buf = Vec::<u8>::new();
+        let writer = BlockNoteWriter::new(&mut buf);
+        let sink = StackTrackingSink::new(writer);
+        docspec_core::pipe(reader, sink).expect("pipe");
+        let actual_json = String::from_utf8(buf).expect("valid utf-8");
+        let output: serde_json::Value = serde_json::from_str(&actual_json).expect("valid json");
+        let table = output
+            .as_array()
+            .expect("top-level array")
+            .iter()
+            .find(|b| b["type"] == "table")
+            .expect("table block");
+        let rows = table["content"]["rows"].as_array().expect("rows array");
+        let last_row = rows.last().expect("last row");
+        let cells = last_row["cells"].as_array().expect("cells array");
+        let lifted_cell = &cells[1];
+        assert_eq!(
+            lifted_cell["content"],
+            serde_json::json!([]),
+            "cell that contained the bullet list must be empty after lift"
         );
     }
 }

--- a/crates/docspec/tests/blocknote_markdown_pipeline.rs
+++ b/crates/docspec/tests/blocknote_markdown_pipeline.rs
@@ -169,13 +169,11 @@ mod tests {
     #[test]
     fn pipeline_list_inside_blockquote_inside_list_item_is_well_formed() {
         // Regression for cmark-gfm/test.md edge case.
-        // A list nested inside a blockquote that is itself inside a list item
-        // must NOT cause premature emission of the outer list item's End event.
         let markdown = "5) I2\n   > text\n   > - [f]\n";
         let actual = run_pipeline(markdown);
         assert_json_eq(
             &actual,
-            r#"[{"type":"numberedListItem","props":{"start":5},"content":[{"type":"text","text":"I2","styles":{}}],"children":[]}]"#,
+            r#"[{"type":"numberedListItem","props":{"start":5},"content":[{"type":"text","text":"I2","styles":{}}],"children":[{"type":"quote","content":[{"type":"text","text":"text","styles":{}}],"children":[{"type":"bulletListItem","content":[{"type":"text","text":"[","styles":{}},{"type":"text","text":"f","styles":{}},{"type":"text","text":"]","styles":{}}],"children":[]}]}]}]"#,
         );
     }
 


### PR DESCRIPTION
## Summary

Replace three ad-hoc behaviors (drop, force-close, lift) in `docspec-blocknote-writer` with one unified policy driven by a single predicate.

### What changed

**New predicate**: `blocknote_accepts_child(parent: Option<BlockKind>, child: ChildKind) -> bool` — the authoritative source of truth for BlockNote schema constraints. Only `TableCell`/`TableHeader` and `Preformatted` (codeBlock) reject block children; everything else accepts.

**Blockquotes** now accept block children via a deferred `content[]`/`children[]` state machine (`BlockquoteContentState`). No more force-closing when a heading or list arrives inside a quote.

**List items** now accept arbitrary block children (headings, blockquotes, code blocks, tables, images, dividers, nested lists) as `children[]`. No more silent drops.

**Cell lifting** generalized to ALL block kinds (was: only nested tables + images). Lifted events drain to the **nearest still-open valid ancestor** (list item or blockquote when one is open, document root otherwise). List levels are **rebased** during drain so the outer list item is never prematurely closed.

**Dead code removed**: `drop_inside_list_depth`, `dropped_list_depth`, `blockquote_force_closed_count` fields; `return_if_table_cell!`, `drop_block_in_list_start!`, `drop_block_in_list_end!` macros; `close_blockquote_for_sibling()` helper.

### User-facing fix

The sample document at <https://docxcorp.us/documents/6cde690ac8d3d12329d659d179389c328a63924c559f470802665f224061fd10.docx> has a 3-item bullet list inside a "Requirements and skills" table cell. Previously the list was silently dropped. Now it lifts and appears as three `bulletListItem` siblings after the table.

End-to-end integration test added: `sample_docx_lifts_list_from_requirements_cell` asserts the exact expected JSON including all three bullet texts.

### Breaking changes

- Blockquote + block child: JSON shape moves from `[{quote},{block}]` to `[{quote,children:[block]}]`
- List item + block child: headings/quotes/code/tables/images/dividers now appear in `children[]` instead of being dropped
- Cell content: headings/lists/blockquotes/code/dividers now lift to nearest ancestor instead of being dropped

### Commits

11 commits, T1 → T7 following the plan in `.sisyphus/plans/stuff-in-table.md`.

### Test coverage

- 235 unit tests + 77 integration tests + 1 doc test — all passing
- 98.17% line coverage on `lib.rs`
- 0 clippy warnings workspace-wide

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of complex document structures, including nested quotes, lists, tables, headings, code blocks, and images.
  * More content now appears in the exported output instead of being omitted or flattened.

* **Bug Fixes**
  * Fixed several cases where nested blocks inside lists, quotes, or tables could be dropped or placed incorrectly.
  * Preserved surrounding formatting more reliably when content is lifted between containers.

* **Documentation**
  * Updated usage notes to better describe current behavior for nested content and images in links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->