### PR TITLE
test(docx-reader): honor CARGO_TARGET_DIR and document memtest_child build

### DIFF
--- a/crates/docspec-docx-reader/tests/memory.rs
+++ b/crates/docspec-docx-reader/tests/memory.rs
@@ -4,7 +4,12 @@
 //! of `document.xml` size. They are marked `#[ignore]` because they are slow and
 //! should not run in normal CI.
 //!
-//! Run with: `cargo test -p docspec-docx-reader --test memory -- --ignored --nocapture`.
+//! The tests spawn a prebuilt release example, so build it first:
+//!
+//! ```text
+//! cargo build --release --example memtest_child -p docspec-docx-reader
+//! cargo test -p docspec-docx-reader --test memory -- --ignored --nocapture
+//! ```
 #![allow(
     clippy::arithmetic_side_effects,
     clippy::expect_used,
@@ -56,11 +61,22 @@ mod linux_only {
         ])
     }
 
+    /// Cargo's target directory, always absolute.
+    ///
+    /// `CARGO_TARGET_TMPDIR` is set at compile time for integration tests to
+    /// `<target-dir>/tmp`, already resolved by Cargo. Reading `CARGO_TARGET_DIR`
+    /// at runtime instead would break on relative values: Cargo resolves those
+    /// against its invocation directory, while the test process runs from the
+    /// package root.
+    fn target_dir() -> std::path::PathBuf {
+        std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+            .parent()
+            .expect("CARGO_TARGET_TMPDIR is <target-dir>/tmp and always has a parent")
+            .to_path_buf()
+    }
+
     fn child_bin_path() -> std::path::PathBuf {
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-            .expect("CARGO_MANIFEST_DIR must be set (run via cargo test)");
-        let workspace_root = std::path::Path::new(&manifest_dir).join("../..");
-        workspace_root.join("target/release/examples/memtest_child")
+        target_dir().join("release/examples/memtest_child")
     }
 
     fn run_child_and_get_peak_rss(docx_path: &std::path::Path) -> u64 {

--- a/crates/docspec/tests/memory.rs
+++ b/crates/docspec/tests/memory.rs
@@ -50,17 +50,26 @@ mod linux_only {
         docspec_test_utils::synth_docx(rels_xml, &doc_xml)
     }
 
+    /// Cargo's target directory, always absolute.
+    ///
+    /// `CARGO_TARGET_TMPDIR` is set at compile time for integration tests to
+    /// `<target-dir>/tmp`, already resolved by Cargo. Reading `CARGO_TARGET_DIR`
+    /// at runtime instead would break on relative values: Cargo resolves those
+    /// against its invocation directory, while the test process runs from the
+    /// package root.
     fn target_dir() -> std::path::PathBuf {
-        if let Ok(dir) = std::env::var("CARGO_TARGET_DIR") {
-            return std::path::PathBuf::from(dir);
-        }
-        let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-            .expect("CARGO_MANIFEST_DIR must be set (run via cargo test)");
-        std::path::Path::new(&manifest_dir).join("../../target")
+        std::path::Path::new(env!("CARGO_TARGET_TMPDIR"))
+            .parent()
+            .expect("CARGO_TARGET_TMPDIR is <target-dir>/tmp and always has a parent")
+            .to_path_buf()
+    }
+
+    fn child_bin_path() -> std::path::PathBuf {
+        target_dir().join("release/examples/memtest_facade_child")
     }
 
     fn run_child_and_get_peak_rss(docx_path: &std::path::Path) -> u64 {
-        let bin = target_dir().join("release/examples/memtest_facade_child");
+        let bin = child_bin_path();
 
         assert!(
             bin.exists(),


### PR DESCRIPTION
The DOCX memory tests could not run under a custom `CARGO_TARGET_DIR`.

- `child_bin_path()` hardcoded `<workspace>/target/release/examples/memtest_child`, so with `CARGO_TARGET_DIR` set the binary-exists assert always failed. Now resolves via `CARGO_TARGET_DIR` first, matching the `target_dir()` helper already used in `crates/docspec/tests/memory.rs`.
- The module doc listed only the `cargo test` command, which never builds `memtest_child` — a clean checkout hit the same assert. Both steps are now documented.

Same two defects CodeRabbit flagged on the sibling facade test in #381; this brings the older test in line.

Verified: both ignored tests now run — 50 MB `document.xml` → 2 MB peak RSS, 200 MB → 2 MB.

Gates (stable 1.97.1): fmt, `clippy --workspace --all-targets -D warnings` (0 warnings), 2364 tests — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated memory test instructions with explicit commands for building the release example before running ignored tests.
  * Improved test setup to locate example binaries using the configured build directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->