### PR TITLE
docs: improve documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # DocSpec Architecture
 
-This document explains how DocSpec works architecturally. For the philosophy behind our design decisions, see the companion [Manifesto](MANIFESTO.md).
+Documents are rivers, not lakes. This document explains how that conviction becomes code. For the philosophy behind these decisions, see the [Manifesto](MANIFESTO.md).
 
 ---
 
@@ -18,7 +18,7 @@ DocSpec rejects all of this. Documents are streams of content, not static struct
 
 ## 2. The Event-Based Pipeline
 
-DocSpec treats every document as a stream of events. Instead of building a tree, we emit events as we parse. A heading becomes StartHeading and EndHeading events. A paragraph becomes StartParagraph, Text events, then EndParagraph. A table becomes StartTable, StartTableRow, StartTableCell, cell content, EndTableCell, EndTableRow, EndTable.
+DocSpec treats every document as a stream of events. Instead of building a tree, we emit events as we parse. A heading becomes `StartHeading` and `EndHeading` events. A paragraph becomes `StartParagraph`, `Text` events, then `EndParagraph`. A table becomes `StartTable`, `StartTableRow`, `StartTableCell`, cell content, `EndTableCell`, `EndTableRow`, `EndTable`.
 
 Events flow in strict document order. Nothing accumulates. Nothing buffers. The document enters as bytes and exits as bytes. In between, it is a stream of events flowing through a pipeline.
 
@@ -34,7 +34,7 @@ The pipeline is transparent and inspectable. You can insert adapters between sou
 
 The event model is universal across all formats. A document is a sequence of structural elements: headings, paragraphs, lists, tables, text runs with styling, links, images. By separating structure from encoding, we achieve true interoperability.
 
-The event flow is predictable. StartDocument begins the stream. EndDocument terminates it. Between these, events arrive in document order. Block-level elements use paired Start and End events. Inline content uses flat events with styling. This consistency makes reasoning about event sequences straightforward.
+The event flow is predictable. `StartDocument` begins the stream. `EndDocument` terminates it. Between these, events arrive in document order. Block-level elements use paired Start and End events. Inline content uses flat events with styling. This consistency makes reasoning about event sequences straightforward.
 
 ---
 
@@ -42,7 +42,7 @@ The event flow is predictable. StartDocument begins the stream. EndDocument term
 
 The dominant alternative to streaming is building an abstract syntax tree. Parse the whole document, construct a tree in memory, walk the tree recursively, emit output. These advantages come at a steep cost that grows with document size.
 
-Memory usage in a tree-based system is O(document size) at best, often worse. A 100 MB document typically needs 100 MB for content storage, plus overhead for tree node structures: pointers, sibling links, type tags, metadata. A 100 MB document can easily become 200-300 MB in memory.
+Memory usage in a tree-based system is O(document size) at best, often worse. A 100 MB document typically needs 100 MB for content storage, plus overhead for tree node structures: pointers, sibling links, type tags, metadata. A 100 MB document can easily become 200–300 MB in memory.
 
 Streaming uses O(1) memory regardless of document size. Events flow through and are immediately consumed. Only a small, fixed-size buffer is needed for the current event. A 1 KB document and a 1 GB document use essentially the same amount of memory.
 
@@ -64,7 +64,7 @@ The streaming model enables processing of documents larger than available memory
 
 Images are where the memory abuse of traditional approaches is most visible. Traditional converters load the full image bytes before deciding what to do with them. A document containing a 50 MB embedded image requires the entire 50 MB in heap memory. A document with twenty such images requires 1 GB of image data in memory simultaneously.
 
-DocSpec never does this. Images are represented as references in the event stream, not as data payloads. When the source encounters an image, it emits an Image event containing a reference. The event itself is tiny, just a few dozen bytes.
+DocSpec never does this. Images are represented as references in the event stream, not as data payloads. When the source encounters an image, it emits an `Image` event containing a reference. The event itself is tiny, just a few dozen bytes.
 
 When the sink needs the actual image bytes, it requests them through an asset provider. The asset provider is an abstraction that can serve bytes on demand. The sink asks for the image by its reference, and the provider streams it piece by piece. The sink writes each chunk directly to its output buffer without ever holding the complete image.
 
@@ -115,7 +115,7 @@ Common adapter patterns include:
 - **Filtering adapters** remove events matching certain criteria. Strip all images to create a text-only version. Remove hidden text. Skip metadata sections.
 - **Remapping adapters** change event types to transform document structure. Convert all headings down by one level. Turn block quotations into indented paragraphs.
 - **Counting adapters** track statistics without modifying the event stream. Count words, paragraphs, images, tables.
-- **Validating adapters** check invariants and fail fast if violated. Ensure every StartParagraph has a corresponding EndParagraph. Verify heading levels are within valid ranges.
+- **Validating adapters** check invariants and fail fast if violated. Ensure every `StartParagraph` has a corresponding `EndParagraph`. Verify heading levels are within valid ranges.
 
 The trait interfaces are intentionally minimal. A source has one main method: return the next event when requested. A sink has two methods: receive an event, and finish. This minimal surface area makes implementations straightforward.
 

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,14 +1,14 @@
 # Coding Standards
 
-This document explains why we enforce the standards we do. For the exact rules, see the workspace `Cargo.toml`. For the philosophy behind them, see `MANIFESTO.md`.
+We do not suppress warnings. We fix the underlying problems. These standards exist because we have seen what happens when they are not followed: production crashes, silent data corruption, security vulnerabilities, code no one dares touch. The compiler is our first reviewer. It never gets tired. A warning that is ignored will become a bug.
+
+For the exact lint configuration, see the workspace `Cargo.toml`. For the philosophy behind these rules, see [MANIFESTO.md](MANIFESTO.md).
 
 ---
 
 ## 1. The Underlying Philosophy
 
-Code quality is about correctness, safety, and maintainability. We enforce standards that eliminate whole categories of bugs. We do not suppress warnings; we fix the underlying problems.
-
-Every rule exists because we have seen what happens when it is not followed: production crashes, silent data corruption, security vulnerabilities, code no one dares touch. The compiler is our first reviewer. It never gets tired. A warning that is ignored will become a bug.
+Code quality is about correctness, safety, and maintainability. We enforce standards that eliminate whole categories of bugs. Every rule exists because we have seen what happens when it is not followed. The compiler is our ally. We do not bypass it.
 
 ---
 
@@ -142,6 +142,6 @@ Quality is not accidental. It is the result of discipline applied consistently o
 
 ## Further Reading
 
-- **MANIFESTO.md** — The philosophy that drives these standards
-- **ARCHITECTURE.md** — The streaming pipeline design
-- **CONTRIBUTING.md** — The workflow that enforces these standards
+- **[MANIFESTO.md](MANIFESTO.md)** — The philosophy that drives these standards
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — The streaming pipeline design
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — The workflow that enforces these standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to DocSpec
 
-Thank you for considering a contribution. DocSpec is a memory-conscious streaming document conversion library with strict quality standards.
+We are not relaxed. We are not permissive. We have standards, and we enforce them — not as gatekeeping, but as stewardship. Read the [Manifesto](MANIFESTO.md) before diving into code. It explains what we stand for: memory efficiency, streaming design, and strict quality above convenience. Then come back here for the workflow.
 
 ## Getting Started
 
@@ -11,6 +11,7 @@ Thank you for considering a contribution. DocSpec is a memory-conscious streamin
 - [Git LFS](https://git-lfs.com/) for large binary test fixtures — run `git lfs install` once per machine after installing; run `git lfs pull` after clone to fetch the `.docx` test fixtures
 - [pre-commit](https://pre-commit.com/) for running pre-commit hooks
 - [taplo](https://taplo.tamasfe.dev/) for TOML formatting (`cargo install taplo-cli`)
+- [`just`](https://github.com/casey/just) for the build and test commands below (`cargo install just`)
 
 Clone the repository:
 ```bash
@@ -21,8 +22,6 @@ pre-commit install --hook-type commit-msg
 pre-commit install --hook-type pre-push
 ```
 
-The pre-commit hooks enforce formatting, linting, and conventional commit message format; the pre-push hooks verify the full build, test suite, and documentation. Before diving into code, read the [Manifesto](MANIFESTO.md) to understand our philosophy: memory efficiency, streaming design, and strict quality above convenience.
-
 The pre-commit stage (runs on every commit) enforces formatting, linting, and hygiene checks. The pre-push stage (runs before push) runs the full build, test suite, and documentation build.
 
 ### Hook Bypass Policy
@@ -32,6 +31,74 @@ Use `git commit --no-verify` or `git push --no-verify` only when:
 - Work-in-progress commits on a personal branch that will be squashed before PR
 
 Never bypass hooks on commits intended for pull request review. CI will catch what hooks miss, but hooks exist to give you fast local feedback.
+
+## Building and Running Locally
+
+The `justfile` is the front door. Running `just` with no arguments runs the whole local gate — format, lint, test, doc, build — the same checks the hooks and CI enforce:
+
+```bash
+just              # fmt · clippy · test · doc · build
+```
+
+Reach for a single recipe when you want one step:
+
+```bash
+just build        # cargo build --workspace
+just test         # cargo test --workspace
+just clippy       # cargo clippy --workspace --all-targets -- -D warnings
+just fmt          # cargo fmt --all
+just doc          # cargo doc --workspace --no-deps, warnings denied
+just coverage     # llvm-cov across covered crates → lcov.info
+```
+
+Every recipe is a thin wrapper over the Cargo command shown beside it, so raw `cargo` works just as well. `just --list` prints the full set.
+
+### Running the CLI from source
+
+The binary is `docspec`. Run it through Cargo without installing anything:
+
+```bash
+cargo run -p docspec-cli -- convert report.docx report.md
+cargo run -p docspec-cli -- convert --from markdown --to blocknote input.md
+cargo run -p docspec-cli -- --help
+```
+
+### Running the HTTP server from source
+
+```bash
+cargo run -p docspec-cli -- http                          # binds 127.0.0.1:3000
+cargo run -p docspec-cli -- http --host 0.0.0.0 --port 8080
+```
+
+`GET /health` reports liveness, `POST /conversion` streams a conversion, and `GET /metrics` exposes Prometheus metrics. Sentry and PostHog are compiled in but stay dormant unless `DOCSPEC_SENTRY_DSN` or `DOCSPEC_POSTHOG_API_KEY` is set — nothing leaves your machine by default.
+
+### Feature flags
+
+`just build` and `just test` run `cargo build/test --workspace`, which builds each crate with its own default feature set — so every reader and writer *crate* is compiled and tested (each has meaningful defaults), but non-default facade feature combinations are only checked when you enable them explicitly. Flags matter when you depend on the [`docspec`](crates/docspec) facade and want a smaller footprint:
+
+- Facade defaults are `markdown`, `blocknote`, and `pandoc-native`.
+- DOCX reading is opt-in — enable the `docx` feature, or `full` for everything.
+- The CLI bundles the HTTP server by default; `cargo install docspec-cli --no-default-features` builds a convert-only binary.
+
+### WebAssembly
+
+`docspec-wasm` builds with [`wasm-pack`](https://rustwasm.github.io/wasm-pack/) (`cargo install wasm-pack`) against the `wasm32-unknown-unknown` target:
+
+```bash
+just wasm          # wasm-pack build --dev --target web crates/docspec-wasm
+just wasm-release  # the optimized build
+```
+
+The output bundle lands in `crates/docspec-wasm/pkg/`.
+
+### Docker
+
+The `Dockerfile` at the repo root is the image published as `ghcr.io/docspec/api` — a static `docspec` binary running `http` on port 3000:
+
+```bash
+docker build -t docspec-api .
+docker run --rm -p 3000:3000 docspec-api
+```
 
 ## Branching Strategy
 
@@ -209,14 +276,10 @@ Better: `fix(docx): prevent panic on documents with missing content types`
 
 ## Questions and Support
 
-- Open an issue for bug reports or feature requests
+- Open an issue for bug reports or feature requests — see [Bug Triage & Reporting](TRIAGE.md) for what makes a report actionable and how we triage
 - Use discussions for questions about usage or architecture
 - Read existing documentation before asking
 
 ## Attribution
 
 Contributions are attributed in the git history. Your commits are your contribution record. By contributing, you agree that your contributions will be licensed under the same license as the project.
-
----
-
-Thank you for helping make DocSpec better.

--- a/README.md
+++ b/README.md
@@ -1,74 +1,173 @@
 # DocSpec
 
-DocSpec is a streaming document conversion library. It converts DOCX, ODT, RTF, HTML, Markdown, BlockNote JSON, and Pandoc native — event by event, byte by byte, without buffering the world. Built in Rust for memory-conscious systems, from microcontrollers to servers.
+**Streaming document conversion that never buffers the whole document.**
 
-## Philosophy
+Documents, as they flow. DocSpec reads a document as a stream of typed events and
+writes it back out in another format — one event at a time, in constant memory, no
+matter how large the file. Streaming is the whole point; the [Manifesto](MANIFESTO.md)
+explains why.
 
-See our [Manifesto](MANIFESTO.md) for what we stand for: memory extremism, streaming-first design, and the belief that software should earn every byte it uses.
+**Funded by** [NLnet](https://nlnet.nl) through the [NGI0 Commons Fund](https://nlnet.nl/commonsfund/), and the Netherlands' [Ministry of the Interior and Kingdom Relations](https://www.rijksoverheid.nl/ministeries/ministerie-van-binnenlandse-zaken-en-koninkrijksrelaties).
 
-## Quick Start
+<p>
+  <a href="https://nlnet.nl"><img src="https://raw.githubusercontent.com/docspec/.github/main/assets/nlnet-banner.svg" alt="NLnet" height="40"></a>
+  &nbsp;&nbsp;
+  <a href="https://nlnet.nl/commonsfund/"><img src="https://raw.githubusercontent.com/docspec/.github/main/assets/ngi0-commons.svg" alt="NGI0 Commons Fund" height="40"></a>
+  &nbsp;&nbsp;
+  <a href="https://www.rijksoverheid.nl/ministeries/ministerie-van-binnenlandse-zaken-en-koninkrijksrelaties"><img src="https://raw.githubusercontent.com/docspec/.github/main/assets/minbzk.jpg" alt="Ministerie van Binnenlandse Zaken en Koninkrijksrelaties" height="40"></a>
+</p>
 
-DocSpec works through a pipeline of readers and writers. A reader (EventSource) parses a document and emits events: StartParagraph, Text, EndParagraph, StartHeading, etc. A writer (EventSink) consumes these events and produces output in the target format.
+**Used by** [DINUM — La Suite Numérique](https://lasuite.numerique.gouv.fr).
 
-The architecture is fully decoupled. Any reader connects to any writer. A DOCX reader can feed a Markdown writer. An HTML reader can feed BlockNote JSON. The events are the contract.
+<p>
+  <a href="https://lasuite.numerique.gouv.fr"><img src="https://raw.githubusercontent.com/docspec/.github/main/assets/dinum-gouv.svg" alt="Gouvernement" height="36"></a>
+  &nbsp;&nbsp;
+  <a href="https://lasuite.numerique.gouv.fr"><img src="https://raw.githubusercontent.com/docspec/.github/main/assets/lasuite.svg" alt="La Suite Numérique" height="36"></a>
+</p>
 
-To convert a document:
+## Getting started
 
-1. Create a reader for your input format
-2. Create a writer for your output format
-3. Connect them through the event pipeline
-4. Let the events flow
+Two ways in, depending on what you need.
 
-No buffering. No intermediate representations. No loading the entire document into memory. The document streams through, event by event.
+### Convert a file — the CLI
 
-### CLI
-
-Install the `docspec` binary:
+Install with Cargo:
 
 ```sh
 cargo install docspec-cli
 ```
 
-Convert a document:
+Convert a document — the formats are inferred from the file extensions:
 
 ```sh
-docspec convert input.docx output.md
+docspec convert report.docx report.md
 ```
 
-Start the HTTP API server:
+Or pipe through stdin and name the formats explicitly:
 
 ```sh
-docspec http
+echo '# Hello' | docspec convert --from markdown --to blocknote
 ```
 
-The Docker image (`ghcr.io/docspec/api`) runs `docspec http` internally.
+### Run the API — Docker or the CLI
+
+The `ghcr.io/docspec/api` image is the conversion server, ready to run with no Rust toolchain:
+
+```sh
+docker run --rm -p 3000:3000 ghcr.io/docspec/api
+```
+
+Installed the CLI instead? It ships the same server:
+
+```sh
+docspec http            # serves on 127.0.0.1:3000
+```
+
+Either way, send it a document — the `Content-Type` picks the reader, the `Accept` header picks the writer (BlockNote JSON by default):
+
+```sh
+curl -X POST http://localhost:3000/conversion \
+     -H 'Content-Type: text/markdown' \
+     -d '# Hello'
+```
+
+`GET /health` is the liveness check; [`docspec-http`](crates/docspec-http) has the full endpoint, header, and format reference.
+
+## What it reads and writes
+
+Readers and writers are fully decoupled: any reader can feed any writer, because the
+event stream is the only contract between them.
+
+| Direction  | Formats                                                     |
+| ---------- | ----------------------------------------------------------- |
+| **Reads**  | DOCX, HTML, Markdown                                         |
+| **Writes** | HTML, Markdown, BlockNote JSON, oxa.dev JSON, Pandoc native  |
+
+## Why DocSpec?
+
+Most document converters load the whole file into memory, build a tree, and hope it fits. That works until someone uploads a 200 MB report — or until you need the same converter to run inside a browser tab. DocSpec exists to turn real-world documents into what modern **web editors** actually consume — BlockNote JSON, oxa.dev — without ever holding the whole document at once.
+
+Streaming event by event, in constant memory, is the one decision everything else follows from:
+
+- **It runs where your editor runs.** The same Rust compiles to a native server, a WebAssembly module in the browser, or an embedded target — one codebase, every surface, no separate front-end and back-end converters drifting apart.
+- **Its memory stays flat.** A 1 KB note and a 500 MB document cost about the same to convert. Constant memory is the architecture, not a tuning flag.
+- **It stays honest.** On corrupt input it stops and says so — no half-converted output quietly reaching your database.
+
+DocSpec is the Rust successor to [NLdoc](https://gitlab.com/logius/nldoc), rebuilt for public-sector digital sovereignty: funded by [NLnet](https://nlnet.nl) and the Dutch Ministry of the Interior, and used in production by [La Suite](https://lasuite.numerique.gouv.fr) to import documents into its collaborative editor. The [Manifesto](MANIFESTO.md) is the long version of why.
+
+## The crates
+
+DocSpec is a Cargo workspace. Most users want the [`docspec`](crates/docspec) facade;
+reach for the individual crates when you want the smallest possible dependency footprint.
+
+**Core**
+
+- [`docspec`](crates/docspec) — convenience facade; readers, writers, and core types behind feature flags
+- [`docspec-core`](crates/docspec-core) — the event model, the `EventSource`/`EventSink` traits, and the streaming pipeline
+
+**Readers**
+
+- [`docspec-docx-reader`](crates/docspec-docx-reader) — DOCX
+- [`docspec-html-reader`](crates/docspec-html-reader) — HTML
+- [`docspec-markdown-reader`](crates/docspec-markdown-reader) — Markdown (CommonMark + GFM)
+
+**Writers**
+
+- [`docspec-html-writer`](crates/docspec-html-writer) — HTML
+- [`docspec-markdown-writer`](crates/docspec-markdown-writer) — Markdown
+- [`docspec-blocknote-writer`](crates/docspec-blocknote-writer) — BlockNote JSON
+- [`docspec-oxa-writer`](crates/docspec-oxa-writer) — oxa.dev JSON
+- [`docspec-pandoc-native-writer`](crates/docspec-pandoc-native-writer) — Pandoc native
+
+**Primitives & tooling**
+
+- [`docspec-json`](crates/docspec-json) — streaming JSON emission primitives for custom writers
+- [`docspec-cli`](crates/docspec-cli) — the `docspec` command-line binary
+- [`docspec-http`](crates/docspec-http) — the HTTP conversion server
+- [`docspec-wasm`](crates/docspec-wasm) — WebAssembly bindings
 
 ## Documentation
 
-- **[Manifesto](MANIFESTO.md)** — Philosophy and values: memory extremism, streaming design, quality standards
-- **[Architecture](ARCHITECTURE.md)** — Streaming pipeline design, reader/writer contracts, event model decisions, and how to read the in-code event reference
-- **[Coding Standards](CODING_STANDARDS.md)** — Code style rules, formatting conventions, review checklist
-- **[Contributing](CONTRIBUTING.md)** — How to contribute, PR process, development workflow
-- **[Testing](TESTING.md)** — Test philosophy, coverage requirements, testing patterns
-- **[Security](SECURITY.md)** — Security principles, vulnerability reporting, safe practices
-- **[Agents](AGENTS.md)** — Guidance for AI agents analyzing or contributing to this codebase
+- [Manifesto](MANIFESTO.md) — philosophy and values
+- [Architecture](ARCHITECTURE.md) — the streaming pipeline, reader/writer contracts, and the event model
+- [Coding Standards](CODING_STANDARDS.md) — the code style and the review bar
+- [Contributing](CONTRIBUTING.md) — workflow, commits, PRs, semver
+- [Bug Triage & Reporting](TRIAGE.md) — filing actionable bug reports and how we triage them
+- [Testing](TESTING.md) — the coverage floor and test philosophy
+- [Security](SECURITY.md) — error handling by context, resource limits
+- [Agents](AGENTS.md) — guidance for AI agents working in this repo
 
-## Core Principles
+## What we stand for
 
-- **Memory Conscious**: Every byte allocated must justify its existence. We measure, profile, and optimize relentlessly.
-- **Streaming First**: Data flows event by event. Nothing accumulates. Everything moves.
-- **Fail Fast**: On corruption or error, surface it immediately. No partial output. No silent truncation.
-- **No Unsafe Code**: The workspace forbids unsafe entirely. Safety is not a limitation; it is a foundation.
-- **Strict Quality**: 98% coverage for new and changed executable Rust lines in covered crates. In source code: no `unwrap`, no `expect`, no inline `#[allow]` warning suppressions. Test files (under `tests/**` and `#[cfg(test)]` modules) may opt out of `unwrap_used` / `expect_used` via crate-level `#![allow(...)]`; source code stays strict.
-
-## Why Rust
-
-We chose Rust because it gives us control: memory layout, allocation, lifetimes — without a garbage collector making decisions for us. The borrow checker enforces at compile time what other languages discover at runtime through crashes. Ownership is not a feature; it is a discipline.
+- **Memory conscious** — constant memory regardless of file size; every allocation earns its keep.
+- **Streaming first** — events flow one at a time; nothing accumulates.
+- **Fail fast** — on corruption we stop and say so: no partial output, no silent truncation.
+- **No unsafe** — the workspace forbids `unsafe` entirely.
+- **Proven** — a 98% coverage floor on new and changed executable Rust lines in covered crates; no `unwrap` or `expect` in source.
 
 ## Status
 
-DocSpec is under active development. The architecture is stable. The event model is defined. Readers and writers are being implemented incrementally.
+DocSpec is under active development. The architecture is stable and the event model is
+defined; readers and writers land incrementally. We keep the public API honest about
+what is supported today versus what a crate silently drops.
+
+## Contributing
+
+DocSpec is built in the open, and contributions are welcome — a new reader or writer, a bug fix, a sharper doc, a failing test that pins down an edge case. We hold a high bar (no `unsafe`, no `unwrap` in source, a 98% coverage floor on new and changed executable Rust lines in covered crates), but the bar is written down, not hidden. Start with [CONTRIBUTING.md](CONTRIBUTING.md) for the full workflow.
+
+A few good entry points:
+
+- **Found a bug?** [Bug Triage & Reporting](TRIAGE.md) shows what makes a report we can fix today. Security issues go [privately](SECURITY.md) — never a public issue.
+- **Have an idea, or a design to talk through?** Open a [Discussion](https://github.com/orgs/docspec/discussions).
+- **Ready to write code?** [Building and Running Locally](CONTRIBUTING.md#building-and-running-locally) gets you set up in a few commands.
+
+Every contribution is attributed in the git history, and we treat review as collaboration, not gatekeeping.
 
 ## License
 
-See LICENSE file.
+[MIT](LICENSE).
+
+## Thanks
+
+This work grew out of the mentoring and support of
+[@virgile-dev](https://github.com/virgile-dev).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,14 +1,12 @@
 # Releasing DocSpec
 
-This document is the maintainer runbook for releasing DocSpec. It covers the full release lifecycle: from conventional commit on `main` to published crates, signed binaries, and Docker images.
+This is the maintainer runbook for releasing DocSpec. It covers the full release lifecycle: from conventional commit on `main` to published crates, signed binaries, and Docker images. The process is designed to be boring. Most releases require a maintainer to review and merge a single PR. The automation handles the rest.
 
 ## Overview
 
 DocSpec uses a unified ecosystem version across all 12 crates. Every release is tagged `vX.Y.Z` at the workspace level, and all publishable crates carry that same version. [release-plz](https://release-plz.dev) is the canonical release driver: it reads Conventional Commits, opens a release PR, and on merge handles tagging and publishing.
 
 Crates publish to crates.io via Trusted Publishing (OIDC). No long-lived API tokens are stored in repository secrets. Binaries for `docspec-cli` are built and distributed by [cargo-dist](https://opensource.axo.dev/cargo-dist/). Docker images are built and pushed from release-plz's native release outputs via the reusable `docker.yml` workflow. All artifacts carry SLSA L2 build provenance attestations and cosign keyless signatures.
-
-The release process is designed to be boring. Most releases require a maintainer to review and merge a single PR. The automation handles the rest.
 
 ## Versioning Policy
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
 # Security Principles
 
-This document describes the security philosophy and principles that guide how we build DocSpec. It is not a threat model, vulnerability policy, or security audit. It is how we think about security.
+Security in DocSpec is not a separate concern. It flows from our core values: memory safety, fail-fast error handling, defensive parsing, and minimal dependencies. This document explains how those values translate into concrete security properties. It is not a threat model, vulnerability policy, or security audit. It is how we think about security.
 
 ---
 
@@ -115,7 +115,7 @@ Security researchers who report valid vulnerabilities will be acknowledged in ou
 
 ## Summary
 
-Security in DocSpec is not a separate concern. It flows from our core values:
+Security in DocSpec flows from our core values:
 
 - Memory safety through Rust's type system
 - Defensive parsing through fail-fast validation

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Philosophy
 
-Testing is not a step that happens after development. It is development. Every feature, every bug fix, every refactor comes with tests that prove it works. Untested code is incomplete code.
+We are uncompromising about testing. We do not ship code we have not verified. Testing is not a step that happens after development — it is development. Every feature, every bug fix, every refactor comes with tests that prove it works. Untested code is incomplete code.
 
 We target 98% test coverage for new and changed executable Rust lines in crates covered by the standard coverage job. Not as an aspirational goal. As a floor. The 2% tolerance exists for genuinely untestable code: platform-specific initialization, embedded hardware interaction, code that interfaces with external systems beyond our control, and WASM/CLI entry points that require integration testing. If your code does not have tests, it is not done.
 
@@ -68,7 +68,7 @@ Snapshots also serve as regression tests. When a bug is fixed, we add a snapshot
 
 Snapshot files live in `tests/snapshots/docx/pandoc/` and are committed alongside the fixtures they cover. Run `cargo insta review` to interactively inspect pending snapshots: press `a` to accept a change as correct, `r` to reject it and keep the existing snapshot. Accept snapshots only when you have verified the new output is correct — not merely different.
 
-To generate snapshots for the first time (or for fixtures added since the last run), use `INSTA_UPDATE=unseen cargo test --test pandoc_corpus -p docspec-docx-reader`. This writes only the missing snapshots and leaves existing ones untouched. In CI (`CI=true`, `INSTA_UPDATE` unset), any missing or mismatched snapshot causes the test to fail immediately — do not set `INSTA_UPDATE=always` in any committed script or workflow.
+To generate snapshots for the first time (or for fixtures added since the last run), use `INSTA_UPDATE=unseen cargo test --test snapshots -p docspec-docx-reader`. This writes only the missing snapshots and leaves existing ones untouched. In CI (`CI=true`, `INSTA_UPDATE` unset), any missing or mismatched snapshot causes the test to fail immediately — do not set `INSTA_UPDATE=always` in any committed script or workflow.
 
 ### Fuzz Tests
 
@@ -99,6 +99,87 @@ A good fixture is minimal but complete. It contains the minimum structure needed
 We do not generate fixtures programmatically unless the generation itself is under test. Real files from real sources are preferred. They contain the complexity that synthetic data misses.
 
 Fixtures are documentation too. They show what kinds of documents we handle and demonstrate the complexity we support.
+
+## How We Test a Conversion
+
+The sections above describe the kinds of tests; this one is the concrete machinery. Every conversion test is built from a small shared harness and asserts an *exact* value — an event stream, an output string, or a committed snapshot.
+
+### The shared harness: `docspec-test-utils`
+
+One internal, unpublished crate — [`docspec-test-utils`](crates/docspec-test-utils) — supplies the pieces every conversion test reuses. It is a dev-dependency of every reader and writer, the facade, the CLI, and the HTTP crate:
+
+- `collect_events(reader)` / `try_collect_events(reader)` — drive a reader to completion and return the `Vec<Event>` it emitted.
+- `drive(sink, events)` / `try_drive(sink, events)` — push a sequence of events into a writer and call `finish()`.
+- `capture(path, open)` — open a fixture with a reader and drain it into a `ReaderFixtureSnapshot`: the event stream plus how it terminated (`Ok` or `Err`), with image assets captured stably by content hash.
+- `FailingWriter` — an `io::Write` that fails after N bytes, for exercising error propagation.
+- `synth_docx(...)` and friends — build minimal in-memory DOCX archives, so DOCX tests don't all need a binary fixture on disk.
+
+### Readers assert the exact event stream
+
+A reader test feeds input, collects the events, and compares the *entire* vector — every field pinned, nothing approximate:
+
+```rust
+let mut reader = HtmlReader::from_str("<p>hello</p>");
+let events = collect_events(&mut reader);
+assert_eq!(events, vec![
+    Event::StartDocument { id: None, language: None, metadata: None },
+    Event::StartParagraph { alignment: None, id: None },
+    Event::Text { content: "hello".to_string() },
+    Event::EndParagraph,
+    Event::EndDocument,
+]);
+```
+
+Wrong event, wrong order, or an unexpected field, and the equality fails. No `contains`, no "is an array", no shape check — the [exact-value rule](#exact-value-assertions) applies to event streams too.
+
+### Writers assert the exact output
+
+The mirror image: drive a known event sequence into the writer, then compare the output byte for byte. The `events` slice below is illustrative — a real test builds the exact `Vec<Event>` for the input:
+
+```rust
+let mut buf = Vec::new();
+let mut writer = HtmlWriter::new(&mut buf);
+for event in events {          // StartDocument … Text("hello world") … EndDocument
+    writer.handle_event(event).unwrap();
+}
+writer.finish().unwrap();
+assert_eq!(String::from_utf8(buf).unwrap(), "<html><body><p>Hello, world</p></body></html>");
+```
+
+### End to end: a reader wired to a writer
+
+The facade's integration tests connect a reader straight to a writer — the real pipeline — and compare the result against a committed fixture. JSON outputs are compared as parsed values, so key ordering and whitespace can't cause false failures while the structure stays pinned exactly. The snippet below is a sketch — `run_pipeline` and `assert_json_eq` are per-test helpers, and the `.../tests/fixtures/…` paths are placeholders for the concrete relative paths each test uses:
+
+```rust
+// crates/docspec/tests/blocknote_markdown_pipeline.rs
+let markdown = include_str!(".../tests/fixtures/markdown/empty.md");
+let expected = include_str!(".../tests/fixtures/blocknote/empty.json");
+assert_json_eq(&run_pipeline(markdown), expected);
+```
+
+Inputs and expected outputs live under `tests/fixtures/<format>/`, paired by name (`empty.md` ↔ `empty.json`), so every conversion is pinned to a real, reviewable before/after pair.
+
+### The DOCX corpus: real files, snapshotted
+
+DOCX input is the messiest, so it gets the heaviest machinery: a corpus of **real** `.docx` files, each pinned by a snapshot of the events it produces.
+
+- **Fixtures** live under `tests/fixtures/docx/<corpus>/`, tracked via Git LFS (`*.docx filter=lfs`). Three corpora, each with its own license recorded in [`tests/fixtures/ATTRIBUTION.md`](tests/fixtures/ATTRIBUTION.md): **pandoc** (80 files), **apache-tika** (55 files), and **docspec** (our own curated regressions).
+- **Tests are generated, not hand-written.** [`crates/docspec-docx-reader/build.rs`](crates/docspec-docx-reader/build.rs) walks each corpus directory and emits one `#[test]` per fixture; [`tests/snapshots.rs`](crates/docspec-docx-reader/tests/snapshots.rs) includes them. Drop a fixture in, and its test exists on the next build.
+- **Each test checks two things.** It opens the fixture both by bytes (`from_reader`) and by path (`from_path`) and asserts the two event streams are identical — the streaming and path-based entry points must never diverge — then snapshots the stream against the committed `.snap` under `tests/snapshots/docx/<corpus>/`.
+
+Run the corpus:
+
+```bash
+cargo test --test snapshots -p docspec-docx-reader
+```
+
+In CI, `INSTA_UPDATE` is unset, so a new or changed snapshot fails the build — output drift is never silent. To add a regression: drop the `.docx` into the corpus, record it in `ATTRIBUTION.md`, generate its snapshot with `INSTA_UPDATE=unseen cargo test --test snapshots -p docspec-docx-reader`, and review it as described in [Snapshot Review](#snapshot-review) before committing the fixture and snapshot together.
+
+### Where the tests live
+
+- **Per-crate** `crates/<crate>/tests/` — `reader.rs` (event-stream assertions), `writer.rs` (output assertions), and `snapshots.rs` for the DOCX reader.
+- **Cross-crate** `crates/docspec/tests/` — reader-to-writer pipelines and reader/writer factory dispatch.
+- **Shared** corpora and snapshots at the workspace root: `tests/fixtures/` and `tests/snapshots/`.
 
 ## The Fail-Fast Test Principle
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -1,0 +1,96 @@
+# Bug Triage & Reporting
+
+A bug report is a reproduction handed to us; triage is how we turn a stream of reports into a queue we can actually work. This guide has two halves: the first is for anyone **reporting** a bug, the second is the **triage** runbook for maintainers. Both lean on the same values as the rest of DocSpec — fail fast, stay honest about what we support, and prove every fix with a test. (See the [Manifesto](MANIFESTO.md) for why.)
+
+---
+
+## Reporting a bug
+
+### First, the one exception: security
+
+If the bug is a **security vulnerability** — a parser that panics or hangs on crafted input, a document that exhausts memory or CPU, anything that lets a malicious document affect the host — **do not open a public issue.** Report it privately through the process in [SECURITY.md](SECURITY.md). Public disclosure before a fix helps attackers, not users. When in doubt about whether something is security-sensitive, treat it as security and report privately.
+
+### Before you file
+
+- **Search first.** Someone may have already reported it. Add to the existing issue instead of opening a duplicate.
+- **Check you're current.** Reproduce on the latest release (or `main`) before filing — the bug may already be fixed.
+- **Check it's actually a bug.** DocSpec is honest about its limits: some inputs are documented as unsupported and some content is knowingly dropped (for example, the HTML reader and writer are paragraph-only today). Skim the relevant crate README before filing. If we drop something *without* documenting it, that itself is a bug — tell us.
+- **Reduce it.** The most useful thing you can send is the *smallest* document that still reproduces the problem. A ten-page report that fails is a mystery; a three-line document that fails is a test case.
+
+### What makes a report actionable
+
+Open a **Bug Report** issue on [`docspec/docspec`](https://github.com/docspec/docspec/issues/new/choose) and fill in the form. The fields exist for a reason:
+
+- **Version** — the release, tag, or commit. "Latest" ages badly; a version number does not.
+- **Description** — what happened, and what you expected instead.
+- **Steps to reproduce** — the exact command or request. For the CLI, the full `docspec convert …` line. For the HTTP API, the `Content-Type`, the `Accept` header, and the endpoint.
+- **Sample document** — the minimal input that triggers it, and the input/output formats involved. For a conversion bug this is the single most valuable field; without it we are guessing.
+- **Error output / logs** — the exact error text, not a paraphrase.
+- **Environment** — OS, Rust version (`rustc --version`), and DocSpec version.
+
+A report that lets us reproduce the bug from one paste is a report we can fix today. A vague one waits while we ask for what the form already requested.
+
+---
+
+## Triaging a bug (maintainers)
+
+Every new bug arrives labelled `bug` and `triage`. Triage is the pass that earns the removal of `triage`: confirm the report, classify it, route it, and decide when it gets worked. Do it promptly — an untriaged queue is a queue no one trusts.
+
+### The triage pass
+
+1. **Reproduce.** Follow the steps. If you can reproduce, say so on the issue. If you can't — missing version, no sample document, unclear steps — ask for exactly what's missing and label `needs-info` (or `needs-repro`). The reporter's minimal sample becomes the regression fixture later, so insist on it.
+2. **Confirm it's a bug.** If the behaviour is a documented limitation or a silent drop we already warn about, it isn't a bug — redirect it (a feature request for the missing capability, or a docs fix if the limitation was *not* actually documented). If it's a request for a new format or feature, relabel `enhancement` and drop `bug`.
+3. **Check for security.** If the "bug" is a crash, hang, or resource exhaustion triggered by crafted or malicious input — especially anything reachable through the HTTP API — stop treating it as public. Crashes on ordinary valid input remain public high-severity bugs handled through normal triage (see the Severity table below). Move the crafted-input cases to the private channel in [SECURITY.md](SECURITY.md) and close the public issue with a pointer there, not a description of the flaw. A fuzzing crash counts even if it looks hard to exploit.
+4. **Set severity.** Use the model below.
+5. **Route to a crate.** Label the area so the right code owner sees it (see [Routing by area](#routing-by-area)).
+6. **Prioritise, then drop `triage`.** Decide whether it's next, soon, or someday, and remove the `triage` label so the issue leaves the intake queue.
+
+### Severity
+
+Severity follows our values, not a generic ladder. The worst bug is the one that lies to the user.
+
+| Severity | What it is | Examples |
+| --- | --- | --- |
+| **Critical** | **Silent wrong output.** The conversion succeeds but the result is corrupt or semantically wrong, with no error. The worst class, because wrong output propagates — it lands in databases and downstream documents before anyone notices. | Text reordered or dropped from otherwise-supported content; mis-encoded characters; a writer emitting structurally wrong JSON that still parses. |
+| **High** | **Crash or hang on ordinary input.** A panic, abort, or infinite loop violates fail-fast and the no-panic rule. If the trigger is *crafted* input, it's a security bug — route it privately instead. | A panic converting a valid DOCX; the HTTP server hanging on a well-formed request. |
+| **High** | **Unbounded resource use** on input that should hit a limit. If it's remotely triggerable, treat it as security. | A document that exhausts memory or never terminates. |
+| **Medium** | **Loud, wrong failure.** It fails visibly when it should succeed, or returns the wrong error. Incorrect, but neither silent nor a crash. | A valid conversion rejected with a spurious parse error; the wrong HTTP status code. |
+| **Low** | **Cosmetic or ergonomic.** Confusing messages, doc mismatches, minor output nits that don't change meaning. | An unhelpful error string; a stray blank line in Markdown output. |
+
+Exactly one severity per bug. When a bug spans tiers, take the higher one — a crash that also corrupts output is Critical.
+
+### Routing by area
+
+Route each bug to the crate that owns the behaviour, so the label points at the code:
+
+- A reader bug (input parsing) → `docspec-docx-reader`, `docspec-html-reader`, or `docspec-markdown-reader`.
+- A writer bug (output generation) → `docspec-html-writer`, `docspec-markdown-writer`, `docspec-blocknote-writer`, `docspec-oxa-writer`, or `docspec-pandoc-native-writer`.
+- Pipeline, event model, or trait behaviour → `docspec-core`.
+- The `docspec convert` command → `docspec-cli`; the HTTP surface → `docspec-http`; WASM bindings → `docspec-wasm`.
+- Wrong in both directions? Route to the reader first — a reader that emits the wrong events makes every writer look broken.
+
+### Labels
+
+Three labels exist today: `bug` and `triage` (applied by the Bug Report form) and `enhancement`. Triage adds three lean dimensions on top; adopt them as repository labels:
+
+- **Severity** — `severity:critical` … `severity:low`, exactly one per bug.
+- **Area** — `area:<crate>` (e.g. `area:docspec-docx-reader`), pointing at the owning crate above.
+- **Status** — `needs-info`, `needs-repro`, `confirmed`, `blocked`, as the issue moves.
+
+Keep the set small. A label that changes no decision is noise.
+
+### From confirmed to closed
+
+A triaged bug moves confirmed → in progress → fixed → closed. Two rules hold at the end:
+
+- **Every fix ships with a regression test.** When we fix a bug we add the reporter's minimal sample as a fixture, so the same bug can never return silently. This is the discipline in [TESTING.md](TESTING.md) — a fixed bug without a test is a bug waiting to come back.
+- **Close with a reason.** Fixed (link the PR), working-as-documented (link the docs), duplicate (link the original), or can't-reproduce after a fair wait on `needs-info`. Close kindly and reopen freely when new information arrives — a closed issue is not a verdict on the reporter.
+
+---
+
+## Related
+
+- [SECURITY.md](SECURITY.md) — the private channel for vulnerabilities, and why we treat all input as untrusted
+- [TESTING.md](TESTING.md) — why every fix needs a regression fixture, and the test types that catch bugs
+- [CONTRIBUTING.md](CONTRIBUTING.md) — the branch, commit, and PR workflow a fix follows
+- [MANIFESTO.md](MANIFESTO.md) — fail fast, and stay honest about what we support

--- a/crates/docspec-blocknote-writer/README.md
+++ b/crates/docspec-blocknote-writer/README.md
@@ -1,70 +1,17 @@
-# `docspec-blocknote-writer`
+# docspec-blocknote-writer
 
-Converts a DocSpec event stream into [BlockNote](https://www.blocknotejs.org/) JSON. Implements the `EventSink` trait and emits JSON tokens directly to any `Write` target as events arrive. Conversion is streaming-first, with local buffering only for bounded conversion details such as asset data URI encoding and lifting nested table event substreams after their enclosing table closes.
+**DocSpec events, written as BlockNote JSON.**
 
-## Supported Features
+Events arrive; BlockNote JSON leaves. `docspec-blocknote-writer` turns a DocSpec event stream into [BlockNote](https://www.blocknotejs.org/) JSON, writing tokens directly to any `Write` target as events arrive. Nothing accumulates beyond what bounded conversion details require — asset data URI encoding and lifting nested table substreams after their enclosing table closes. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-| Block type                         | BlockNote type                                    |
-| ---------------------------------- | ------------------------------------------------- |
-| Paragraph                          | `paragraph`                                       |
-| Heading (levels 1–6)               | `heading`                                         |
-| Block quote                        | `quote`                                           |
-| Preformatted / code block          | `codeBlock`                                       |
-| Image                              | `image`                                           |
-| Table (with header and data cells) | `table`                                           |
-| Thematic break                     | `divider`                                         |
-| Unordered list item                | `bulletListItem`                                  |
-| Ordered list item                  | `numberedListItem`                                |
-| Inline link                        | `link` inline type with `href` (title is dropped) |
+## Add it
 
-Inline styles are consumed from `StartTextStyle`/`EndTextStyle` spans around `Text` events. Bold, italic, code, strikethrough, and underline render as BlockNote style flags. Subscript and superscript are accepted but omitted because BlockNote's default schema has no equivalent representation.
-Inline links (`StartLink`/`EndLink`) emit a `link` inline type with the `href`. The optional `title` field is dropped (BlockNote's default link schema has no title).
+```toml
+[dependencies]
+docspec-blocknote-writer = "1"
+```
 
-List items support arbitrary nesting via BlockNote's native `children: Block[]` arrays. The `start` prop on `numberedListItem` is preserved when the first item in a sequence carries an explicit start number. The `id` field on `Start*ListItem` events is dropped — list items never emit an `id` key, regardless of source. Upstream readers such as `docspec-docx-reader` set this field to the OOXML `numId`, which is shared by every item in the same list and so is not a per-item identifier.
-
-### Color Styles
-
-Two color-bearing style kinds emit JSON keys in the inline `styles` object:
-
-- **`textColor`** — emitted when the reader sends `StartTextStyle { kind: TextColor(Color) }`. The RGB value is snapped to the nearest BlockNote palette color and written as a string, e.g. `"textColor":"red"`.
-- **`backgroundColor`** — emitted when the reader sends `StartTextStyle { kind: Mark(Color) }`. Same palette snap, written as e.g. `"backgroundColor":"blue"`.
-
-Pure black `(0, 0, 0)` and pure white `(255, 255, 255)` are both treated as BlockNote's default and produce no key for either style. White is filtered because it is the standard page-default color and the OOXML idiom for "no visible shading" (`<w:shd w:val="clear" w:fill="FFFFFF"/>`); without this guard, every such no-op shading would snap to the pastel `"gray"` palette entry. Non-RGB colors are also omitted. Any other RGB color is snapped to one of the 9 named palette entries.
-
-#### Palette
-
-Each style type has its own 9-entry palette of named colors. The names are the same for both, but the RGB values differ because BlockNote uses distinct pastel shades for backgrounds versus richer tones for text:
-
-| Name     |
-| -------- |
-| `gray`   |
-| `brown`  |
-| `red`    |
-| `orange` |
-| `yellow` |
-| `green`  |
-| `blue`   |
-| `purple` |
-| `pink`   |
-
-#### Palette snap algorithm
-
-The palette snap uses squared Euclidean distance in 8-bit sRGB space. No perceptual weighting, no gamma correction. Ties are broken by iteration order. This mirrors the reference Elixir implementation.
-
-The two palettes use different RGB values, so the same input color can snap to different names depending on whether it's a text color or a background color. For instance, the saturated red `(224, 62, 62)` snaps to background palette `"orange"` (not `"red"`) because the background palette uses pastel colors and the Euclidean distance to pastel orange is shorter than to pastel red. This is intentional and matches the reference implementation.
-
-See [COLOR_SNAPPING.md](./COLOR_SNAPPING.md) for an example of how this snap can rename a source color end-to-end (OOXML `<w:highlight w:val="yellow"/>` → BlockNote `"backgroundColor":"orange"`) and the mechanism behind it.
-
-## Not Yet Supported
-
-- Footnotes — `StartFootnote`/`EndFootnote`/`FootnoteRef` are silently ignored; BlockNote's default schema has no equivalent
-- Definition lists — `StartDefinitionList`/`StartDefinitionTerm`/`StartDefinitionDetail` (and their `End*` pairs) are silently ignored; BlockNote's default schema has no equivalent
-- Captions — `StartCaption`/`EndCaption` are silently ignored
-- `checkListItem` — requires upstream DocSpec event support not yet defined
-- `toggleListItem` — no DocSpec event equivalent
-- Custom list style markers — the `style_type` field on `StartOrderedListItem`/`StartUnorderedListItem` is always dropped (BlockNote's default schema has no equivalent); list kind is determined entirely by the event variant (ordered vs unordered)
-
-## Usage
+## Write some BlockNote JSON
 
 Wrap `BlockNoteWriter` in `StackTrackingSink` before feeding list events. The writer lazily opens the list item's `content[]` array when the first paragraph or inline content arrives, which lets it preserve non-default first-paragraph alignment on the list item while omitting BlockNote's default props. `StackTrackingSink` is still required because it normalizes paragraph boundaries (especially from sources that don't always emit an explicit `StartParagraph` inside list items), which is what lets the writer detect multi-paragraph items and transition emission into `children[]` for subsequent paragraphs.
 
@@ -123,7 +70,69 @@ let json = String::from_utf8(buf)?;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-## Limitations
+## What it handles today
+
+| Block type                         | BlockNote type                                    |
+| ---------------------------------- | ------------------------------------------------- |
+| Paragraph                          | `paragraph`                                       |
+| Heading (levels 1–6)               | `heading`                                         |
+| Block quote                        | `quote`                                           |
+| Preformatted / code block          | `codeBlock`                                       |
+| Image                              | `image`                                           |
+| Table (with header and data cells) | `table`                                           |
+| Thematic break                     | `divider`                                         |
+| Unordered list item                | `bulletListItem`                                  |
+| Ordered list item                  | `numberedListItem`                                |
+| Inline link                        | `link` inline type with `href` (title is dropped) |
+
+Inline styles are consumed from `StartTextStyle`/`EndTextStyle` spans around `Text` events. Bold, italic, code, strikethrough, and underline render as BlockNote style flags. Subscript and superscript are accepted but omitted because BlockNote's default schema has no equivalent representation.
+Inline links (`StartLink`/`EndLink`) emit a `link` inline type with the `href`. The optional `title` field is dropped (BlockNote's default link schema has no title).
+
+List items support arbitrary nesting via BlockNote's native `children: Block[]` arrays. The `start` prop on `numberedListItem` is preserved when the first item in a sequence carries an explicit start number. The `id` field on `Start*ListItem` events is dropped — list items never emit an `id` key, regardless of source. Upstream readers such as `docspec-docx-reader` set this field to the OOXML `numId`, which is shared by every item in the same list and so is not a per-item identifier.
+
+### Color Styles
+
+Two color-bearing style kinds emit JSON keys in the inline `styles` object:
+
+- **`textColor`** — emitted when the reader sends `StartTextStyle { kind: TextColor(Color) }`. The RGB value is snapped to the nearest BlockNote palette color and written as a string, e.g. `"textColor":"red"`.
+- **`backgroundColor`** — emitted when the reader sends `StartTextStyle { kind: Mark(Color) }`. Same palette snap, written as e.g. `"backgroundColor":"blue"`.
+
+Pure black `(0, 0, 0)` and pure white `(255, 255, 255)` are both treated as BlockNote's default and produce no key for either style. White is filtered because it is the standard page-default color and the OOXML idiom for "no visible shading" (`<w:shd w:val="clear" w:fill="FFFFFF"/>`); without this guard, every such no-op shading would snap to the pastel `"gray"` palette entry. Non-RGB colors are also omitted. Any other RGB color is snapped to one of the 9 named palette entries.
+
+#### Palette
+
+Each style type has its own 9-entry palette of named colors. The names are the same for both, but the RGB values differ because BlockNote uses distinct pastel shades for backgrounds versus richer tones for text:
+
+| Name     |
+| -------- |
+| `gray`   |
+| `brown`  |
+| `red`    |
+| `orange` |
+| `yellow` |
+| `green`  |
+| `blue`   |
+| `purple` |
+| `pink`   |
+
+#### Palette snap algorithm
+
+The palette snap uses squared Euclidean distance in 8-bit sRGB space. No perceptual weighting, no gamma correction. Ties are broken by iteration order. This mirrors the reference Elixir implementation.
+
+The two palettes use different RGB values, so the same input color can snap to different names depending on whether it's a text color or a background color. For instance, the saturated red `(224, 62, 62)` snaps to background palette `"orange"` (not `"red"`) because the background palette uses pastel colors and the Euclidean distance to pastel orange is shorter than to pastel red. This is intentional and matches the reference implementation.
+
+See [COLOR_SNAPPING.md](./COLOR_SNAPPING.md) for an example of how this snap can rename a source color end-to-end (OOXML `<w:highlight w:val="yellow"/>` → BlockNote `"backgroundColor":"orange"`) and the mechanism behind it.
+
+## What it doesn't handle yet
+
+- Footnotes — `StartFootnote`/`EndFootnote`/`FootnoteRef` are silently ignored; BlockNote's default schema has no equivalent
+- Definition lists — `StartDefinitionList`/`StartDefinitionTerm`/`StartDefinitionDetail` (and their `End*` pairs) are silently ignored; BlockNote's default schema has no equivalent
+- Captions — `StartCaption`/`EndCaption` are silently ignored
+- `checkListItem` — requires upstream DocSpec event support not yet defined
+- `toggleListItem` — no DocSpec event equivalent
+- Custom list style markers — the `style_type` field on `StartOrderedListItem`/`StartUnorderedListItem` is always dropped (BlockNote's default schema has no equivalent); list kind is determined entirely by the event variant (ordered vs unordered)
+
+## Hard edges
 
 ### Table cell content
 
@@ -145,10 +154,7 @@ Headings, lists, code blocks, images, dividers, and nested quotes inside a block
 
 Images inside a link span are emitted as plain text using the alt-text of the image. This is a BlockNote limitation: BlockNote's inline content cannot contain image nodes.
 
-## API Documentation
+## Related
 
-See the [module-level docs](https://docs.rs/docspec-blocknote-writer) for the full API surface, including `BlockNoteWriter` and its `EventSink` implementation.
-
-## License
-
-See the [repository LICENSE](../../LICENSE).
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-blocknote-writer` on docs.rs](https://docs.rs/docspec-blocknote-writer)

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -1,10 +1,24 @@
-# `docspec-cli`
+# docspec-cli
 
-Command-line interface for DocSpec document conversion.
+**Convert documents from the command line.**
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation.
+One binary, every format DocSpec speaks. `docspec-cli` wraps the full DocSpec conversion pipeline behind two subcommands: `convert` turns a file (or stdin) from one format into another, and `http` starts the HTTP API server. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-## Usage
+## Install it
+
+```bash
+cargo install docspec-cli
+```
+
+For a slim install without the HTTP server stack (and therefore no telemetry):
+
+```bash
+cargo install docspec-cli --no-default-features
+```
+
+The resulting binary supports only `docspec convert`; running `docspec http` will print "unknown subcommand".
+
+## Convert a document
 
 ```bash
 docspec <COMMAND> [OPTIONS]
@@ -53,15 +67,7 @@ Starts the HTTP API server. Listens on `127.0.0.1:3000` by default.
 `docspec-http`'s defaults. The telemetry integrations are runtime no-ops until their respective env vars are set —
 see the [`docspec-http` README](https://docs.rs/docspec-http) for the full list.
 
-For a slim install without the HTTP server stack (and therefore no telemetry):
-
-```bash
-cargo install docspec-cli --no-default-features
-```
-
-The resulting binary will only support `docspec convert`; running `docspec http` will print "unknown subcommand".
-
-## Supported Input Formats
+## Supported input formats
 
 - `markdown` — Full Markdown support including headings, lists, tables, and inline formatting
 - `html` — HTML input (see note below)
@@ -91,7 +97,7 @@ docspec convert --from html --to blocknote input.html --output output.json
 Convert a DOCX file to BlockNote JSON (preserves paragraphs, tables, lists, hyperlinks, images, and run styles):
 
 ```bash
-docspec --from docx --to blocknote input.docx --output output.json
+docspec convert --from docx --to blocknote input.docx --output output.json
 ```
 
 Convert Markdown from stdin to BlockNote JSON on stdout:
@@ -129,3 +135,8 @@ extension is ambiguous, so `--to oxa` must be explicit. HTML output is selected 
 or auto-detected from `.html` and `.htm` output paths. Pandoc native output is selected by
 `--to pandoc-native` or auto-detected from `.native` output paths. Markdown output is selected
 by `--to markdown` or auto-detected from `.md` output paths.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [DocSpec repository](https://github.com/docspec/docspec)

--- a/crates/docspec-core/README.md
+++ b/crates/docspec-core/README.md
@@ -1,11 +1,54 @@
-# `docspec-core`
+# docspec-core
 
-Core types and traits for the DocSpec streaming document pipeline. Documents are streams of typed events flowing from `EventSource` readers to `EventSink` writers.
+**The events every reader and writer agree on.**
 
-## Documentation
+`docspec-core` is the foundation of DocSpec: the `Event` type that documents stream as,
+the `EventSource` and `EventSink` traits that decouple readers from writers, and the
+`pipe` helper that drives one into the other. It reads and writes nothing itself — it
+defines the contract every other crate speaks. Streaming, like the rest of DocSpec.
+(See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-Run `just doc-open` to browse the full API documentation including all event types, traits, and field descriptions.
+## Add it
 
-## Adapters
+```toml
+[dependencies]
+docspec-core = "1"
+```
 
-- `SkipEmptyBlocks` — source adapter that suppresses empty `Heading`, `BlockQuote`, and `Paragraph` Start/End pairs via 1-event look-back (O(1) memory). Used by `docspec-cli` and `docspec-http` by default.
+## Speak the contract
+
+A reader is an `EventSource`, a writer is an `EventSink`, and `pipe` moves events from one
+into the other until the source runs dry. Implementing a sink is this small — here we
+count the events flowing through:
+
+```rust
+use docspec_core::{Event, EventSink, Result};
+
+/// A sink that counts the events flowing through it.
+struct CountEvents(usize);
+
+impl EventSink for CountEvents {
+    fn handle_event(&mut self, _event: Event) -> Result<()> {
+        self.0 += 1;
+        Ok(())
+    }
+    fn finish(self) -> Result<()> {
+        Ok(())
+    }
+}
+```
+
+Pair it with any `EventSource` — a DOCX, HTML, or Markdown reader from a sibling crate —
+and drive them with `pipe(source, sink)`. Nothing is buffered; events flow one at a time.
+
+## What's inside
+
+- **`Event`** — every document structure DocSpec understands. The [`event`](https://docs.rs/docspec-core/latest/docspec_core/event/index.html) module documents each variant and its well-formedness rules.
+- **`EventSource` / `EventSink` / `AssetHandle`** — the reader, writer, and streamed-asset contracts.
+- **`pipe`** — connect a source to a sink with no buffering.
+- **Adapters** — `SkipEmptyBlocks` drops empty heading/blockquote/paragraph pairs with O(1) look-back; `StackTrackingSink` validates nesting. Each wraps a source or sink without holding the document.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-core` on docs.rs](https://docs.rs/docspec-core) — every event variant, field, and rule

--- a/crates/docspec-docx-reader/README.md
+++ b/crates/docspec-docx-reader/README.md
@@ -1,11 +1,13 @@
 # docspec-docx-reader
 
-Streaming DOCX to DocSpec event stream reader.
+**DOCX in, a stream of events out.**
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation,
-architecture, and the event protocol.
+Word documents, unwrapped as they flow. `docspec-docx-reader` parses a `.docx` archive with
+`quick-xml` and `zip` and emits DocSpec events one at a time — and from `from_path`, in
+constant memory, whatever the file's size. Streaming, like the rest of DocSpec. (See the
+[Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-## Supported
+## What it handles today
 
 - Paragraphs (`<w:p>`) and direct text (`<w:t>` inside `<w:r>`)
 - Line breaks (`<w:br>`, including `w:type="page"` and `w:type="column"` — all emit `LineBreak`)
@@ -41,12 +43,17 @@ When both `<w:highlight>` and `<w:shd w:fill>` appear in the same `<w:rPr>`, `<w
 
 Adjacent runs with the same color emit separate `StartTextStyle`/`EndTextStyle` pairs. The reader maintains per-run discipline and does not merge consecutive runs, even when their style properties are identical.
 
-## Out of Scope (subtree silently dropped)
+### Style references (resolved, not on the denylist)
+
+Two elements look like they should belong to the denylist below, but are actually resolved through the styles table — the surrounding content is emitted normally:
+
+- `<w:rStyle>` (run-level style references) — resolved via `apply_resolved_rpr_style`. Style values that classify as `Code` promote the run to `TextStyleKind::Code`; other values contribute no style metadata, but the run's text is still emitted.
+- `<w:pStyle>` values other than the heading, block-quote, and code-style names listed in "What it handles today" — the paragraph emits as `StartParagraph` with no style metadata, and its content is emitted normally.
+
+## Out of scope (subtree silently dropped)
 
 The XML elements listed below are the reader's denylist — their entire subtree is silently dropped during parsing. Any element NOT listed (whether a known structural tag like `<w:p>` or an unknown extension) is processed normally; the reader just continues into its children.
 
-- `<w:rStyle>` (run-level style references) — silently dropped
-- `<w:pStyle>` values other than the heading, block-quote, and code-style names listed in "Supported" — silently dropped; the paragraph emits as `StartParagraph` with no style metadata
 - Run formatting not listed above: `<w:sz>`, `<w:szCs>`, `<w:caps>`, `<w:smallCaps>`, `<w:position>`, `<w:spacing>`, `<w:kern>`, `<w:lang>`, `<w:noProof>`
 - `<w:rFonts>` (general font tracking is not exposed as events, *except for symbol font resolution (Wingdings, Wingdings 2, Wingdings 3, Webdings, Symbol) which is used internally to normalize codepoints to Unicode*)
 - `themeColor` / `themeTint` / `themeShade` attributes on `<w:color>` and `<w:shd>` — silently dropped. The reader does not parse `styles.xml` or `theme1.xml`, so theme-referenced colors cannot be resolved. Future work.
@@ -127,7 +134,7 @@ In both cases, `_rels/.rels` and `word/_rels/document.xml.rels` are fully read i
 memory at package-open time (typical combined size < 10 KB even for large documents).
 The internal event queue remains bounded regardless of document size or hyperlink count.
 
-## Quick Start
+## Read a DOCX
 
 ```rust,no_run
 use docspec_docx_reader::{DocxReader, EventSource};
@@ -139,8 +146,7 @@ while let Some(event) = reader.next_event()? {
 # Ok::<(), docspec_core::Error>(())
 ```
 
-## See Also
+## Related
 
-- [MANIFESTO.md](../../MANIFESTO.md) — philosophy and values
-- [ARCHITECTURE.md](../../ARCHITECTURE.md) — pipeline design, event model decisions, and pointers to the in-code event reference
-- [`docspec_core` on docs.rs](https://docs.rs/docspec-core) — every event variant, field, and well-formedness rule
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — pipeline design, event model decisions, and pointers to the in-code event reference
+- [`docspec-core` on docs.rs](https://docs.rs/docspec-core) — every event variant, field, and well-formedness rule

--- a/crates/docspec-html-reader/README.md
+++ b/crates/docspec-html-reader/README.md
@@ -1,29 +1,19 @@
 # docspec-html-reader
 
-Streaming HTML to DocSpec event stream reader.
+**Paragraphs from HTML, one event at a time.**
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation,
-architecture, and the event protocol.
+Raw HTML arrives; a clean event stream leaves. `docspec-html-reader` parses HTML5 source and emits DocSpec events as it goes, touching only what it understands and dropping the rest without complaint. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-## Supported Elements
+## Add it
 
-- Paragraphs (`<p>`)
-- Emits exactly: `StartDocument`, `StartParagraph`, `Text`, `EndParagraph`, `EndDocument`
+```toml
+[dependencies]
+docspec-html-reader = "1"
+```
 
-## Out of Scope (silently dropped)
+## Read some HTML
 
-All other HTML elements are silently ignored. Text content inside inline elements
-(e.g., `<strong>`, `<em>`) is preserved as `Text` events, but the formatting
-structure is dropped.
-
-## Streaming Guarantee
-
-`HtmlReader` streams its source via `html5gum::IoReader`'s 16 KB sliding-window
-buffer. Memory usage is constant regardless of document size — the document need
-not fit in memory. Both `from_str` and `from_reader` use this streaming path
-internally.
-
-## Quick Start
+`HtmlReader` is an `EventSource`: call `next_event()` and events arrive one at a time. From a string:
 
 ```rust
 use docspec_html_reader::{HtmlReader, EventSource};
@@ -49,8 +39,15 @@ while let Some(event) = reader.next_event()? {
 # Ok::<(), docspec_core::Error>(())
 ```
 
-## See Also
+In a real pipeline, connect it to any `EventSink` with `docspec_core::pipe(reader, writer)`.
 
-- [MANIFESTO.md](../../MANIFESTO.md) — philosophy and values
-- [ARCHITECTURE.md](../../ARCHITECTURE.md) — pipeline design, event model decisions, and pointers to the in-code event reference
-- [`docspec_core` on docs.rs](https://docs.rs/docspec-core) — every event variant, field, and well-formedness rule
+## What it handles today
+
+We emit exactly five event kinds: `StartDocument`, `StartParagraph`, `Text`, `EndParagraph`, `EndDocument`. That means `<p>` elements and the text inside them. Text content inside inline elements like `<strong>` or `<em>` is preserved as `Text` events, but the formatting structure is dropped. Everything else — headings, lists, tables, images, every other HTML element — is silently ignored. No half-formed events, no silent guesses.
+
+Memory stays constant regardless of document size. Both `from_str` and `from_reader` stream through `html5gum::IoReader`'s 16 KB sliding-window buffer; the document never needs to fit in memory.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-html-reader` on docs.rs](https://docs.rs/docspec-html-reader)

--- a/crates/docspec-html-writer/README.md
+++ b/crates/docspec-html-writer/README.md
@@ -1,5 +1,57 @@
 # docspec-html-writer
 
-Streaming HTML5 writer for DocSpec events.
+**Streaming HTML5, one event at a time.**
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation.
+HTML, written as it flows. `docspec-html-writer` turns a stream of DocSpec events into
+HTML5 without ever assembling the document in memory. Paragraphs become `<p>`, text is
+escaped as it passes, and nothing accumulates — streaming, like the rest of DocSpec.
+(See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
+
+## Add it
+
+```toml
+[dependencies]
+docspec-html-writer = "1"
+```
+
+## Write some HTML
+
+`HtmlWriter` is an `EventSink`: hand it events and it writes HTML5 as they arrive. We open
+`<html><body>`, emit a `<p>` for each paragraph, escape every character as it passes, and
+close everything when the document ends:
+
+```rust,no_run
+use docspec_html_writer::HtmlWriter;
+use docspec_core::{Event, EventSink};
+
+let mut html = Vec::new();
+let mut writer = HtmlWriter::new(&mut html);
+for event in [
+    Event::StartDocument { id: None, language: None, metadata: None },
+    Event::StartParagraph { alignment: None, id: None },
+    Event::Text { content: "Hello, world".into() },
+    Event::EndParagraph,
+    Event::EndDocument,
+] {
+    writer.handle_event(event)?;
+}
+writer.finish()?;
+
+assert_eq!(html, b"<html><body><p>Hello, world</p></body></html>");
+# Ok::<(), docspec_core::Error>(())
+```
+
+In a real pipeline you feed it from a reader with `docspec_core::pipe(reader, writer)`
+rather than hand-writing events.
+
+## What it handles today
+
+Paragraphs and their text, escaped for safety (`&`, `<`, `>`). It emits nothing for
+headings, lists, tables, images, thematic breaks, or inline text styles — no half-formed
+HTML, no silent guesses. Text outside a paragraph is ignored, and an open paragraph is
+closed for you when the document ends.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-html-writer` on docs.rs](https://docs.rs/docspec-html-writer)

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -1,22 +1,24 @@
-# `docspec-http`
+# docspec-http
 
-Library providing an Axum-based HTTP server that wraps a DocSpec conversion pipeline. Designed for embedding in custom binaries or running via the unified `docspec http` subcommand.
+**An Axum HTTP server that wraps a DocSpec conversion pipeline.**
+
+Send a document, receive a converted one. `docspec-http` is an Axum-based library that wraps the full DocSpec conversion pipeline behind a small HTTP surface — designed for embedding in custom binaries or running via the unified `docspec http` subcommand. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
 Send markdown (`Content-Type: text/markdown`), HTML (`Content-Type: text/html`), or DOCX (`Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document`), receive BlockNote JSON (default), HTML (`Accept: text/html`), oxa.dev JSON (`Accept: application/vnd.oxa+json`), or Pandoc native (`Accept: application/vnd.pandoc.native`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
 
-> **HTML is paragraph-only.** The HTML reader currently parses `<p>` elements only, and the HTML writer currently emits only paragraph events. Other HTML input elements and non-paragraph output events (headings, lists, tables, formatting, etc.) are silently dropped. See [docspec-html-reader](../docspec-html-reader/README.md) and [docspec-html-writer](../docspec-html-writer/README.md).
+> **HTML is paragraph-only.** The HTML reader currently parses `<p>` elements only, and the HTML writer currently emits only paragraph events. Other HTML input elements and non-paragraph output events (headings, lists, tables, formatting, etc.) are silently dropped. See [docspec-html-reader](https://docs.rs/docspec-html-reader) and [docspec-html-writer](https://docs.rs/docspec-html-writer).
 
-## When to Use This Crate
+## When to use this crate
 
 Use `docspec-http` directly when you're embedding the HTTP server into your own binary or need programmatic control over server startup, configuration, or telemetry initialization.
 
 For end users who want a running HTTP server without writing Rust code, install `docspec-cli` and run `docspec http`.
 
-## Quick Start
+## Add it
 
 ```toml
 [dependencies]
-docspec-http = "1.5"
+docspec-http = "1"
 tokio = { version = "1", features = ["full"] }
 ```
 
@@ -376,3 +378,8 @@ sum by (input_mime_type) (rate(docspec_conversions_total{result="success"}[5m]))
 ### Security
 
 `/metrics` has no authentication. It's intended for internal scraping only. Deploy behind a private overlay network or a Kubernetes `NetworkPolicy` that restricts access to your Prometheus pods.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-http` on docs.rs](https://docs.rs/docspec-http)

--- a/crates/docspec-json/README.md
+++ b/crates/docspec-json/README.md
@@ -1,5 +1,55 @@
-# `docspec-json`
+# docspec-json
 
-JSON writing primitives for docspec writers.
+**A JSON emitter that can't emit invalid JSON.**
 
-This crate provides the JSON emission backend and emitter scaffolding for DocSpec writers.
+`docspec-json` is the toolkit the JSON-shaped DocSpec writers are built on. Its
+`JsonEmitter` drives a pluggable `JsonBackend` through valid JSON shapes only — write a
+key outside an object, or two values for one key, and you get an error before a single
+byte reaches the backend. The default `StrusonBackend` streams to any `io::Write`.
+Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
+
+Reach for this crate when you are building your own JSON writer; the
+[BlockNote](https://docs.rs/docspec-blocknote-writer) and [oxa.dev](https://docs.rs/docspec-oxa-writer) writers are
+built on it.
+
+## Add it
+
+```toml
+[dependencies]
+docspec-json = "1"
+```
+
+## Emit some JSON
+
+Wrap a writer in `StrusonBackend`, hand it to a `JsonEmitter`, and build the document with
+the fluent closure API — objects, arrays, keys, and scalars:
+
+```rust
+use docspec_json::{JsonEmitter, StrusonBackend};
+
+let mut emitter = JsonEmitter::new(StrusonBackend::new(Vec::new()));
+emitter.object(|doc| {
+    doc.key("type").value("heading")?;
+    doc.key("level").value(1u32)?;
+    doc.key("content").array(|c| c.value("Hello"))
+})?;
+let json: Vec<u8> = emitter.finish()?;
+
+assert_eq!(json, br#"{"type":"heading","level":1,"content":["Hello"]}"#);
+# Ok::<(), docspec_core::Error>(())
+```
+
+Prefer to open and close frames yourself? The streaming form — `open_object`,
+`close_object`, `open_array`, `close_array` — shares the same state machine.
+
+## What's inside
+
+- **`JsonEmitter`** — the fluent and streaming API, with stack-based shape validation.
+- **`JsonBackend`** — the trait a backend implements; swap in your own.
+- **`StrusonBackend`** — the default backend, streaming to any `io::Write` via `struson`.
+- **`WriteVal`** — the scalar values the emitter accepts (`&str`, `bool`, `u8`, `u32`, `Null`).
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-json` on docs.rs](https://docs.rs/docspec-json)

--- a/crates/docspec-markdown-reader/README.md
+++ b/crates/docspec-markdown-reader/README.md
@@ -1,81 +1,19 @@
 # docspec-markdown-reader
 
-Streaming Markdown to DocSpec event stream reader.
+**CommonMark and GFM, flowing out as events.**
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation,
-architecture, and the event protocol.
+Markdown arrives as text; a typed event stream leaves. `docspec-markdown-reader` parses CommonMark and GitHub Flavored Markdown and emits DocSpec events as it goes, including raw HTML tags embedded in the source. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-## Supported Elements
+## Add it
 
-- Headings (h1–h6)
-- Paragraphs
-- Block quotes
-- Code blocks (fenced and indented)
-- Bold (`StartTextStyle { kind: Bold }`), italic (`StartTextStyle { kind: Italic }`),
-  inline code (`StartTextStyle { kind: Code }`), strikethrough
-  (`StartTextStyle { kind: Strikethrough }`)
-- Images
-- Hard and soft line breaks
-- Thematic breaks
-- Tables (GFM)
-- Bullet and numbered lists (nested)
-- Links (inline, reference, autolink)
+```toml
+[dependencies]
+docspec-markdown-reader = "1"
+```
 
-## Supported Raw HTML Tags
+## Read some Markdown
 
-Raw HTML tags embedded in markdown source are translated into DocSpec events. All
-attributes on these tags are silently ignored. All other HTML tags are silently dropped.
-
-### Inline formatting
-
-| Tag(s) | DocSpec event |
-|---|---|
-| `<b>`, `<strong>` | `StartTextStyle { kind: Bold }` / `EndTextStyle` |
-| `<i>`, `<em>` | `StartTextStyle { kind: Italic }` / `EndTextStyle` |
-| `<u>` | `StartTextStyle { kind: Underline }` / `EndTextStyle` |
-| `<s>`, `<strike>`, `<del>` | `StartTextStyle { kind: Strikethrough }` / `EndTextStyle` |
-| `<code>` | `StartTextStyle { kind: Code }` / `EndTextStyle` |
-| `<sub>` | `StartTextStyle { kind: Subscript }` / `EndTextStyle` |
-| `<sup>` | `StartTextStyle { kind: Superscript }` / `EndTextStyle` |
-| `<mark>` | `StartTextStyle { kind: Mark }` with constant yellow `#FFFF00` |
-
-### Self-closing / void
-
-| Tag(s) | DocSpec event |
-|---|---|
-| `<br>`, `<br/>`, `<br />` | `Event::LineBreak` |
-| `<hr>` | `Event::ThematicBreak` (block context only; ignored in paragraph context) |
-
-### Block headings
-
-`<h1>` through `<h6>` inside an HTML block emit `StartHeading { level: N }` + content +
-`EndHeading`. Inline styles inside headings are fully supported.
-
-### Known limitations
-
-- `<pre><code>...</code></pre>` is NOT treated as a code block. The `<pre>` is dropped and
-  `<code>` becomes an inline style. Use markdown fenced code blocks instead.
-- HTML attributes (id, class, style, href, src, etc.) are NOT extracted.
-- Unclosed tags are auto-closed at the end of the containing block.
-
-## Out of Scope (silently dropped)
-
-- Definition lists and footnotes
-- Math blocks and inline math
-- Subscript and superscript formatting (use `<sub>` / `<sup>` raw HTML instead)
-- All HTML tags not listed in "Supported Raw HTML Tags" above
-
-## Memory Model
-
-`MarkdownReader` owns its source `String` for the parser's lifetime. Events still flow
-one at a time via `next_event()`, but the full source text stays in memory until the
-reader is dropped. This is a constraint of `pulldown-cmark`, which is permanently
-borrow-based by design.
-
-For true constant-memory streaming, use `docspec-html-reader`'s `HtmlReader`, which
-reads through a 16 KB sliding-window buffer regardless of document size.
-
-## Quick Start
+`MarkdownReader` is an `EventSource`: call `next_event()` and events arrive one at a time. From a string:
 
 ```rust
 use docspec_markdown_reader::{MarkdownReader, EventSource};
@@ -101,8 +39,55 @@ while let Some(event) = reader.next_event()? {
 # Ok::<(), docspec_core::Error>(())
 ```
 
-## See Also
+## What it handles today
 
-- [MANIFESTO.md](../../MANIFESTO.md) — philosophy and values
-- [ARCHITECTURE.md](../../ARCHITECTURE.md) — pipeline design, event model decisions, and pointers to the in-code event reference
-- [`docspec_core` on docs.rs](https://docs.rs/docspec-core) — every event variant, field, and well-formedness rule
+We emit events for a broad slice of CommonMark and GFM:
+
+- Headings (h1–h6)
+- Paragraphs
+- Block quotes
+- Code blocks (fenced and indented)
+- Bold (`StartTextStyle { kind: Bold }`), italic (`StartTextStyle { kind: Italic }`), inline code (`StartTextStyle { kind: Code }`), strikethrough (`StartTextStyle { kind: Strikethrough }`)
+- Images
+- Hard and soft line breaks
+- Thematic breaks
+- Tables (GFM)
+- Bullet and numbered lists, nested
+- Links (inline, reference, autolink)
+
+Raw HTML tags embedded in Markdown source are translated into DocSpec events. All attributes on these tags are silently ignored. All other HTML tags are silently dropped.
+
+**Inline formatting**
+
+| Tag(s) | DocSpec event |
+|---|---|
+| `<b>`, `<strong>` | `StartTextStyle { kind: Bold }` / `EndTextStyle` |
+| `<i>`, `<em>` | `StartTextStyle { kind: Italic }` / `EndTextStyle` |
+| `<u>` | `StartTextStyle { kind: Underline }` / `EndTextStyle` |
+| `<s>`, `<strike>`, `<del>` | `StartTextStyle { kind: Strikethrough }` / `EndTextStyle` |
+| `<code>` | `StartTextStyle { kind: Code }` / `EndTextStyle` |
+| `<sub>` | `StartTextStyle { kind: Subscript }` / `EndTextStyle` |
+| `<sup>` | `StartTextStyle { kind: Superscript }` / `EndTextStyle` |
+| `<mark>` | `StartTextStyle { kind: Mark }` with constant yellow `#FFFF00` |
+
+**Self-closing / void**
+
+| Tag(s) | DocSpec event |
+|---|---|
+| `<br>`, `<br/>`, `<br />` | `Event::LineBreak` |
+| `<hr>` | `Event::ThematicBreak` (block context only; ignored in paragraph context) |
+
+**Block headings**
+
+`<h1>` through `<h6>` inside an HTML block emit `StartHeading { level: N }` + content + `EndHeading`. Inline styles inside headings are fully supported.
+
+The following are not supported and are silently dropped: definition lists, footnotes, math blocks, inline math, subscript and superscript formatting (use `<sub>` / `<sup>` raw HTML instead), and all HTML tags not listed above.
+
+Three raw-HTML limitations to know: `<pre><code>...</code></pre>` is not treated as a code block — `<pre>` is dropped and `<code>` becomes an inline style, so use fenced code blocks instead. HTML attributes (`id`, `class`, `style`, `href`, `src`, etc.) are not extracted. Unclosed tags are auto-closed at the end of the containing block.
+
+**A note on memory.** `MarkdownReader` owns its source `String` for the parser's lifetime. Events still flow one at a time via `next_event()`, but the full source text stays in memory until the reader is dropped — a constraint of `pulldown-cmark`, which is permanently borrow-based by design. For true constant-memory streaming, use `docspec-html-reader`'s `HtmlReader`, which reads through a 16 KB sliding-window buffer regardless of document size.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-markdown-reader` on docs.rs](https://docs.rs/docspec-markdown-reader)

--- a/crates/docspec-markdown-writer/README.md
+++ b/crates/docspec-markdown-writer/README.md
@@ -1,30 +1,19 @@
-# `docspec-markdown-writer`
+# docspec-markdown-writer
 
-Streaming Markdown (CommonMark) writer for DocSpec events — paragraphs and headings only.
+**Paragraphs and headings, written as CommonMark.**
 
-Converts a DocSpec event stream into CommonMark-compliant Markdown output. Implements the `EventSink` trait and emits output directly to any `Write` target as events arrive — no intermediate document representation, constant memory regardless of file size.
+Events arrive; Markdown leaves. `docspec-markdown-writer` turns a DocSpec event stream into CommonMark-compliant Markdown, writing directly to any `Write` target as each event passes through. Nothing accumulates. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-## Supported Events
+## Add it
 
-| DocSpec Event | Markdown output |
-| --- | --- |
-| `StartDocument` / `EndDocument` | (no output — Markdown has no document framing) |
-| `StartParagraph` / `EndParagraph` | paragraph text + `\n\n` (empty paragraphs produce zero bytes) |
-| `StartHeading { level, id }` / `EndHeading` | ATX heading `# ` ... `###### ` + `\n\n` (level clamped to 1–6; `id` dropped) |
-| `Text` | CommonMark-escaped text |
+```toml
+[dependencies]
+docspec-markdown-writer = "1"
+```
 
-## Not Supported
+## Write some Markdown
 
-The following DocSpec events are silently ignored:
-
-- Text styles — `StartTextStyle` / `EndTextStyle`
-- Line breaks — `LineBreak`, `SoftBreak`
-- Thematic breaks — `ThematicBreak`
-- Block quotes, lists, tables, links, images, footnotes, definition lists, captions, preformatted blocks
-- Heading IDs (`{#id}` syntax not emitted)
-- Inline formatting markers (`**bold**`, `*italic*`, `` `code` ``, `~~strike~~`)
-
-## Usage
+`MarkdownWriter` is an `EventSink`: hand it events and it writes CommonMark as they arrive. We escape text as it passes and close each paragraph with a double newline:
 
 ```rust
 use docspec_markdown_writer::MarkdownWriter;
@@ -47,14 +36,20 @@ assert_eq!(output, "Hello, world\n\n");
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-## Limitations
+## What it handles today
 
-- **ATX headings only**: no setext `===` / `---` underlines.
-- **No inline style markers**: bold, italic, code, and strikethrough are not emitted.
-- **No GFM extensions**: tables, task lists, and footnotes are not supported.
-- **LF line endings only**: no CRLF, no BOM, no trailing spaces.
-- **Heading IDs dropped silently**: `{#id}` syntax is never emitted.
+| DocSpec event | Markdown output |
+| --- | --- |
+| `StartDocument` / `EndDocument` | (no output — Markdown has no document framing) |
+| `StartParagraph` / `EndParagraph` | paragraph text + `\n\n` (empty paragraphs produce zero bytes) |
+| `StartHeading { level, id }` / `EndHeading` | ATX heading — prefixes from `#` through `######`, each followed by a space, then the heading text and `\n\n` (level clamped to 1–6; `id` dropped) |
+| `Text` | CommonMark-escaped text |
 
-## License
+Everything else is silently ignored: text styles (`StartTextStyle` / `EndTextStyle`), line breaks (`LineBreak`, `SoftBreak`), thematic breaks, block quotes, lists, tables, links, images, footnotes, definition lists, captions, and preformatted blocks. Heading IDs are dropped — we never emit `{#id}` syntax. Inline formatting markers (`**bold**`, `*italic*`, `` `code` ``, `~~strike~~`) are not emitted either.
 
-See the [repository LICENSE](../../LICENSE).
+A few more hard edges: ATX headings only, no setext `===` / `---` underlines. LF line endings only — no CRLF, no BOM, no trailing spaces. No GFM extensions: tables, task lists, and footnotes are not supported.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-markdown-writer` on docs.rs](https://docs.rs/docspec-markdown-writer)

--- a/crates/docspec-oxa-writer/README.md
+++ b/crates/docspec-oxa-writer/README.md
@@ -1,31 +1,21 @@
-# `docspec-oxa-writer`
+# docspec-oxa-writer
 
-Converts a DocSpec event stream into [oxa.dev](https://oxa.dev/) JSON. Implements the `EventSink` trait and emits JSON tokens directly to any `Write` target as events arrive — no intermediate document representation, constant memory regardless of file size.
+**Paragraphs into oxa.dev JSON, token by token.**
 
-## Supported Features
+Events arrive; oxa.dev JSON leaves. `docspec-oxa-writer` turns a DocSpec event stream into the [oxa.dev](https://oxa.dev/) JSON format, writing tokens directly to any `Write` target as each event passes through. Nothing accumulates. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-| Block type | oxa.dev type |
-| --- | --- |
-| Paragraph | `Paragraph` |
-| Text | `Text` |
+Built on [`docspec-json`](https://docs.rs/docspec-json), which guarantees the output is structurally valid JSON before a single byte reaches the backend.
 
-## Not Supported
+## Add it
 
-The following DocSpec events are not yet supported and will be silently ignored:
+```toml
+[dependencies]
+docspec-oxa-writer = "1"
+```
 
-- Headings — `StartHeading` / `EndHeading`
-- Block quotes — `StartBlockQuote` / `EndBlockQuote`
-- Preformatted / code blocks — `StartPreformatted` / `EndPreformatted`
-- Images — `Image`
-- Tables — `StartTable` / `EndTable` and related events
-- Thematic breaks — `ThematicBreak`
-- List items — `StartOrderedListItem` / `StartUnorderedListItem` and related events
-- Inline links — `StartLink` / `EndLink`
-- Footnotes — `StartFootnote` / `EndFootnote` / `FootnoteRef`
-- Definition lists — `StartDefinitionList` / `StartDefinitionTerm` / `StartDefinitionDetail`
-- Captions — `StartCaption` / `EndCaption`
+## Emit some oxa.dev JSON
 
-## Usage
+`OxaWriter` is an `EventSink`: hand it events and it writes oxa.dev JSON as they arrive. We open a `Document` object, emit a `Paragraph` for each paragraph, and nest `Text` nodes inside:
 
 ```rust
 use docspec_oxa_writer::OxaWriter;
@@ -38,7 +28,6 @@ writer.handle_event(Event::StartDocument { id: None, language: None, metadata: N
 writer.handle_event(Event::StartParagraph { alignment: None, id: None })?;
 writer.handle_event(Event::Text {
     content: "Hello, world".to_string(),
-    style: Default::default(),
 })?;
 writer.handle_event(Event::EndParagraph)?;
 writer.handle_event(Event::EndDocument)?;
@@ -48,10 +37,17 @@ let json = String::from_utf8(buf)?;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-## Limitations
+The output for that sequence is:
 
-This is a minimal scaffold. Full implementation will follow in subsequent tasks.
+```json
+{"type":"Document","children":[{"type":"Paragraph","children":[{"type":"Text","value":"Hello, world"}]}]}
+```
 
-## License
+## What it handles today
 
-See the [repository LICENSE](../../LICENSE).
+Paragraphs and the text inside them. `Text` style information is dropped — we emit the content string only. Everything else is silently ignored: headings, block quotes, preformatted blocks, images, tables, thematic breaks, lists, links, footnotes, definition lists, and captions. No half-formed JSON, no silent guesses.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-oxa-writer` on docs.rs](https://docs.rs/docspec-oxa-writer)

--- a/crates/docspec-pandoc-native-writer/README.md
+++ b/crates/docspec-pandoc-native-writer/README.md
@@ -1,44 +1,19 @@
-# `docspec-pandoc-native-writer`
+# docspec-pandoc-native-writer
 
-Streaming [Pandoc native](https://pandoc.org/MANUAL.html#native-pandoc) (block-list) writer for DocSpec events.
+**Pandoc's native block-list syntax, written as events flow.**
 
-Converts a DocSpec event stream into compact Pandoc native block-list syntax, suitable for being read by Pandoc's `-f native` reader. Implements the `EventSink` trait and emits output directly to any `Write` target as events arrive — no intermediate document representation, constant memory regardless of file size.
+Events arrive; Pandoc native leaves. `docspec-pandoc-native-writer` turns a DocSpec event stream into compact Pandoc native block-list syntax, suitable for Pandoc's `-f native` reader, writing directly to any `Write` target as each event passes through. Nothing accumulates. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-## Supported Events
+## Add it
 
-| DocSpec Event | Pandoc native output |
-| --- | --- |
-| `StartDocument` / `EndDocument` | `[` / `]` (block list framing) |
-| `StartParagraph` / `EndParagraph` | `Para [` / `]` |
-| `StartHeading { level, id }` / `EndHeading` | `Header N ("id",[],[]) [` / `]` (level passed through raw; classes and key-value attrs always empty) |
-| `Text` | `Str "..."` |
-| `ThematicBreak` (id dropped) | `HorizontalRule` |
-| `LineBreak` | `LineBreak` |
-| `SoftBreak` | `SoftBreak` |
-| `StartTextStyle { kind: Bold }` / `EndTextStyle` | `Strong [` / `]` |
-| `StartTextStyle { kind: Italic }` / `EndTextStyle` | `Emph [` / `]` |
-| `StartTextStyle { kind: Strikethrough }` / `EndTextStyle` | `Strikeout [` / `]` |
-| `StartTextStyle { kind: Underline }` / `EndTextStyle` | `Underline [` / `]` |
-| `StartTextStyle { kind: Subscript }` / `EndTextStyle` | `Subscript [` / `]` |
-| `StartTextStyle { kind: Superscript }` / `EndTextStyle` | `Superscript [` / `]` |
-| `StartTextStyle { kind: Code, id }` / `EndTextStyle` | `Code ("id",[],[]) "..."` (Text payload buffered between Start and End) |
-| `StartPreformatted { id, syntax }` / `EndPreformatted` | `CodeBlock ("id",["syntax"],[]) "..."` (Text payload buffered; literal newlines preserved) |
+```toml
+[dependencies]
+docspec-pandoc-native-writer = "1"
+```
 
-## Not Supported
+## Emit Pandoc native
 
-The following DocSpec events are silently ignored:
-
-- Block quotes — `StartBlockQuote` / `EndBlockQuote`
-- Images — `Image`
-- Tables — `StartTable` / `EndTable` and related events
-- List items — `StartOrderedListItem` / `StartUnorderedListItem` and related events
-- Inline links — `StartLink` / `EndLink`
-- Footnotes — `StartFootnote` / `EndFootnote` / `FootnoteRef`
-- Definition lists — `StartDefinitionList` / `StartDefinitionTerm` / `StartDefinitionDetail`
-- Captions — `StartCaption` / `EndCaption`
-- Text formatting styles — `StartTextStyle { kind: Mark | TextColor }` are accepted but silently flattened (text inside is preserved without a wrapper)
-
-## Usage
+`PandocNativeWriter` is an `EventSink`: hand it events and it writes Pandoc native syntax as they arrive. We open the block list with `[`, emit a `Para` for each paragraph, and close with `]`:
 
 ```rust
 use docspec_pandoc_native_writer::PandocNativeWriter;
@@ -61,13 +36,31 @@ let output = String::from_utf8(buf)?;
 # Ok::<(), Box<dyn std::error::Error>>(())
 ```
 
-## Limitations
+## What it handles today
 
-- **Compact output only**: no pretty-printing, no indentation.
-- **No metadata wrapper**: emits block-list form `[Para [...]]`, not `Pandoc (Meta ...) [...]`.
-- **No `Space` inlines**: adjacent `Text` events produce adjacent `Str` constructors with no auto-inserted `Space`.
-- **Targets pandoc-types >= 1.23**: uses `Str Text` (not `Str String`).
+| DocSpec event | Pandoc native output |
+| --- | --- |
+| `StartDocument` / `EndDocument` | `[` / `]` (block list framing) |
+| `StartParagraph` / `EndParagraph` | `Para [` / `]` |
+| `StartHeading { level, id }` / `EndHeading` | `Header N ("id",[],[]) [` / `]` (level passed through raw; classes and key-value attrs always empty) |
+| `Text` | `Str "..."` |
+| `ThematicBreak` (id dropped) | `HorizontalRule` |
+| `LineBreak` | `LineBreak` |
+| `SoftBreak` | `SoftBreak` |
+| `StartTextStyle { kind: Bold }` / `EndTextStyle` | `Strong [` / `]` |
+| `StartTextStyle { kind: Italic }` / `EndTextStyle` | `Emph [` / `]` |
+| `StartTextStyle { kind: Strikethrough }` / `EndTextStyle` | `Strikeout [` / `]` |
+| `StartTextStyle { kind: Underline }` / `EndTextStyle` | `Underline [` / `]` |
+| `StartTextStyle { kind: Subscript }` / `EndTextStyle` | `Subscript [` / `]` |
+| `StartTextStyle { kind: Superscript }` / `EndTextStyle` | `Superscript [` / `]` |
+| `StartTextStyle { kind: Code, id }` / `EndTextStyle` | `Code ("id",[],[]) "..."` (Text payload buffered between Start and End) |
+| `StartPreformatted { id, syntax }` / `EndPreformatted` | `CodeBlock ("id",["syntax"],[]) "..."` (Text payload buffered; literal newlines preserved) |
 
-## License
+The following are silently ignored: block quotes, images, tables, lists, links, footnotes, definition lists, and captions. `StartTextStyle { kind: Mark | TextColor }` are accepted but silently flattened — the text inside is preserved without a wrapper.
 
-See the [repository LICENSE](../../LICENSE).
+Four hard edges: compact output only, no pretty-printing or indentation. No metadata wrapper — we emit block-list form `[Para [...]]`, not `Pandoc (Meta ...) [...]`. No `Space` inlines — adjacent `Text` events produce adjacent `Str` constructors with no auto-inserted `Space`. We target pandoc-types >= 1.23, which uses `Str Text` rather than `Str String`.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec-pandoc-native-writer` on docs.rs](https://docs.rs/docspec-pandoc-native-writer)

--- a/crates/docspec-wasm/README.md
+++ b/crates/docspec-wasm/README.md
@@ -1,5 +1,39 @@
-# `docspec-wasm`
+# docspec-wasm
 
-WebAssembly bindings for the DocSpec document conversion library.
+**DocSpec in the browser, still streaming.**
 
-See the [main DocSpec repository](https://github.com/docspec/docspec) for documentation.
+WebAssembly bindings for DocSpec, built with `wasm-bindgen`. Today they expose one entry
+point — Markdown to BlockNote JSON — so a browser can run the same streaming conversion
+the native crates do, with no server round-trip. Streaming, like the rest of DocSpec.
+(See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
+
+This crate is not published to crates.io; you build it from the workspace.
+
+## Build it
+
+```sh
+wasm-pack build crates/docspec-wasm --target web
+```
+
+## Use it
+
+Import the generated package and call the converter. It returns the BlockNote JSON string,
+or throws a JavaScript error if the Markdown can't be parsed or serialized:
+
+```js
+import init, { convert_markdown_to_blocknote } from "./pkg/docspec_wasm.js";
+
+await init();
+const blocknote = convert_markdown_to_blocknote("# Hello\n\nWorld");
+```
+
+## What it handles today
+
+One conversion: Markdown (CommonMark + GFM) to BlockNote JSON. Every other format pair
+runs in the native crates and the [HTTP server](https://docs.rs/docspec-http) — they are not yet
+exposed through the WebAssembly surface.
+
+## Related
+
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec`](https://docs.rs/docspec) — the native facade these bindings wrap

--- a/crates/docspec/README.md
+++ b/crates/docspec/README.md
@@ -1,20 +1,30 @@
-# `docspec`
+# docspec
 
-Streaming document conversion. Convenience facade re-exporting the DocSpec readers,
-writers, and core event types.
+**One import, every reader and writer.**
 
-Use this crate when you want a single entry point. For the smallest possible dependency
-footprint, depend directly on the individual sub-crates (`docspec-core`,
-`docspec-markdown-reader`, etc.) instead.
+`docspec` is the convenience facade over the DocSpec workspace. It re-exports the core
+event types and traits, and — behind feature flags — the format readers and writers you
+opt into. Reach for it when you want a single entry point; drop to the individual crates
+(`docspec-core`, `docspec-markdown-reader`, …) when you want the smallest possible
+dependency footprint. Streaming, like the rest of DocSpec. (See the [Manifesto](https://github.com/docspec/docspec/blob/main/MANIFESTO.md) for why.)
 
-## Usage
+## Add it
+
+Pick the formats you need through features:
 
 ```toml
 [dependencies]
-docspec = { version = "1.5", features = ["markdown", "blocknote"] }
+docspec = { version = "1", features = ["markdown", "blocknote"] }
 ```
 
-```rust
+Default features are `markdown`, `blocknote`, and `pandoc-native`; disable them when you
+want to opt in explicitly.
+
+## Convert a document
+
+Wire a reader to a writer and let the events flow — here, Markdown into BlockNote JSON:
+
+```rust,no_run
 use docspec::readers::MarkdownReader;
 use docspec::writers::BlockNoteWriter;
 use docspec::{EventSink, EventSource, StackTrackingSink};
@@ -28,46 +38,35 @@ while let Some(event) = reader.next_event()? {
     writer.handle_event(event)?;
 }
 writer.finish()?;
+# Ok::<(), docspec_core::Error>(())
 ```
 
-## Feature Flags
+Opening a file by format instead? `AnyReader::from_path(InputFormat::Docx, "document.docx")`
+picks the right reader for you.
+
+## Feature flags
 
 ### Readers
 
-| Feature    | Format                                           | Crate                     |
-| ---------- | ------------------------------------------------ | ------------------------- |
-| `markdown` | Markdown (CommonMark + GFM tables/strikethrough) | `docspec-markdown-reader` |
-| `html`     | HTML (paragraphs only)                           | `docspec-html-reader`     |
-| `docx`     | DOCX (paragraphs, tables, lists, hyperlinks, embedded images, run styles, color/highlight) | `docspec-docx-reader`   |
+| Feature    | Format                                                                                      | Crate                     |
+| ---------- | ------------------------------------------------------------------------------------------- | ------------------------- |
+| `markdown` | Markdown (CommonMark + GFM tables/strikethrough)                                            | `docspec-markdown-reader` |
+| `html`     | HTML (paragraphs only)                                                                       | `docspec-html-reader`     |
+| `docx`     | DOCX (paragraphs, headings, tables, lists, hyperlinks, images, run styles, color/highlight) | `docspec-docx-reader`     |
 
-`DocxReader` covers paragraphs, line breaks, tabs, tables, ordered/unordered lists,
-hyperlinks, embedded images (streamed via `AssetHandle`), and run styles (bold, italic,
-underline, strikethrough, sub/superscript) with text color, highlight, and shading.
-See [`docspec-docx-reader`](https://docs.rs/docspec-docx-reader) for the authoritative
-list of supported and out-of-scope OOXML elements.
-
-`DocxReader` is dispatched through `AnyReader::from_reader` and `AnyReader::from_path`.
-Use `AnyReader::from_path(InputFormat::Docx, path)` to open a DOCX file, or
-`AnyReader::from_reader(InputFormat::Docx, cursor)` to read from an in-memory buffer.
-
-```rust
-use docspec::{AnyReader, InputFormat};
-
-# fn main() -> docspec::Result<()> {
-let reader = AnyReader::from_path(InputFormat::Docx, "document.docx")?;
-# Ok(())
-# }
-```
+`DocxReader` is dispatched through `AnyReader::from_reader` and `AnyReader::from_path`. See
+[`docspec-docx-reader`](https://docs.rs/docspec-docx-reader) for the authoritative list of supported and
+out-of-scope OOXML elements.
 
 ### Writers
 
-| Feature            | Format                 | Crate                      |
-| ------------------ | ---------------------- | -------------------------- |
-| `blocknote-writer` | BlockNote JSON         | `docspec-blocknote-writer` |
-| `oxa-writer`       | oxa.dev JSON           | `docspec-oxa-writer`       |
-| `html-writer`      | HTML (paragraphs only) | `docspec-html-writer`      |
-| `pandoc-native-writer` | Pandoc native block list | `docspec-pandoc-native-writer` |
-| `markdown-writer` | Markdown (paragraphs and headings only) | `docspec-markdown-writer` |
+| Feature                | Format                                  | Crate                          |
+| ---------------------- | --------------------------------------- | ------------------------------ |
+| `blocknote-writer`     | BlockNote JSON                          | `docspec-blocknote-writer`     |
+| `oxa-writer`           | oxa.dev JSON                            | `docspec-oxa-writer`           |
+| `html-writer`          | HTML (paragraphs only)                  | `docspec-html-writer`          |
+| `pandoc-native-writer` | Pandoc native block list                | `docspec-pandoc-native-writer` |
+| `markdown-writer`      | Markdown (paragraphs and headings only) | `docspec-markdown-writer`      |
 
 ### Primitives
 
@@ -77,21 +76,20 @@ let reader = AnyReader::from_path(InputFormat::Docx, "document.docx")?;
 
 ### Convenience
 
-| Feature       | Enables                                                       |
-| ------------- | ------------------------------------------------------------- |
-| `blocknote`   | BlockNote in both directions (writer only until reader lands) |
-| `oxa`         | oxa.dev in both directions (writer only until reader lands)   |
-| `pandoc-native` | Pandoc native in both directions (writer only until reader lands) |
-| `all-readers` | All reader features                                           |
-| `all-writers` | All writer features                                           |
-| `all-libs`    | All primitive/library features (currently `json`)             |
-| `full`        | Everything (`all-readers` + `all-writers` + `all-libs`)       |
+| Feature         | Enables                                            |
+| --------------- | -------------------------------------------------- |
+| `blocknote`     | BlockNote (writer only until the reader lands)     |
+| `oxa`           | oxa.dev (writer only until the reader lands)       |
+| `pandoc-native` | Pandoc native (writer only until the reader lands) |
+| `all-readers`   | Every reader feature                               |
+| `all-writers`   | Every writer feature                               |
+| `all-libs`      | Every primitive feature (currently `json`)         |
+| `full`          | Everything                                         |
 
-There is no `markdown` convenience feature for the writer. The name `markdown` is already taken by the reader feature, so `markdown-writer` must be enabled explicitly — there is no shorthand that enables both directions at once.
+There is no `markdown` convenience feature for the writer — `markdown` is already the
+reader feature, so enable `markdown-writer` explicitly.
 
-Default features are `markdown`, `blocknote`, and `pandoc-native`; disable default features when you need the smallest possible dependency footprint.
+## Related
 
-## Documentation
-
-See the [main DocSpec repository](https://github.com/docspec/docspec) for the full
-project documentation, architecture, and event protocol.
+- [Architecture](https://github.com/docspec/docspec/blob/main/ARCHITECTURE.md) — the streaming pipeline and event model
+- [`docspec` on docs.rs](https://docs.rs/docspec) — the full API and feature reference

--- a/crates/docspec/src/format.rs
+++ b/crates/docspec/src/format.rs
@@ -15,7 +15,8 @@ pub enum InputFormat {
     /// Markdown (`CommonMark` + GFM). Available when the `markdown` feature is enabled.
     #[cfg(feature = "markdown")]
     Markdown,
-    /// DOCX format (paragraphs and text only). Available when the `docx` feature is enabled.
+    /// DOCX format (paragraphs, headings, tables, lists, hyperlinks, images, and run styles).
+    /// Available when the `docx` feature is enabled.
     #[cfg(feature = "docx")]
     Docx,
 }

--- a/crates/docspec/src/lib.rs
+++ b/crates/docspec/src/lib.rs
@@ -16,7 +16,7 @@
 //! |----------------|-----------------------------------------------------|-----------------------------|
 //! | `markdown`     | Markdown (`CommonMark` + GFM tables/strikethrough)  | [`readers::MarkdownReader`] |
 //! | `html`         | HTML (paragraphs only)                              | `readers::HtmlReader`       |
-//! | `docx`         | DOCX (paragraphs, text, color, highlight, shading)  | `readers::DocxReader`       |
+//! | `docx`         | DOCX (paragraphs, headings, tables, lists, hyperlinks, images, run styles)  | `readers::DocxReader`       |
 //!
 //! [`readers::DocxReader`] is dispatched through [`AnyReader::from_reader`] and
 //! [`AnyReader::from_path`]. Use `AnyReader::from_path(InputFormat::Docx, path)` to
@@ -119,10 +119,14 @@ pub mod readers {
 
     /// Streaming DOCX reader. Available when the `docx` feature is enabled.
     /// Dispatched through [`crate::AnyReader::from_reader`] and
-    /// [`crate::AnyReader::from_path`]. Emits paragraphs, text, and inline
-    /// formatting including text color, highlight color, and run/text shading
-    /// (via `TextColor` and `Mark` events). Tables, lists, images,
-    /// headers/footers, metadata, and tracked changes are silently dropped.
+    /// [`crate::AnyReader::from_path`]. Emits paragraphs, headings, block quotes,
+    /// preformatted blocks, tables, ordered/unordered lists, hyperlinks, images
+    /// (`DrawingML` and VML, streamed via `AssetHandle`), and inline run styles —
+    /// bold, italic, underline, strikethrough, sub/superscript, plus text color,
+    /// highlight, and shading. Comments, footnotes, headers/footers, document
+    /// metadata, and tracked deletions are silently dropped; see
+    /// [`docspec-docx-reader`](https://docs.rs/docspec-docx-reader) for the
+    /// authoritative supported and out-of-scope list.
     #[cfg(feature = "docx")]
     #[cfg_attr(docsrs, doc(cfg(feature = "docx")))]
     pub use docspec_docx_reader::DocxReader;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked the main README and crate guides to emphasize constant-memory streaming conversion and example-first CLI/HTTP/API usage (including `/health`).
  * Expanded the “What it reads and writes” overview with clearer reader/writer support tables and updated DOCX capability descriptions.
  * Updated contribution, testing, security, and release guidance, adding new local build/run instructions and a maintainer triage runbook with actionable bug-report checklists and severity routing rules.
  * Standardized documentation navigation with consistent “Related” links and refreshed architecture/philosophy and licensing/attribution wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->