### PR TITLE
fix(docspec-http): capture usable stacktraces on Sentry errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,12 @@ unnecessary_wraps = "allow"
 # Reason: AnyReader enum variants (HtmlReader, MarkdownReader) are large but must be stack-allocated for zero heap allocation and zero virtual-dispatch overhead per MANIFESTO.md. Boxing would violate the design constraint.
 large_enum_variant = "allow"
 
+[profile.release]
+# Reason: Preserve line-table debug info so Sentry stacktraces (captured
+# via attach_stacktrace) resolve to file:line pairs. Adds ~5% binary size;
+# drops symbol names — Sentry symbolication only needs file:line.
+debug = "line-tables-only"
+
 [workspace.metadata.cargo-semver-checks.lints]
 feature_not_enabled_by_default = { required-update = "minor" }
 enum_variant_added = { required-update = "minor" }

--- a/crates/docspec-http/src/telemetry/sentry.rs
+++ b/crates/docspec-http/src/telemetry/sentry.rs
@@ -23,6 +23,7 @@ fn client_options(parsed_data_source_name: sentry::types::Dsn) -> sentry::Client
         sample_rate: env_sample_rate(),
         traces_sample_rate: env_traces_sample_rate(),
         send_default_pii: false,
+        attach_stacktrace: true,
         before_send: Some(std::sync::Arc::new(before_send)),
         ..Default::default()
     }
@@ -184,5 +185,17 @@ mod tests {
     #[test]
     fn init_sentry_returns_none_on_invalid_dsn() {
         assert!(super::init_sentry("not-a-dsn").is_none());
+    }
+
+    #[test]
+    fn client_options_enables_attach_stacktrace() -> Result<(), Box<dyn core::error::Error>> {
+        let _env_guard = lock_env();
+        let dsn: sentry::types::Dsn = "https://public@example.com/1".parse()?;
+        let opts = super::client_options(dsn);
+        if opts.attach_stacktrace {
+            Ok(())
+        } else {
+            Err("attach_stacktrace should be true".into())
+        }
     }
 }


### PR DESCRIPTION
Enables `attach_stacktrace: true` on Sentry `ClientOptions` and preserves line-table debug info in release builds — together, `sentry::capture_error(...)` now captures readable call-site stacktraces.

Refs DOCSPEC-3 (Sentry event shows "No stacktrace available").
