### PR TITLE
Run release-plz-pr after release-plz-release to prevent duplicate changelogs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,11 @@ jobs:
 
   release-plz-pr:
     name: Open / update release PR
-    needs: [test, clippy, fmt, docker-build]
+    # Must run AFTER `release-plz-release` so the new tag and crates.io publish
+    # are visible. Otherwise the PR job computes the next-version diff against
+    # the still-old crates.io baseline and re-includes commits the release job
+    # is in the middle of publishing, producing duplicate CHANGELOG entries.
+    needs: [test, clippy, fmt, docker-build, release-plz-release]
     if: >-
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Problem

PR #339 (release v1.21.0) contained a duplicate CHANGELOG entry: `*(docx-reader)* emit effective counter as start value on list resumption` appeared in **both** the new `[1.21.0]` section and the existing `[1.20.0]` section on main. Flagged by Kody in [discussion r3500439815](https://github.com/docspec/docspec/pull/339#discussion_r3500439815).

## Root cause

In `.github/workflows/ci.yml`, `release-plz-pr` and `release-plz-release` were declared as siblings: same `needs: [test, clippy, fmt, docker-build]`, separate concurrency groups (`release-plz-pr-…` vs `release-plz-release-…`), no `needs:` link between them.

When the v1.20.0 release PR was merged, GitHub fired **one** push event on main that started **both** jobs in parallel:

- `release-plz-release` began publishing v1.20.0 (push git tag, publish to crates.io).
- `release-plz-pr` simultaneously diffed against the **still-old** crates.io baseline (v1.19.0) and the **still-missing** v1.20.0 git tag, concluded the just-merged feat commits were 'unreleased', and wrote them into a v1.21.0 release PR.

That is how the docx-reader feat ended up in both the 1.20.0 section (correct, already on main) and the new 1.21.0 section (the duplicate Kody flagged).

The official release-plz quickstart pattern relies on jobs being able to skip when nothing is new, but with separate concurrency groups (and no explicit `needs:` ordering), nothing actually prevents the race within a single push event.

## Fix

Add `release-plz-release` to `release-plz-pr`'s `needs:` so the PR job runs **after** the release job. By the time `release-plz-pr` runs:

- The new git tag is pushed.
- crates.io has the new version.
- The next-version diff is computed against a correct baseline → no duplicate entries.

Override the implicit `success()` gate with `!cancelled()` so a flaky crates.io publish does not permanently block PR updates — the next push retries the release while `release-plz-pr` keeps the open PR in sync.

```diff
-    needs: [test, clippy, fmt, docker-build]
+    needs: [test, clippy, fmt, docker-build, release-plz-release]
     if: >-
-      github.event_name == 'push'
+      !cancelled()
+      && github.event_name == 'push'
       && github.ref == 'refs/heads/main'
       && github.repository == 'docspec/docspec'
```

A multi-line comment documents the rationale inline so the `needs:` link cannot be 'simplified' away in a future cleanup without reading why it exists.

## Validation

- YAML syntactically valid (`yaml.safe_load` passes).
- `docker-publish` job (downstream of `release-plz-release`) is unaffected — its `needs:` and `if:` are unchanged.
- `release-plz-release`'s own `if:` and concurrency are unchanged: it still runs immediately on push, never gets cancelled.

## Follow-up

After this lands on main, the next push will re-run `release-plz-pr` with the corrected sequencing. PR #339 should be rewritten (or closed) by release-plz with no duplicate entry. If anything since v1.20.0 still warrants a release, it will be the only content in the new PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved workflow sequencing for release-related jobs to run in the intended order.
  * Added stronger run conditions so the process only continues on push events and does not proceed after cancellation.
  * Updated workflow notes to better explain the execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->