### PR TITLE
Propagate internal error source to Sentry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,6 +947,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,6 +2803,7 @@ dependencies = [
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-debug-images",
  "sentry-panic",
  "sentry-tower",
  "sentry-tracing",
@@ -2834,6 +2847,16 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.48.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b603a51b083141062a142d73e36391b14244b4bd0bfe28bcd80e8327bb1d7698"
+dependencies = [
+ "findshlibs",
+ "sentry-core",
 ]
 
 [[package]]

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -43,6 +43,7 @@ thiserror = "2"
 sentry = { version = "0.48", optional = true, default-features = false, features = [
   "backtrace",
   "contexts",
+  "debug-images",
   "panic",
   "tower",
   "tower-http",
@@ -69,6 +70,7 @@ wiremock = "0.6"
 sentry = { version = "0.48", default-features = false, features = [
   "backtrace",
   "contexts",
+  "debug-images",
   "panic",
   "tower",
   "tower-http",

--- a/crates/docspec-http/src/error.rs
+++ b/crates/docspec-http/src/error.rs
@@ -96,8 +96,17 @@ pub enum HttpError {
     EmptyBody,
     /// An unexpected internal error occurred during conversion.
     ///
+    /// The `source` error is captured for observability (sent to Sentry via
+    /// [`sentry::capture_error`], logged at `warn!` in stderr) and drives the
+    /// error chain visible to operators. It is **never** exposed to the HTTP
+    /// client — the RFC 7807 response detail is always the generic
+    /// "An unexpected error occurred during conversion" string.
+    ///
     /// → HTTP 500 Internal Server Error.
-    Internal,
+    Internal {
+        /// The underlying error that caused this internal failure.
+        source: Box<dyn core::error::Error + Send + Sync + 'static>,
+    },
     /// The HTTP method is not supported on this endpoint.
     ///
     /// → HTTP 405 Method Not Allowed (response includes an `Allow` header).
@@ -152,18 +161,37 @@ fn build_posthog_error_event(detail: &str, sentry_event_id: Option<String>) -> p
     event
 }
 
+#[cfg(feature = "sentry")]
+#[inline]
+fn capture_sentry(
+    detail: &str,
+    source: Option<&(dyn core::error::Error + Send + Sync + 'static)>,
+) -> sentry::types::Uuid {
+    source.map_or_else(
+        || sentry::capture_message(detail, sentry::Level::Error),
+        sentry::capture_error,
+    )
+}
+
 #[cfg(any(feature = "sentry", feature = "posthog"))]
-fn capture_error_telemetry(status: StatusCode, detail: &str) {
+fn capture_error_telemetry(
+    status: StatusCode,
+    detail: &str,
+    source: Option<&(dyn core::error::Error + Send + Sync + 'static)>,
+) {
     if status != StatusCode::INTERNAL_SERVER_ERROR && status != StatusCode::UNPROCESSABLE_ENTITY {
         return;
     }
+
+    #[cfg(not(feature = "sentry"))]
+    let _ = source;
+
     #[cfg(all(feature = "sentry", not(feature = "posthog")))]
     {
-        let _ = sentry::capture_message(detail, sentry::Level::Error);
+        let _ = capture_sentry(detail, source);
     }
     #[cfg(all(feature = "sentry", feature = "posthog"))]
-    let sentry_id_string: Option<String> =
-        Some(sentry::capture_message(detail, sentry::Level::Error).to_string());
+    let sentry_id_string: Option<String> = Some(capture_sentry(detail, source).to_string());
     #[cfg(all(not(feature = "sentry"), feature = "posthog"))]
     let sentry_id_string: Option<String> = None;
     #[cfg(feature = "posthog")]
@@ -191,6 +219,9 @@ impl IntoResponse for HttpError {
     /// [`HttpError::MethodNotAllowed`] additionally sets the `Allow` response header.
     #[inline]
     fn into_response(self) -> Response {
+        #[cfg(any(feature = "sentry", feature = "posthog"))]
+        self.capture_to_telemetry();
+
         let (status, title, detail, allow): (
             StatusCode,
             &'static str,
@@ -253,16 +284,13 @@ impl IntoResponse for HttpError {
                 Cow::Owned(detail),
                 None,
             ),
-            Self::Internal => (
+            Self::Internal { .. } => (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Internal Server Error",
                 Cow::Borrowed("An unexpected error occurred during conversion"),
                 None,
             ),
         };
-
-        #[cfg(any(feature = "sentry", feature = "posthog"))]
-        capture_error_telemetry(status, detail.as_ref());
 
         let body = ProblemJson {
             detail,
@@ -295,7 +323,7 @@ impl HttpError {
         match self {
             Self::BodyNotUtf8 => "body_not_utf8",
             Self::EmptyBody => "empty_body",
-            Self::Internal => "internal",
+            Self::Internal { .. } => "internal",
             Self::MethodNotAllowed { .. } => "method_not_allowed",
             Self::NotAcceptable => "not_acceptable",
             Self::NotFound { .. } => "not_found",
@@ -317,7 +345,47 @@ impl HttpError {
             | Self::NotFound { .. }
             | Self::Unprocessable { .. }
             | Self::UnsupportedMediaType { .. } => RESULT_CLIENT_ERROR,
-            Self::Internal => RESULT_SERVER_ERROR,
+            Self::Internal { .. } => RESULT_SERVER_ERROR,
+        }
+    }
+
+    /// Wrap an unexpected internal error as [`HttpError::Internal`].
+    ///
+    /// The source is preserved end-to-end for observability — it flows to
+    /// Sentry via [`sentry::capture_error`] (walking the [`core::error::Error::source`]
+    /// chain) and is logged at `warn!` level via [`core::fmt::Debug`] formatting.
+    #[inline]
+    #[must_use]
+    pub fn internal<E>(source: E) -> Self
+    where
+        E: core::error::Error + Send + Sync + 'static,
+    {
+        Self::Internal {
+            source: Box::new(source),
+        }
+    }
+
+    /// Capture this error to configured telemetry backends (Sentry, `PostHog`)
+    /// when the variant is a 500 or 422.
+    #[cfg(any(feature = "sentry", feature = "posthog"))]
+    pub(crate) fn capture_to_telemetry(&self) {
+        match self {
+            Self::Internal { source } => {
+                capture_error_telemetry(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "An unexpected error occurred during conversion",
+                    Some(source.as_ref()),
+                );
+            }
+            Self::Unprocessable { detail } => {
+                capture_error_telemetry(StatusCode::UNPROCESSABLE_ENTITY, detail.as_str(), None);
+            }
+            Self::BodyNotUtf8
+            | Self::EmptyBody
+            | Self::MethodNotAllowed { .. }
+            | Self::NotAcceptable
+            | Self::NotFound { .. }
+            | Self::UnsupportedMediaType { .. } => {}
         }
     }
 }
@@ -343,6 +411,10 @@ mod tests {
             .await
             .unwrap()
             .to_vec()
+    }
+
+    fn dummy_error() -> std::io::Error {
+        std::io::Error::other("dummy internal error")
     }
 
     #[test]
@@ -389,7 +461,7 @@ mod tests {
             StatusCode::UNPROCESSABLE_ENTITY
         );
         assert_eq!(
-            HttpError::Internal.into_response().status(),
+            HttpError::internal(dummy_error()).into_response().status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
     }
@@ -403,28 +475,38 @@ mod tests {
 
     #[test]
     fn content_type_is_problem_json() {
-        let response = HttpError::Internal.into_response();
+        let response = HttpError::internal(dummy_error()).into_response();
         let content_type = response.headers().get(CONTENT_TYPE).unwrap();
         assert_eq!(content_type, "application/problem+json; charset=utf-8");
     }
 
     #[test]
     fn no_allow_header_on_non_405_variants() {
-        let response = HttpError::Internal.into_response();
+        let response = HttpError::internal(dummy_error()).into_response();
         assert!(response.headers().get(ALLOW).is_none());
     }
 
     #[cfg(feature = "sentry")]
     #[test]
-    fn internal_error_is_captured_by_sentry() {
+    fn internal_error_is_captured_by_sentry_with_source_chain() {
         let events = sentry::test::with_captured_events(|| {
-            let _response = HttpError::Internal.into_response();
+            let _response = HttpError::internal(dummy_error()).into_response();
         });
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].level, sentry::Level::Error);
+        assert!(
+            events[0].message.is_none(),
+            "capture_error must not populate top-level message"
+        );
+        let first_exception = events[0]
+            .exception
+            .values
+            .first()
+            .expect("exception chain must be populated by capture_error");
         assert_eq!(
-            events[0].message.as_deref(),
-            Some("An unexpected error occurred during conversion")
+            first_exception.value.as_deref(),
+            Some("dummy internal error"),
+            "exception value must equal the Display of the source error"
         );
     }
 
@@ -464,7 +546,7 @@ mod tests {
 
     #[tokio::test]
     async fn serializes_with_four_fields() {
-        let bytes = body_bytes(HttpError::Internal).await;
+        let bytes = body_bytes(HttpError::internal(dummy_error())).await;
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(
             json,
@@ -508,7 +590,7 @@ mod tests {
 
     #[tokio::test]
     async fn internal_detail_is_fixed() {
-        let bytes = body_bytes(HttpError::Internal).await;
+        let bytes = body_bytes(HttpError::internal(dummy_error())).await;
         let json: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(
             json["detail"].as_str().unwrap(),
@@ -577,7 +659,7 @@ mod tests {
 
     #[test]
     fn internal_error_class_returns_internal() {
-        assert_eq!(HttpError::Internal.error_class(), "internal");
+        assert_eq!(HttpError::internal(dummy_error()).error_class(), "internal");
     }
 
     #[test]
@@ -636,7 +718,10 @@ mod tests {
 
     #[test]
     fn internal_result_class_returns_server_error() {
-        assert_eq!(HttpError::Internal.result_class(), "server_error");
+        assert_eq!(
+            HttpError::internal(dummy_error()).result_class(),
+            "server_error"
+        );
     }
 
     #[test]
@@ -687,12 +772,13 @@ mod tests {
     mod posthog_tests {
         #![allow(clippy::expect_used, clippy::unwrap_used)]
         use super::super::HttpError;
+        use super::dummy_error;
         use axum::response::IntoResponse as _;
 
         #[cfg(all(feature = "sentry", feature = "posthog"))]
         #[test]
         fn internal_error_into_response_does_not_panic_with_both_features() {
-            let response = HttpError::Internal.into_response();
+            let response = HttpError::internal(dummy_error()).into_response();
             assert_eq!(
                 response.status(),
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR
@@ -702,7 +788,7 @@ mod tests {
         #[cfg(all(feature = "posthog", not(feature = "sentry")))]
         #[test]
         fn internal_error_into_response_does_not_panic_with_posthog_only() {
-            let response = HttpError::Internal.into_response();
+            let response = HttpError::internal(dummy_error()).into_response();
             assert_eq!(
                 response.status(),
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR
@@ -721,7 +807,7 @@ mod tests {
 
         #[test]
         fn into_response_outside_tokio_runtime_does_not_panic() {
-            let response = HttpError::Internal.into_response();
+            let response = HttpError::internal(dummy_error()).into_response();
             assert_eq!(
                 response.status(),
                 axum::http::StatusCode::INTERNAL_SERVER_ERROR

--- a/crates/docspec-http/src/handlers/conversion.rs
+++ b/crates/docspec-http/src/handlers/conversion.rs
@@ -312,14 +312,16 @@ async fn do_conversion(
         }
 
         sink.finish().map_err(|error| {
-            tracing::debug!(error = %error, "conversion sink finish failed");
-            HttpError::Internal
+            tracing::warn!(error = ?error, "conversion sink finish failed");
+            HttpError::internal(error)
         })?;
 
         // Capture byte count before output_buffer is consumed by Body::from.
         // u64::try_from is lossless on 64-bit targets (usize ≤ u64::MAX).
-        let output_bytes =
-            u64::try_from(output_buffer.len()).map_err(|_conversion_error| HttpError::Internal)?;
+        let output_bytes = u64::try_from(output_buffer.len()).map_err(|conversion_error| {
+            tracing::warn!(error = ?conversion_error, "output size exceeded u64 range");
+            HttpError::internal(conversion_error)
+        })?;
         Ok((output_buffer, output_bytes))
     })
     .await;
@@ -343,13 +345,13 @@ async fn do_conversion(
             .body(Body::from(output))
             .map(|response| (response, output_bytes, output_format))
             .map_err(|error| {
-                tracing::error!(error = %error, "failed to build conversion response");
-                HttpError::Internal
+                tracing::warn!(error = ?error, "failed to build conversion response");
+                HttpError::internal(error)
             }),
         Ok(Err(http_error)) => Err(http_error),
         Err(join_error) => {
-            tracing::error!(error = %join_error, "spawn_blocking join failed");
-            Err(HttpError::Internal)
+            tracing::warn!(error = ?join_error, "spawn_blocking join failed");
+            Err(HttpError::internal(join_error))
         }
     }
 }

--- a/crates/docspec-http/src/router.rs
+++ b/crates/docspec-http/src/router.rs
@@ -30,7 +30,7 @@ pub fn router() -> Router {
     use axum::routing::{get, post};
     use tower::ServiceBuilder;
     use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
-    use tower_http::trace::TraceLayer;
+    use tower_http::trace::{DefaultOnFailure, TraceLayer};
 
     use crate::cache::cache_control_layer;
     use crate::handlers::{
@@ -110,7 +110,10 @@ pub fn router() -> Router {
         .layer(option_layer(telemetry::tower_new_layer()))
         .layer(option_layer(telemetry::tower_http_layer()))
         .layer(middleware::from_fn(attach_sentry_tags))
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http()
+                .on_failure(DefaultOnFailure::new().level(tracing::Level::DEBUG)),
+        )
         .layer(middleware::from_fn(record_http_metrics))
         .layer(PropagateRequestIdLayer::new(x_request_id))
         .layer(PropagateRequestIdLayer::new(x_trace_id))
@@ -129,7 +132,10 @@ pub fn router() -> Router {
             MakeRequestUuid,
         ))
         .layer(SetRequestIdLayer::new(x_trace_id.clone(), EchoOnly))
-        .layer(TraceLayer::new_for_http())
+        .layer(
+            TraceLayer::new_for_http()
+                .on_failure(DefaultOnFailure::new().level(tracing::Level::DEBUG)),
+        )
         .layer(middleware::from_fn(record_http_metrics))
         .layer(PropagateRequestIdLayer::new(x_request_id))
         .layer(PropagateRequestIdLayer::new(x_trace_id))

--- a/crates/docspec-http/tests/http_posthog_integration.rs
+++ b/crates/docspec-http/tests/http_posthog_integration.rs
@@ -27,6 +27,10 @@ fn lock_env() -> std::sync::MutexGuard<'static, ()> {
     }
 }
 
+fn dummy_error() -> std::io::Error {
+    std::io::Error::other("dummy internal error")
+}
+
 /// Helper to initialize a `PostHog` client pointing at the wiremock server.
 async fn init_test_posthog_client(
     mock_server: &wiremock::MockServer,
@@ -88,7 +92,7 @@ async fn internal_error_dual_fire_includes_sentry_event_id() {
     mount_posthog_stub(&mock_server).await;
     let client = init_test_posthog_client(&mock_server).await;
 
-    drop(docspec_http::error::HttpError::Internal.into_response());
+    drop(docspec_http::error::HttpError::internal(dummy_error()).into_response());
 
     flush_and_clear_slot(client).await;
 
@@ -115,7 +119,7 @@ async fn internal_error_posthog_only_no_sentry_id() {
     mount_posthog_stub(&mock_server).await;
     let client = init_test_posthog_client(&mock_server).await;
 
-    drop(docspec_http::error::HttpError::Internal.into_response());
+    drop(docspec_http::error::HttpError::internal(dummy_error()).into_response());
 
     flush_and_clear_slot(client).await;
 
@@ -260,7 +264,7 @@ async fn zero_sample_rate_sends_no_events() {
         .expect("client should init even with sample rate 0");
     install_posthog_client(std::sync::Arc::clone(&client));
 
-    drop(docspec_http::error::HttpError::Internal.into_response());
+    drop(docspec_http::error::HttpError::internal(dummy_error()).into_response());
 
     client.shutdown().await;
     clear_posthog_client();
@@ -289,7 +293,7 @@ async fn flush_on_shutdown_delivers_all_events_before_returning() {
         .expect("client should init");
     install_posthog_client(client);
 
-    drop(docspec_http::error::HttpError::Internal.into_response());
+    drop(docspec_http::error::HttpError::internal(dummy_error()).into_response());
 
     docspec_http::telemetry::shutdown().await;
     clear_posthog_client();

--- a/crates/docspec-http/tests/http_sentry_integration.rs
+++ b/crates/docspec-http/tests/http_sentry_integration.rs
@@ -19,12 +19,16 @@ fn lock_env() -> std::sync::MutexGuard<'static, ()> {
     }
 }
 
+fn dummy_error() -> std::io::Error {
+    std::io::Error::other("dummy internal error")
+}
+
 #[test]
 fn internal_error_captured_with_request_id_tag() {
     let _env_guard = lock_env();
     let events = sentry::test::with_captured_events(|| {
         use axum::response::IntoResponse as _;
-        drop(docspec_http::error::HttpError::Internal.into_response());
+        drop(docspec_http::error::HttpError::internal(dummy_error()).into_response());
     });
     assert_eq!(
         events.len(),
@@ -123,7 +127,7 @@ fn body_not_in_extras_or_contexts() {
     let _env_guard = lock_env();
     let events = sentry::test::with_captured_events(|| {
         use axum::response::IntoResponse as _;
-        drop(docspec_http::error::HttpError::Internal.into_response());
+        drop(docspec_http::error::HttpError::internal(dummy_error()).into_response());
     });
     assert_eq!(events.len(), 1);
     let event = events.first().expect("expected event");


### PR DESCRIPTION
Fixes uninformative 500 events observed as Sentry DOCSPEC-1 / DOCSPEC-2.

- `HttpError::Internal` carries a boxed source error; Sentry captured via `capture_error` (walks source chain + attaches backtrace)
- Enables sentry `debug-images` feature so backtrace addresses can be symbolicated server-side
- `do_conversion` 500-path logs use `warn!(error = ?error, ...)` for full Debug chain in stderr
- tower-http `on_failure` downgraded ERROR → DEBUG (was the source of the duplicate DOCSPEC-1)