### PR TITLE
chore: fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,8 +113,14 @@ shadow_reuse = "allow"
 # Reason: Too noisy; numeric types clear from context
 default_numeric_fallback = "allow"
 # Reason: Targeting embedded — prefer core/alloc over std where possible
-std_instead_of_core = "warn"
+# std_instead_of_core is unactionable on stable for the std::io items we depend on
+# (Cursor is unstable in core::io; Read/Seek/Write/Take/Error/ErrorKind do not exist in core at all).
+# Keep alloc_instead_of_core enforced.
+std_instead_of_core = "allow"
 alloc_instead_of_core = "warn"
+# Reason: `#[cfg(test)] mod tests { ... }` is idiomatic Rust for co-locating unit tests
+# with their target module; splitting each into a separate file adds churn without value.
+inline_modules = "allow"
 # Reason: std crates should use std paths where clearer than alloc aliases
 std_instead_of_alloc = "allow"
 # Reason: Public docs enforced by missing_docs = "deny"; private doc requirement too noisy

--- a/crates/docspec-cli/src/commands/convert.rs
+++ b/crates/docspec-cli/src/commands/convert.rs
@@ -9,16 +9,18 @@ use crate::args::ConvertArgs;
 use crate::error::{CliError, Result};
 use crate::format;
 
-fn run_pipeline<W: Write>(
-    reader: AnyReader,
-    output_format: docspec::OutputFormat,
-    output: W,
-) -> Result<()> {
+fn run_pipeline<W>(reader: AnyReader, output_format: docspec::OutputFormat, output: W) -> Result<()>
+where
+    W: Write,
+{
     let sink = AnyWriter::new(output_format, output);
     docspec_core::pipe(docspec_core::SkipEmptyBlocks::new(reader), sink).map_err(Into::into)
 }
 
-fn write_cli_terminating_newline<W: Write>(output: &mut W) -> Result<()> {
+fn write_cli_terminating_newline<W>(output: &mut W) -> Result<()>
+where
+    W: Write,
+{
     output.write_all(b"\n").map_err(Into::into)
 }
 

--- a/crates/docspec-core/src/skip_empty_blocks.rs
+++ b/crates/docspec-core/src/skip_empty_blocks.rs
@@ -219,7 +219,10 @@ mod tests {
         }
     }
 
-    fn drain<S: EventSource>(mut src: S) -> alloc::vec::Vec<Event> {
+    fn drain<S>(mut src: S) -> alloc::vec::Vec<Event>
+    where
+        S: EventSource,
+    {
         let mut out = alloc::vec::Vec::new();
         while let Some(e) = src.next_event().expect("unexpected error") {
             out.push(e);
@@ -431,7 +434,11 @@ mod tests {
 
     #[test]
     fn send_sync_compile_assertion() {
-        fn assert_send_sync<T: Send + Sync>() {}
+        fn assert_send_sync<T>()
+        where
+            T: Send + Sync,
+        {
+        }
         assert_send_sync::<SkipEmptyBlocks<Replay>>();
     }
 

--- a/crates/docspec-core/tests/error.rs
+++ b/crates/docspec-core/tests/error.rs
@@ -7,7 +7,11 @@ mod tests {
 
     #[test]
     fn error_is_send_sync_static() {
-        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        fn assert_send_sync_static<T>()
+        where
+            T: Send + Sync + 'static,
+        {
+        }
         assert_send_sync_static::<Error>();
     }
 

--- a/crates/docspec-core/tests/traits.rs
+++ b/crates/docspec-core/tests/traits.rs
@@ -152,7 +152,11 @@ mod tests {
 
     #[test]
     fn asset_handle_is_dyn_compatible_send_sync() {
-        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        fn assert_send_sync_static<T>()
+        where
+            T: Send + Sync + 'static,
+        {
+        }
         assert_send_sync_static::<std::sync::Arc<dyn docspec_core::AssetHandle>>();
     }
 }

--- a/crates/docspec-docx-reader/src/asset_provider.rs
+++ b/crates/docspec-docx-reader/src/asset_provider.rs
@@ -73,7 +73,11 @@ mod tests {
 
     #[test]
     fn is_send_sync_static() {
-        fn assert_send_sync_static<T: Send + Sync + 'static>() {}
+        fn assert_send_sync_static<T>()
+        where
+            T: Send + Sync + 'static,
+        {
+        }
         assert_send_sync_static::<DocxAssetHandle>();
         assert_send_sync_static::<Arc<dyn AssetHandle>>();
     }

--- a/crates/docspec-docx-reader/src/content_types.rs
+++ b/crates/docspec-docx-reader/src/content_types.rs
@@ -108,11 +108,14 @@ impl ContentTypes {
     }
 }
 
-fn process_element<R: Read>(
+fn process_element<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
     ct: &mut ContentTypes,
-) -> docspec_core::Result<()> {
+) -> docspec_core::Result<()>
+where
+    R: Read,
+{
     match element.local_name().as_ref() {
         b"Default" => {
             let ext = attr_string(reader, element, b"Extension")?;
@@ -134,11 +137,14 @@ fn process_element<R: Read>(
     Ok(())
 }
 
-fn attr_string<R: Read>(
+fn attr_string<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
     name: &[u8],
-) -> docspec_core::Result<Option<String>> {
+) -> docspec_core::Result<Option<String>>
+where
+    R: Read,
+{
     for attribute_result in element.attributes() {
         let attribute = attribute_result
             .map_err(|err| parse_error(format!("malformed [Content_Types].xml: {err}")))?;

--- a/crates/docspec-docx-reader/src/document.rs
+++ b/crates/docspec-docx-reader/src/document.rs
@@ -1151,10 +1151,9 @@ impl DocumentReader {
 
         let href = if let Some(rid_val) = rid {
             self.hyperlink_map.get(&rid_val).cloned()?
-        } else if let Some(anchor_val) = anchor.filter(|a| !a.is_empty()) {
-            format!("#{anchor_val}")
         } else {
-            return None;
+            let anchor_val = anchor.filter(|a| !a.is_empty())?;
+            format!("#{anchor_val}")
         };
 
         let title = tooltip.and_then(|t| {

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -155,7 +155,10 @@ impl DocxReader {
     /// Returns [`docspec_core::Error::Io`] if the file cannot be opened. See [`from_reader`](Self::from_reader)
     /// for additional error conditions.
     #[inline]
-    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self> {
+    pub fn from_path<P>(path: P) -> Result<Self>
+    where
+        P: AsRef<Path>,
+    {
         let (style_list, numbering, hyperlink_map, image_map, content_types, archive, stream) =
             package::open_package_from_path(path.as_ref())?;
         let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
@@ -189,7 +192,10 @@ impl DocxReader {
     /// `_rels/.rels` is missing or malformed, or if the document target entry
     /// cannot be opened. Returns [`docspec_core::Error::Io`] for I/O failures.
     #[inline]
-    pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
+    pub fn from_reader<R>(reader: R) -> Result<Self>
+    where
+        R: Read + Seek + Send + 'static,
+    {
         let (style_list, numbering, hyperlink_map, image_map, content_types, archive, stream) =
             package::open_package(reader)?;
         let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
@@ -225,7 +231,11 @@ mod tests {
 
     #[test]
     fn docx_reader_is_send_static() {
-        fn assert_send_static<T: Send + 'static>() {}
+        fn assert_send_static<T>()
+        where
+            T: Send + 'static,
+        {
+        }
         assert_send_static::<DocxReader>();
     }
 

--- a/crates/docspec-docx-reader/src/numbering.rs
+++ b/crates/docspec-docx-reader/src/numbering.rs
@@ -144,7 +144,10 @@ impl fmt::Debug for MinimalNumbering {
 ///
 /// Returns an error for I/O failures and malformed XML structure.
 #[inline]
-pub fn parse_numbering<R: Read>(reader: R) -> docspec_core::Result<MinimalNumbering> {
+pub fn parse_numbering<R>(reader: R) -> docspec_core::Result<MinimalNumbering>
+where
+    R: Read,
+{
     let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
     let mut buf = Vec::new();
     let mut element_depth: usize = 0;
@@ -258,11 +261,14 @@ fn finish_level(
     *current_level_outcome = None;
 }
 
-fn attr_u32<R: Read>(
+fn attr_u32<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
     name: &[u8],
-) -> docspec_core::Result<Option<u32>> {
+) -> docspec_core::Result<Option<u32>>
+where
+    R: Read,
+{
     let Some(value) = attr_string(reader, element, name)? else {
         return Ok(None);
     };
@@ -270,11 +276,14 @@ fn attr_u32<R: Read>(
     Ok(value.parse::<u32>().ok())
 }
 
-fn attr_string<R: Read>(
+fn attr_string<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
     name: &[u8],
-) -> docspec_core::Result<Option<String>> {
+) -> docspec_core::Result<Option<String>>
+where
+    R: Read,
+{
     for attribute_result in element.attributes() {
         let attribute = attribute_result
             .map_err(|err| parse_error(format!("malformed numbering.xml attribute: {err}")))?;

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -33,7 +33,10 @@ type PackageContents = (
 /// relationships, locates `document.xml`, reads `[Content_Types].xml`, and returns
 /// a [`PackageContents`] tuple with all parsed data and a streaming reader for the
 /// main document part.
-pub fn open_package<R: Read + Seek + Send + 'static>(reader: R) -> Result<PackageContents> {
+pub fn open_package<R>(reader: R) -> Result<PackageContents>
+where
+    R: Read + Seek + Send + 'static,
+{
     let boxed: Box<dyn ReadSeek + 'static> = Box::new(reader);
     let mut archive = ZipArchive::new(boxed).map_err(map_zip_open_error)?;
 
@@ -110,7 +113,10 @@ fn map_zip_open_error(err: ZipError) -> Error {
     }
 }
 
-fn read_root_rels_bytes<R: Read + Seek>(archive: &mut ZipArchive<R>) -> Result<Vec<u8>> {
+fn read_root_rels_bytes<R>(archive: &mut ZipArchive<R>) -> Result<Vec<u8>>
+where
+    R: Read + Seek,
+{
     let mut rels_entry = archive.by_name("_rels/.rels").map_err(|err| {
         if matches!(err, ZipError::FileNotFound) {
             Error::Parse {
@@ -126,7 +132,7 @@ fn read_root_rels_bytes<R: Read + Seek>(archive: &mut ZipArchive<R>) -> Result<V
     Ok(bytes)
 }
 
-fn load_small_package_parts<R: Read + Seek>(
+fn load_small_package_parts<R>(
     archive: &mut ZipArchive<R>,
     document_path: &str,
 ) -> Result<(
@@ -135,7 +141,10 @@ fn load_small_package_parts<R: Read + Seek>(
     HyperlinkMap,
     ImageMap,
     ContentTypes,
-)> {
+)>
+where
+    R: Read + Seek,
+{
     let (style_list, hyperlink_map, image_map) =
         load_style_list_and_hyperlink_map(archive, document_path)?;
     let numbering = load_numbering(archive, document_path)?;
@@ -152,10 +161,13 @@ fn load_small_package_parts<R: Read + Seek>(
     ))
 }
 
-fn load_style_list_and_hyperlink_map<R: Read + Seek>(
+fn load_style_list_and_hyperlink_map<R>(
     archive: &mut ZipArchive<R>,
     document_path: &str,
-) -> Result<(StyleList, HyperlinkMap, ImageMap)> {
+) -> Result<(StyleList, HyperlinkMap, ImageMap)>
+where
+    R: Read + Seek,
+{
     let doc_rels_path = rels::derive_part_rels_path(document_path);
     let maybe_doc_rels_bytes = if doc_rels_path == "word/_rels/document.xml.rels" {
         match archive.by_name("word/_rels/document.xml.rels") {
@@ -203,10 +215,10 @@ fn load_style_list_and_hyperlink_map<R: Read + Seek>(
     Ok((style_list, hyperlink_map, image_map))
 }
 
-fn read_optional_entry<R: Read + Seek>(
-    archive: &mut ZipArchive<R>,
-    path: &str,
-) -> Result<Option<Vec<u8>>> {
+fn read_optional_entry<R>(archive: &mut ZipArchive<R>, path: &str) -> Result<Option<Vec<u8>>>
+where
+    R: Read + Seek,
+{
     match archive.by_name(path) {
         Ok(mut entry) => {
             let mut bytes = Vec::new();
@@ -218,10 +230,13 @@ fn read_optional_entry<R: Read + Seek>(
     }
 }
 
-fn load_numbering<R: Read + Seek>(
+fn load_numbering<R>(
     archive: &mut ZipArchive<R>,
     document_path: &str,
-) -> Result<crate::numbering::MinimalNumbering> {
+) -> Result<crate::numbering::MinimalNumbering>
+where
+    R: Read + Seek,
+{
     let doc_rels_path = rels::derive_part_rels_path(document_path);
     let doc_rels_bytes = match archive.by_name(&doc_rels_path) {
         Ok(mut entry) => {

--- a/crates/docspec-docx-reader/src/rels.rs
+++ b/crates/docspec-docx-reader/src/rels.rs
@@ -24,7 +24,10 @@ pub(crate) struct ImageRel {
 /// whose Type ends with "/image".
 pub(crate) type ImageMap = HashMap<String, ImageRel>;
 
-pub fn find_document_target<R: Read>(reader: R) -> docspec_core::Result<String> {
+pub fn find_document_target<R>(reader: R) -> docspec_core::Result<String>
+where
+    R: Read,
+{
     let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
     let mut buf = Vec::new();
     let mut element_depth: usize = 0;
@@ -75,7 +78,10 @@ pub fn find_document_target<R: Read>(reader: R) -> docspec_core::Result<String> 
 /// Returns `Ok(None)` if no `/styles` relationship is present (legal per ECMA-376 §11.3.12).
 /// Returns `Err` if the target contains a path-traversal (`..`) segment.
 /// Ignores relationships with `TargetMode="External"`.
-pub fn find_styles_target<R: Read>(reader: R) -> docspec_core::Result<Option<String>> {
+pub fn find_styles_target<R>(reader: R) -> docspec_core::Result<Option<String>>
+where
+    R: Read,
+{
     let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
     let mut buf = Vec::new();
     let mut element_depth: usize = 0;
@@ -118,7 +124,10 @@ pub fn find_styles_target<R: Read>(reader: R) -> docspec_core::Result<Option<Str
     }
 }
 
-pub(crate) fn collect_hyperlink_map<R: Read>(reader: R) -> Result<HyperlinkMap, Error> {
+pub(crate) fn collect_hyperlink_map<R>(reader: R) -> Result<HyperlinkMap, Error>
+where
+    R: Read,
+{
     let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
     let mut buf = Vec::new();
     let mut element_depth: usize = 0;
@@ -214,7 +223,10 @@ pub(crate) fn collect_image_map(rels_xml: &[u8], document_path: &str) -> Result<
 /// Returns `Ok(None)` if no `/numbering` relationship is present (legal per ECMA-376 §17.9).
 /// Returns `Err` if the target contains a path-traversal (`..`) segment.
 /// Ignores relationships with `TargetMode="External"`.
-pub fn find_numbering_target<R: Read>(reader: R) -> docspec_core::Result<Option<String>> {
+pub fn find_numbering_target<R>(reader: R) -> docspec_core::Result<Option<String>>
+where
+    R: Read,
+{
     let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
     let mut buf = Vec::new();
     let mut element_depth: usize = 0;
@@ -276,10 +288,13 @@ fn validate_document_path(document_path: &str) -> docspec_core::Result<String> {
     Ok(document_path.to_string())
 }
 
-fn office_document_target<R: Read>(
+fn office_document_target<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
-) -> docspec_core::Result<Option<String>> {
+) -> docspec_core::Result<Option<String>>
+where
+    R: Read,
+{
     let mut rel_type = None;
     let mut target = None;
 
@@ -311,10 +326,13 @@ fn office_document_target<R: Read>(
     })
 }
 
-fn styles_target<R: Read>(
+fn styles_target<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
-) -> docspec_core::Result<Option<String>> {
+) -> docspec_core::Result<Option<String>>
+where
+    R: Read,
+{
     let mut rel_type = None;
     let mut target = None;
     let mut target_mode = None;
@@ -353,10 +371,13 @@ fn styles_target<R: Read>(
     })
 }
 
-fn hyperlink_entry<R: Read>(
+fn hyperlink_entry<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
-) -> Result<Option<(String, String)>, Error> {
+) -> Result<Option<(String, String)>, Error>
+where
+    R: Read,
+{
     let mut id = None;
     let mut rel_type = None;
     let mut target = None;
@@ -392,11 +413,14 @@ fn hyperlink_entry<R: Read>(
     })
 }
 
-fn image_entry<R: Read>(
+fn image_entry<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
     document_path: &str,
-) -> Result<Option<(String, ImageRel)>, Error> {
+) -> Result<Option<(String, ImageRel)>, Error>
+where
+    R: Read,
+{
     let mut id = None;
     let mut rel_type = None;
     let mut target = None;
@@ -452,10 +476,13 @@ fn image_entry<R: Read>(
     }
 }
 
-fn numbering_target<R: Read>(
+fn numbering_target<R>(
     reader: &quick_xml::Reader<R>,
     element: &quick_xml::events::BytesStart<'_>,
-) -> docspec_core::Result<Option<String>> {
+) -> docspec_core::Result<Option<String>>
+where
+    R: Read,
+{
     let mut rel_type = None;
     let mut target = None;
     let mut target_mode = None;

--- a/crates/docspec-docx-reader/src/streaming_archive.rs
+++ b/crates/docspec-docx-reader/src/streaming_archive.rs
@@ -95,7 +95,11 @@ impl Read for StreamingArchive {
 const _: fn(&Path, &str) -> Result<StreamingArchive> = StreamingArchive::open;
 
 const _: fn() = || {
-    fn assert_send<T: Send + 'static>() {}
+    fn assert_send<T>()
+    where
+        T: Send + 'static,
+    {
+    }
     assert_send::<StreamingArchive>();
 };
 

--- a/crates/docspec-docx-reader/src/styles.rs
+++ b/crates/docspec-docx-reader/src/styles.rs
@@ -72,7 +72,10 @@ fn classify_name(name: &str, kind: StyleType) -> Option<StyleClassification> {
 }
 
 impl StyleList {
-    pub fn parse<R: Read>(reader: R) -> Result<Self> {
+    pub fn parse<R>(reader: R) -> Result<Self>
+    where
+        R: Read,
+    {
         let mut xml_reader = quick_xml::Reader::from_reader(std::io::BufReader::new(reader));
         let mut buf = Vec::new();
         let mut styles: Vec<Style> = Vec::new();
@@ -127,12 +130,15 @@ impl StyleList {
     }
 }
 
-fn parse_style_body<R: std::io::BufRead>(
+fn parse_style_body<R>(
     xml_reader: &mut quick_xml::Reader<R>,
     buf: &mut Vec<u8>,
     id: String,
     kind: StyleType,
-) -> Result<Style> {
+) -> Result<Style>
+where
+    R: std::io::BufRead,
+{
     let mut name: Option<String> = None;
     let mut based_on: Option<String> = None;
 

--- a/crates/docspec-html-reader/src/lib.rs
+++ b/crates/docspec-html-reader/src/lib.rs
@@ -112,7 +112,10 @@ impl HtmlReader {
     /// This constructor does not read from the source eagerly and therefore
     /// currently cannot fail.
     #[inline]
-    pub fn from_reader<R: Read + Seek + Send + 'static>(reader: R) -> Result<Self> {
+    pub fn from_reader<R>(reader: R) -> Result<Self>
+    where
+        R: Read + Seek + Send + 'static,
+    {
         let boxed: Box<dyn Read + Send> = Box::new(reader);
         Ok(Self::from_boxed_reader(boxed))
     }
@@ -247,7 +250,11 @@ impl EventSource for HtmlReader {
 
 #[cfg(test)]
 mod send_static_assertions {
-    fn assert_send_static<T: Send + 'static>() {}
+    fn assert_send_static<T>()
+    where
+        T: Send + 'static,
+    {
+    }
 
     #[test]
     fn html_reader_is_send_static() {

--- a/crates/docspec-json/src/backend.rs
+++ b/crates/docspec-json/src/backend.rs
@@ -343,7 +343,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let tokens = result.unwrap_or_default();
-        assert!(tokens == vec![Token::BeginObject, Token::EndObject]);
+        assert_eq!(tokens, vec![Token::BeginObject, Token::EndObject]);
     }
 
     #[test]

--- a/crates/docspec-json/src/emitter.rs
+++ b/crates/docspec-json/src/emitter.rs
@@ -155,7 +155,10 @@ impl<B: JsonBackend> JsonEmitter<B> {
     ///
     /// Returns `Err` if a value is not allowed here, or if the backend errors.
     #[inline]
-    pub fn value<V: WriteVal>(&mut self, v: V) -> Result<()> {
+    pub fn value<V>(&mut self, v: V) -> Result<()>
+    where
+        V: WriteVal,
+    {
         self.stack.expect_value_allowed()?;
         v.write_to(&mut self.backend)?;
         self.stack.mark_value_written()
@@ -253,7 +256,10 @@ impl<B: JsonBackend> KeyedEmitter<'_, B> {
     ///
     /// Returns `Err` if a key is not allowed here, or if the backend errors.
     #[inline]
-    pub fn value<V: WriteVal>(self, v: V) -> Result<()> {
+    pub fn value<V>(self, v: V) -> Result<()>
+    where
+        V: WriteVal,
+    {
         let emitter = self.emitter;
         let name = self.name;
         emitter.write_key(name)?;

--- a/crates/docspec-json/src/struson_backend.rs
+++ b/crates/docspec-json/src/struson_backend.rs
@@ -132,7 +132,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == b"[]");
+        assert_eq!(bytes, b"[]");
     }
 
     #[test]
@@ -147,7 +147,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == br#"[1,true,null,"x"]"#);
+        assert_eq!(bytes, br#"[1,true,null,"x"]"#);
     }
 
     #[test]
@@ -158,7 +158,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == b"{}");
+        assert_eq!(bytes, b"{}");
     }
 
     #[test]
@@ -177,7 +177,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == br#"{"a":[1,{"b":true}]}"#);
+        assert_eq!(bytes, br#"{"a":[1,{"b":true}]}"#);
     }
 
     #[test]
@@ -190,7 +190,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == br#"{"k":"v"}"#);
+        assert_eq!(bytes, br#"{"k":"v"}"#);
     }
 
     #[test]
@@ -200,7 +200,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == br#""hello""#);
+        assert_eq!(bytes, br#""hello""#);
     }
 
     #[test]
@@ -212,7 +212,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == br#""data:image/png;base64,iVBORw==""#);
+        assert_eq!(bytes, br#""data:image/png;base64,iVBORw==""#);
     }
 
     #[test]
@@ -224,7 +224,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == br#""\"quoted\"""#);
+        assert_eq!(bytes, br#""\"quoted\"""#);
     }
 
     #[test]
@@ -242,7 +242,7 @@ mod tests {
         let result = b.finish();
         assert!(result.is_ok());
         let bytes = result.unwrap_or_default();
-        assert!(bytes == br#""one-two-three""#);
+        assert_eq!(bytes, br#""one-two-three""#);
     }
 
     #[test]
@@ -265,7 +265,7 @@ mod tests {
         let finish_result = b.finish();
         assert!(finish_result.is_ok());
         let bytes = finish_result.unwrap_or_default();
-        assert!(bytes == br#"{"failed":"","after":"ok"}"#);
+        assert_eq!(bytes, br#"{"failed":"","after":"ok"}"#);
     }
 
     /// Tracks each write call to the inner writer.

--- a/crates/docspec-json/src/value.rs
+++ b/crates/docspec-json/src/value.rs
@@ -14,40 +14,57 @@ pub trait WriteVal {
     /// # Errors
     ///
     /// Returns any error produced while writing the value.
-    fn write_to<B: JsonBackend>(self, backend: &mut B) -> Result<()>;
+    fn write_to<B>(self, backend: &mut B) -> Result<()>
+    where
+        B: JsonBackend;
 }
 
 impl WriteVal for &str {
     #[inline]
-    fn write_to<B: JsonBackend>(self, backend: &mut B) -> Result<()> {
+    fn write_to<B>(self, backend: &mut B) -> Result<()>
+    where
+        B: JsonBackend,
+    {
         backend.write_string(self)
     }
 }
 
 impl WriteVal for bool {
     #[inline]
-    fn write_to<B: JsonBackend>(self, backend: &mut B) -> Result<()> {
+    fn write_to<B>(self, backend: &mut B) -> Result<()>
+    where
+        B: JsonBackend,
+    {
         backend.write_bool(self)
     }
 }
 
 impl WriteVal for u8 {
     #[inline]
-    fn write_to<B: JsonBackend>(self, backend: &mut B) -> Result<()> {
+    fn write_to<B>(self, backend: &mut B) -> Result<()>
+    where
+        B: JsonBackend,
+    {
         backend.write_number(u32::from(self))
     }
 }
 
 impl WriteVal for u32 {
     #[inline]
-    fn write_to<B: JsonBackend>(self, backend: &mut B) -> Result<()> {
+    fn write_to<B>(self, backend: &mut B) -> Result<()>
+    where
+        B: JsonBackend,
+    {
         backend.write_number(self)
     }
 }
 
 impl WriteVal for Null {
     #[inline]
-    fn write_to<B: JsonBackend>(self, backend: &mut B) -> Result<()> {
+    fn write_to<B>(self, backend: &mut B) -> Result<()>
+    where
+        B: JsonBackend,
+    {
         backend.write_null()
     }
 }

--- a/crates/docspec-markdown-reader/src/lib.rs
+++ b/crates/docspec-markdown-reader/src/lib.rs
@@ -387,7 +387,10 @@ impl MarkdownReader {
     ///
     /// Returns [`Error::Io`](docspec_core::Error::Io) if reading fails.
     #[inline]
-    pub fn from_reader<R: Read + Seek + Send + 'static>(mut reader: R) -> Result<Self> {
+    pub fn from_reader<R>(mut reader: R) -> Result<Self>
+    where
+        R: Read + Seek + Send + 'static,
+    {
         let mut source = String::new();
         reader.read_to_string(&mut source)?;
         Ok(Self::from_owned_string(source))
@@ -987,7 +990,11 @@ mod tests {
 
 #[cfg(test)]
 mod send_static_assertions {
-    fn assert_send_static<T: Send + 'static>() {}
+    fn assert_send_static<T>()
+    where
+        T: Send + 'static,
+    {
+    }
 
     #[test]
     fn markdown_reader_is_send_static() {

--- a/crates/docspec-markdown-writer/src/escape.rs
+++ b/crates/docspec-markdown-writer/src/escape.rs
@@ -11,7 +11,10 @@ const REPLACEMENT_CHARACTER: &[u8] = "\u{FFFD}".as_bytes();
 ///
 /// Normalizes NUL and line endings before escaping and streams output without
 /// accumulating the whole escaped text.
-pub(crate) fn write_escaped_inline<W: Write>(writer: &mut W, text: &str) -> io::Result<()> {
+pub(crate) fn write_escaped_inline<W>(writer: &mut W, text: &str) -> io::Result<()>
+where
+    W: Write,
+{
     let mut chars = text.chars().peekable();
     while let Some(ch) = next_normalized_char(&mut chars) {
         write_inline_char(writer, ch)?;
@@ -24,7 +27,10 @@ pub(crate) fn write_escaped_inline<W: Write>(writer: &mut W, text: &str) -> io::
 ///
 /// Normalizes NUL and line endings before escaping and streams output without
 /// accumulating the whole escaped text.
-pub(crate) fn write_escaped_block_start<W: Write>(writer: &mut W, text: &str) -> io::Result<()> {
+pub(crate) fn write_escaped_block_start<W>(writer: &mut W, text: &str) -> io::Result<()>
+where
+    W: Write,
+{
     let mut chars = text.chars().peekable();
     let Some(first) = next_normalized_char(&mut chars) else {
         return Ok(());
@@ -48,10 +54,13 @@ pub(crate) fn write_escaped_block_start<W: Write>(writer: &mut W, text: &str) ->
     Ok(())
 }
 
-fn write_ordered_list_marker_tail<W: Write>(
+fn write_ordered_list_marker_tail<W>(
     writer: &mut W,
     chars: &mut Peekable<Chars<'_>>,
-) -> io::Result<()> {
+) -> io::Result<()>
+where
+    W: Write,
+{
     let possible_marker = next_normalized_char(chars);
     let Some(marker @ ('.' | ')')) = possible_marker else {
         if let Some(ch) = possible_marker {
@@ -88,7 +97,10 @@ fn next_normalized_char(chars: &mut Peekable<Chars<'_>>) -> Option<char> {
     }
 }
 
-fn write_inline_char<W: Write>(writer: &mut W, ch: char) -> io::Result<()> {
+fn write_inline_char<W>(writer: &mut W, ch: char) -> io::Result<()>
+where
+    W: Write,
+{
     match ch {
         '\\' => writer.write_all(b"\\\\"),
         '`' => writer.write_all(b"\\`"),
@@ -104,7 +116,10 @@ fn write_inline_char<W: Write>(writer: &mut W, ch: char) -> io::Result<()> {
     }
 }
 
-fn write_raw_char<W: Write>(writer: &mut W, ch: char) -> io::Result<()> {
+fn write_raw_char<W>(writer: &mut W, ch: char) -> io::Result<()>
+where
+    W: Write,
+{
     let mut buf = [0; 4];
     writer.write_all(ch.encode_utf8(&mut buf).as_bytes())
 }

--- a/crates/docspec-markdown-writer/src/lib.rs
+++ b/crates/docspec-markdown-writer/src/lib.rs
@@ -79,7 +79,10 @@ impl<W: Write> MarkdownWriter<W> {
     }
 }
 
-fn write_atx_prefix<W: Write>(writer: &mut W, level: u8) -> Result<()> {
+fn write_atx_prefix<W>(writer: &mut W, level: u8) -> Result<()>
+where
+    W: Write,
+{
     let prefix: &[u8] = match level {
         1 => b"# ",
         2 => b"## ",

--- a/crates/docspec-test-utils/src/collect.rs
+++ b/crates/docspec-test-utils/src/collect.rs
@@ -15,7 +15,10 @@ use docspec_core::{Event, EventSource, Result};
 /// Panics with the underlying error if [`EventSource::next_event`] ever
 /// returns `Err`.
 #[inline]
-pub fn collect_events<R: EventSource>(reader: &mut R) -> Vec<Event> {
+pub fn collect_events<R>(reader: &mut R) -> Vec<Event>
+where
+    R: EventSource,
+{
     try_collect_events(reader).expect("event source returned an error")
 }
 
@@ -26,7 +29,10 @@ pub fn collect_events<R: EventSource>(reader: &mut R) -> Vec<Event> {
 ///
 /// Returns the first error produced by [`EventSource::next_event`].
 #[inline]
-pub fn try_collect_events<R: EventSource>(reader: &mut R) -> Result<Vec<Event>> {
+pub fn try_collect_events<R>(reader: &mut R) -> Result<Vec<Event>>
+where
+    R: EventSource,
+{
     let mut events = Vec::new();
     while let Some(event) = reader.next_event()? {
         events.push(event);

--- a/crates/docspec-test-utils/src/drive.rs
+++ b/crates/docspec-test-utils/src/drive.rs
@@ -17,7 +17,11 @@ use docspec_core::{Event, EventSink, Result};
 /// Panics with the underlying error if [`EventSink::handle_event`] or
 /// [`EventSink::finish`] ever returns `Err`.
 #[inline]
-pub fn drive<W: EventSink, I: IntoIterator<Item = Event>>(sink: W, events: I) {
+pub fn drive<W, I>(sink: W, events: I)
+where
+    W: EventSink,
+    I: IntoIterator<Item = Event>,
+{
     try_drive(sink, events).expect("event sink returned an error");
 }
 
@@ -29,10 +33,11 @@ pub fn drive<W: EventSink, I: IntoIterator<Item = Event>>(sink: W, events: I) {
 /// Returns the first error produced by [`EventSink::handle_event`] or
 /// [`EventSink::finish`].
 #[inline]
-pub fn try_drive<W: EventSink, I: IntoIterator<Item = Event>>(
-    mut sink: W,
-    events: I,
-) -> Result<()> {
+pub fn try_drive<W, I>(mut sink: W, events: I) -> Result<()>
+where
+    W: EventSink,
+    I: IntoIterator<Item = Event>,
+{
     for event in events {
         sink.handle_event(event)?;
     }

--- a/crates/docspec-wasm/Cargo.toml
+++ b/crates/docspec-wasm/Cargo.toml
@@ -56,6 +56,9 @@ default_numeric_fallback = "allow"
 std_instead_of_core = "warn"
 alloc_instead_of_core = "warn"
 std_instead_of_alloc = "warn"
+# Reason: `#[cfg(test)] mod tests { ... }` is idiomatic Rust for co-locating unit tests
+# with their target module; splitting each into a separate file adds churn without value.
+inline_modules = "allow"
 missing_docs_in_private_items = "allow"
 partial_pub_fields = "allow"
 let_underscore_untyped = "allow"

--- a/crates/docspec/src/factory/bom_stripping_reader.rs
+++ b/crates/docspec/src/factory/bom_stripping_reader.rs
@@ -67,7 +67,10 @@ impl<R: Read + Seek> Seek for BomStrippingReader<R> {
 /// Returns the number of bytes actually read (0, 1, 2, or 3). Unlike
 /// `read_exact`, this never returns `UnexpectedEof` for inputs shorter than
 /// 3 bytes — those are valid text (e.g. empty input, one character).
-fn read_up_to_3<R: Read>(reader: &mut R, buf: &mut [u8; 3]) -> std::io::Result<usize> {
+fn read_up_to_3<R>(reader: &mut R, buf: &mut [u8; 3]) -> std::io::Result<usize>
+where
+    R: Read,
+{
     let mut filled = usize::default();
     while filled < 3 {
         let remaining = buf.get_mut(filled..).ok_or_else(|| {

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -59,7 +59,10 @@ impl AnyReader {
     /// # }
     /// ```
     #[inline]
-    pub fn from_path<P: AsRef<std::path::Path>>(format: InputFormat, path: P) -> Result<Self> {
+    pub fn from_path<P>(format: InputFormat, path: P) -> Result<Self>
+    where
+        P: AsRef<std::path::Path>,
+    {
         let file = std::fs::File::open(path.as_ref())
             .map_err(|source| docspec_core::Error::Io { source })?;
         Self::from_reader(format, file)
@@ -90,10 +93,10 @@ impl AnyReader {
     /// # }
     /// ```
     #[inline]
-    pub fn from_reader<R: Read + Seek + Send + 'static>(
-        format: InputFormat,
-        reader: R,
-    ) -> Result<Self> {
+    pub fn from_reader<R>(format: InputFormat, reader: R) -> Result<Self>
+    where
+        R: Read + Seek + Send + 'static,
+    {
         #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
         {
             let _ = reader;
@@ -190,7 +193,11 @@ impl EventSource for AnyReader {
 
 #[cfg(test)]
 mod send_static_assertions {
-    fn assert_send_static<T: Send + 'static>() {}
+    fn assert_send_static<T>()
+    where
+        T: Send + 'static,
+    {
+    }
     #[test]
     fn any_reader_is_send_static() {
         #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]

--- a/crates/docspec/tests/factory_reader.rs
+++ b/crates/docspec/tests/factory_reader.rs
@@ -74,14 +74,22 @@ mod tests {
     #[cfg(feature = "markdown")]
     #[test]
     fn assert_is_event_source() {
-        fn check<S: EventSource>(_: S) {}
+        fn check<S>(_: S)
+        where
+            S: EventSource,
+        {
+        }
         check(AnyReader::from_str(InputFormat::Markdown, "").unwrap());
     }
 
     #[cfg(feature = "html")]
     #[test]
     fn html_assert_is_event_source() {
-        fn check<S: EventSource>(_: S) {}
+        fn check<S>(_: S)
+        where
+            S: EventSource,
+        {
+        }
         check(AnyReader::from_str(InputFormat::Html, "").unwrap());
     }
 

--- a/crates/docspec/tests/factory_writer.rs
+++ b/crates/docspec/tests/factory_writer.rs
@@ -87,7 +87,11 @@ mod tests {
     #[cfg(feature = "blocknote-writer")]
     #[test]
     fn assert_is_event_sink() {
-        fn check<K: EventSink>(_: K) {}
+        fn check<K>(_: K)
+        where
+            K: EventSink,
+        {
+        }
         let output = Vec::new();
         check(AnyWriter::new(OutputFormat::Blocknote, output));
     }
@@ -145,7 +149,11 @@ mod tests {
     #[cfg(feature = "oxa-writer")]
     #[test]
     fn oxa_assert_is_event_sink() {
-        fn check<K: EventSink>(_: K) {}
+        fn check<K>(_: K)
+        where
+            K: EventSink,
+        {
+        }
         let output = Vec::new();
         check(AnyWriter::new(OutputFormat::Oxa, output));
     }
@@ -197,7 +205,11 @@ mod tests {
     #[cfg(feature = "pandoc-native-writer")]
     #[test]
     fn pandoc_native_assert_is_event_sink() {
-        fn check<K: EventSink>(_: K) {}
+        fn check<K>(_: K)
+        where
+            K: EventSink,
+        {
+        }
         let output = Vec::new();
         check(AnyWriter::new(OutputFormat::PandocNative, output));
     }
@@ -277,7 +289,11 @@ mod tests {
     #[cfg(feature = "html-writer")]
     #[test]
     fn html_dispatch_is_event_sink() {
-        fn check<K: EventSink>(_: K) {}
+        fn check<K>(_: K)
+        where
+            K: EventSink,
+        {
+        }
         let output = Vec::new();
         check(AnyWriter::new(OutputFormat::Html, output));
     }

--- a/crates/docspec/tests/readers_docx.rs
+++ b/crates/docspec/tests/readers_docx.rs
@@ -18,7 +18,11 @@ mod tests {
 
     #[test]
     fn docx_reader_implements_event_source() {
-        fn assert_event_source<S: EventSource>() {}
+        fn assert_event_source<S>()
+        where
+            S: EventSource,
+        {
+        }
         assert_event_source::<DocxReader>();
     }
 


### PR DESCRIPTION
Fix clippy warnings surfaced by stable Rust 1.97.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized generic constraint formatting across public APIs and internal helpers.
  * Improved consistency in DOCX, HTML, Markdown, JSON, and reader/writer interfaces without changing behavior.

* **Chores**
  * Updated lint configuration to accommodate stable standard-library usage and co-located test modules.

* **Tests**
  * Improved assertion clarity and maintained compile-time type-safety checks across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->