### PR TITLE
fix(docspec-http): enable posthog Cargo feature by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 
-RUN cargo build -p docspec-cli --release --no-default-features --features http && \
+RUN cargo build -p docspec-cli --release && \
   mkdir -p /out && \
   cp target/release/docspec /out/docspec
 

--- a/crates/docspec-cli/Cargo.toml
+++ b/crates/docspec-cli/Cargo.toml
@@ -22,7 +22,7 @@ docspec-http = { workspace = true, optional = true }
 thiserror = "2"
 
 [features]
-default = ["http"]
+default = ["http", "posthog"]
 http = ["dep:docspec-http"]
 posthog = ["http", "docspec-http/posthog"]
 

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -49,7 +49,11 @@ Starts the HTTP API server. Listens on `127.0.0.1:3000` by default.
 
 ### Feature flags
 
-`docspec-cli` ships with `http` enabled by default. For a slim install without the HTTP server stack:
+`docspec-cli` ships with `http` and `posthog` enabled by default. Sentry compiles in via
+`docspec-http`'s defaults. The telemetry integrations are runtime no-ops until their respective env vars are set —
+see the [`docspec-http` README](https://docs.rs/docspec-http) for the full list.
+
+For a slim install without the HTTP server stack (and therefore no telemetry):
 
 ```bash
 cargo install docspec-cli --no-default-features

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["network-programming", "web-programming"]
 dist = false
 
 [features]
-default = ["sentry"]
+default = ["sentry", "posthog"]
 sentry = ["dep:sentry"]
 posthog = ["dep:posthog-rs", "dep:uuid"]
 

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -171,23 +171,15 @@ Each captured event is tagged with `request_id` (UUID v4) and `trace_id`
 ### PostHog
 
 `docspec-http` integrates with [PostHog](https://posthog.com/) for product analytics and error reporting.
-Activation is fully opt-in via Cargo feature and environment variables — the binary has zero PostHog
-overhead when the `posthog` feature is disabled or no API key is configured.
+Activation is fully opt-in via environment variables — the binary has zero PostHog
+overhead when no API key is configured.
 
 #### Activation
 
-Enable the `posthog` Cargo feature and set ONE of the following:
+The `posthog` Cargo feature is on by default. Set ONE of the following to send events:
 
 - `DOCSPEC_POSTHOG_API_KEY` — docspec-specific override (preferred)
 - `POSTHOG_API_KEY` — PostHog's standard convention (fallback)
-
-**For `docspec-cli` users:** the power-user path is:
-
-```bash
-cargo install docspec-cli --features posthog
-```
-
-This enables PostHog analytics in the HTTP server without needing to specify the nested feature.
 
 If both are set, `DOCSPEC_POSTHOG_API_KEY` wins. An empty string is treated as "not set" — the server
 starts normally without PostHog.
@@ -253,27 +245,27 @@ The server handles SIGINT and SIGTERM. In-flight requests complete before the pr
 | Feature | Default | Description |
 | --- | --- | --- |
 | `sentry` | **on** (part of `default`) | Enables Sentry error reporting integration |
-| `posthog` | off | Enables PostHog product analytics integration |
+| `posthog` | **on** (part of `default`) | Enables PostHog product analytics integration |
 
-Default:
+Default (both integrations compiled in):
 
 ```toml
 [dependencies]
 docspec-http = "1"
 ```
 
-Opt into PostHog:
+Sentry only:
 
 ```toml
 [dependencies]
-docspec-http = { version = "1", features = ["posthog"] }
+docspec-http = { version = "1", default-features = false, features = ["sentry"] }
 ```
 
-Both backends:
+PostHog only:
 
 ```toml
 [dependencies]
-docspec-http = { version = "1", features = ["sentry", "posthog"] }
+docspec-http = { version = "1", default-features = false, features = ["posthog"] }
 ```
 
 No telemetry:
@@ -283,9 +275,11 @@ No telemetry:
 docspec-http = { version = "1", default-features = false }
 ```
 
-> **Migration note:** if you depend on `docspec-http` with `default-features = false`, you will
-> lose the Sentry integration after this release. Add `features = ["sentry"]` to preserve the
-> previous behavior.
+> **Migration note:** starting with this release, `posthog` joins `sentry` in the default feature
+> set. Upgrading `docspec-http` without Cargo changes will additionally compile the PostHog
+> integration into your binary — at runtime it stays a no-op unless `DOCSPEC_POSTHOG_API_KEY` (or
+> `POSTHOG_API_KEY`) is set. To exclude either integration, use `default-features = false` and
+> opt into just what you need.
 
 ## Metrics
 


### PR DESCRIPTION
Flips `posthog` to default so `ghcr.io/docspec/api` compiles it in. Runtime no-op without `DOCSPEC_POSTHOG_API_KEY`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Default builds now include additional telemetry and reporting support out of the box.

* **Documentation**
  * Updated setup and feature-flag guidance to reflect the new default behavior.
  * Clarified how telemetry components behave at runtime and what to expect during upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->