### PR TITLE
docs: distinguish supported from experimental formats

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,6 +30,8 @@ A sink takes events and produces a document in some format. It receives events o
 
 This decoupling is the key architectural insight. Sources and sinks are fully independent. They communicate only through the event protocol. Any source can connect to any sink. A system with four readers and four writers needs only eight implementations instead of sixteen. Complexity grows linearly, not quadratically.
 
+"Any source can connect to any sink" is a statement about **protocol compatibility**, not about fidelity. Every pairing runs, but the result is only as faithful as its least-capable endpoint: a sink silently drops events it cannot represent. See the [format matrix](README.md#what-it-reads-and-writes) for which readers and writers are production-ready and which are experimental.
+
 The pipeline is transparent and inspectable. You can insert adapters between source and sink without either knowing the adapter exists. An adapter is a sink that consumes events and a source that emits events. This composability enables powerful transformation chains: filter events, remap event types, validate events, count events.
 
 The event model is universal across all formats. A document is a sequence of structural elements: headings, paragraphs, lists, tables, text runs with styling, links, images. By separating structure from encoding, we achieve true interoperability.
@@ -78,7 +80,9 @@ This approach also enables lazy loading and conditional processing. If a sink do
 
 Events flow until they cannot. When a reader encounters a malformed byte sequence, corrupted structure, or unsupported feature, it surfaces an error immediately. There is no attempt to recover and continue. There is no partial output. There is no "best effort" conversion that produces garbage.
 
-Fail fast means the caller receives one of exactly two outcomes: a complete, correct conversion that processed the entire document successfully, or a clear error describing precisely what went wrong and where. Never a partial conversion. Never truncated output. Never corrupted output that propagates downstream.
+Fail fast means the caller receives one of exactly two outcomes: a conversion that processed the entire input successfully, or a clear error describing precisely what went wrong and where. Never a partial conversion. Never truncated output. Never corrupted output that propagates downstream.
+
+This guarantee is about **input integrity**, not **semantic coverage**. A successful conversion means every byte of the source was read and understood; it does not mean every event survived into the output. A sink that has no representation for an event drops it and keeps going — so a writer marked *Experimental* in the [format matrix](README.md#what-it-reads-and-writes) can return success while omitting headings, lists, or tables entirely. That is a documented coverage gap, not a failure, and it is deliberately not surfaced as an error today.
 
 Error information is structured, typed, and contextual. Each error carries relevant context: what operation was being performed, where in the document the problem occurred, what values were expected and what was actually found.
 

--- a/README.md
+++ b/README.md
@@ -76,12 +76,30 @@ curl -X POST http://localhost:3000/conversion \
 ## What it reads and writes
 
 Readers and writers are fully decoupled: any reader can feed any writer, because the
-event stream is the only contract between them.
+event stream is the only contract between them. That decoupling is *mechanical* — every
+pairing runs, but a conversion is only as faithful as its least-capable endpoint.
 
-| Direction  | Formats                                                     |
-| ---------- | ----------------------------------------------------------- |
-| **Reads**  | DOCX, HTML, Markdown                                         |
-| **Writes** | HTML, Markdown, BlockNote JSON, oxa.dev JSON, Pandoc native  |
+Formats carry one of two statuses:
+
+- **Supported** — intended for production use within its documented mapping. Common
+  document structure is covered, and the known limitations are part of the maintained
+  contract. This does not mean lossless interchange.
+- **Experimental** — coverage is deliberately incomplete. Common structures may be
+  **silently omitted from the output**. Don't rely on it where fidelity matters.
+
+| Direction  | Format           | Status           | Coverage today                                                    |
+| ---------- | ---------------- | ---------------- | ----------------------------------------------------------------- |
+| **Reads**  | DOCX             | **Supported**    | Headings, tables, lists, hyperlinks, images, run styles, colors    |
+| **Reads**  | Markdown         | **Supported**    | CommonMark + GFM tables and strikethrough                          |
+| **Reads**  | HTML             | *Experimental*   | `<p>` elements and their text only — every other tag is dropped    |
+| **Writes** | BlockNote JSON   | **Supported**    | Headings, lists, tables, links, images, styles, quotes, code       |
+| **Writes** | Pandoc native    | *Experimental*   | Paragraphs, headings, styles, code; no lists, tables, links, images |
+| **Writes** | Markdown         | *Experimental*   | Paragraphs and headings, text only                                 |
+| **Writes** | HTML             | *Experimental*   | Paragraphs and text only                                           |
+| **Writes** | oxa.dev JSON     | *Experimental*   | Paragraphs and text only                                           |
+
+This table is the canonical statement of format maturity. Each crate's README remains the
+authoritative reference for exactly which events it handles and drops.
 
 ## Why DocSpec?
 

--- a/crates/docspec-cli/README.md
+++ b/crates/docspec-cli/README.md
@@ -85,6 +85,25 @@ see the [`docspec-http` README](https://docs.rs/docspec-http) for the full list.
 > Known losses include vertical cell merges, comments, footnotes, headers and footers,
 > document metadata, tracked deletions, and field-code hyperlinks.
 
+## Supported output formats
+
+Only `blocknote` is production-ready. **Every other output format is experimental and will
+silently drop structure it cannot express** — the conversion succeeds and exits `0`, but
+content is missing from the output.
+
+- `blocknote` — **Supported.** Headings, lists, tables, links, images, styles, block quotes, code
+- `pandoc-native` — *Experimental.* Paragraphs, headings, text styles and code blocks; lists, tables, links and images are dropped
+- `markdown` — *Experimental.* Paragraphs and headings only, text only
+- `html` — *Experimental.* Paragraphs and text only; headings, lists, tables, links and images are dropped
+- `oxa` — *Experimental.* Paragraphs and text only; headings, lists, tables, links and images are dropped
+
+> **Worked example.** `echo '# Foo' | docspec convert --from markdown --to html` prints
+> `<html><body></body></html>` — the heading is dropped, and its text with it, because the
+> HTML writer only emits text inside a paragraph.
+
+See the [format matrix](https://github.com/docspec/docspec/blob/main/README.md#what-it-reads-and-writes)
+for the canonical status of every format.
+
 ## Examples
 
 Convert a Markdown file to BlockNote JSON:
@@ -111,7 +130,7 @@ Convert Markdown from stdin to BlockNote JSON on stdout:
 echo "# Hello" | docspec convert --from markdown --to blocknote
 ```
 
-Convert Markdown to HTML:
+Convert Markdown to HTML (experimental — paragraphs and text only):
 
 ```bash
 echo "Hello" | docspec convert --from markdown --to html

--- a/crates/docspec-cli/src/args.rs
+++ b/crates/docspec-cli/src/args.rs
@@ -90,13 +90,13 @@ pub enum ColorChoice {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[non_exhaustive]
 pub enum CliInputFormat {
-    /// DOCX format (paragraphs and text only).
+    /// DOCX — supported: headings, tables, lists, hyperlinks, images, run styles.
     #[value(name = "docx")]
     Docx,
-    /// HTML format (paragraph-only; `<p>` elements and text within them only).
+    /// HTML — EXPERIMENTAL: `<p>` and its text only; all other tags are dropped.
     #[value(name = "html")]
     Html,
-    /// Markdown format.
+    /// Markdown — supported: `CommonMark` plus GFM tables and strikethrough.
     #[value(name = "markdown")]
     Markdown,
 }
@@ -105,19 +105,22 @@ pub enum CliInputFormat {
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[non_exhaustive]
 pub enum CliOutputFormat {
-    /// `BlockNote` JSON format.
+    /// `BlockNote` JSON — supported: headings, lists, tables, links, images, styles.
     #[value(name = "blocknote")]
     Blocknote,
-    /// HTML5 format.
+    /// HTML5 — EXPERIMENTAL: paragraphs and text only; headings, lists, tables,
+    /// links and images are silently dropped.
     #[value(name = "html")]
     Html,
-    /// `oxa.dev` JSON format.
+    /// `oxa.dev` JSON — EXPERIMENTAL: paragraphs and text only; headings, lists,
+    /// tables, links and images are silently dropped.
     #[value(name = "oxa")]
     Oxa,
-    /// Pandoc native block-list syntax.
+    /// Pandoc native — EXPERIMENTAL: paragraphs, headings, styles and code only;
+    /// no lists, tables, links or images.
     #[value(name = "pandoc-native")]
     PandocNative,
-    /// Markdown format (paragraphs and headings only).
+    /// Markdown — EXPERIMENTAL: paragraphs and headings only, text only.
     #[value(name = "markdown")]
     Markdown,
 }

--- a/crates/docspec-html-writer/src/lib.rs
+++ b/crates/docspec-html-writer/src/lib.rs
@@ -1,6 +1,12 @@
 #![forbid(unsafe_code)]
 
 //! Streaming HTML5 writer for `DocSpec` events.
+//!
+//! **Experimental.** This writer emits paragraphs and their text, and nothing else.
+//! Headings, lists, tables, links, images, text styles, block quotes, preformatted
+//! blocks and breaks are all silently dropped, as is any `Text` event that arrives
+//! outside a paragraph. A heading therefore produces no output at all — not even its
+//! text. Do not rely on this writer where fidelity matters.
 
 use docspec_core::{Event, EventSink, Result};
 use html5ever::serialize::{HtmlSerializer, SerializeOpts, Serializer as _};

--- a/crates/docspec-http/README.md
+++ b/crates/docspec-http/README.md
@@ -6,7 +6,15 @@ Send a document, receive a converted one. `docspec-http` is an Axum-based librar
 
 Send markdown (`Content-Type: text/markdown`), HTML (`Content-Type: text/html`), or DOCX (`Content-Type: application/vnd.openxmlformats-officedocument.wordprocessingml.document`), receive BlockNote JSON (default), HTML (`Accept: text/html`), oxa.dev JSON (`Accept: application/vnd.oxa+json`), or Pandoc native (`Accept: application/vnd.pandoc.native`). The underlying DocSpec pipeline is streaming, but this v1 HTTP wrapper **buffers the request body and the conversion output in memory** before responding. End-to-end streaming over HTTP is planned for a future version. For now, request size scales with available memory.
 
-> **HTML is paragraph-only.** The HTML reader currently parses `<p>` elements only, and the HTML writer currently emits only paragraph events. Other HTML input elements and non-paragraph output events (headings, lists, tables, formatting, etc.) are silently dropped. See [docspec-html-reader](https://docs.rs/docspec-html-reader) and [docspec-html-writer](https://docs.rs/docspec-html-writer).
+> **Only BlockNote output is production-ready.** `text/html`, `application/vnd.oxa+json` and `application/vnd.pandoc.native` are **experimental**: the server returns `200` while silently dropping structure those writers cannot express.
+>
+> - `text/html` — paragraphs and text only; headings, lists, tables, links and images are dropped
+> - `application/vnd.oxa+json` — paragraphs and text only; same omissions
+> - `application/vnd.pandoc.native` — paragraphs, headings, styles and code; lists, tables, links and images are dropped
+>
+> HTML **input** is likewise paragraph-only: the reader parses `<p>` elements and their text, and drops all other structure.
+>
+> See the [format matrix](https://github.com/docspec/docspec/blob/main/README.md#what-it-reads-and-writes) for canonical status, and [docspec-html-reader](https://docs.rs/docspec-html-reader) / [docspec-html-writer](https://docs.rs/docspec-html-writer) for exact event coverage.
 
 ## When to use this crate
 

--- a/crates/docspec-oxa-writer/src/lib.rs
+++ b/crates/docspec-oxa-writer/src/lib.rs
@@ -4,6 +4,10 @@
 //! This crate provides a streaming [`OxaWriter`] that implements [`EventSink`] to convert
 //! `DocSpec` event streams into `oxa.dev` JSON format.
 //!
+//! **Experimental.** This writer emits paragraphs and their text, and nothing else.
+//! Headings, lists, tables, links, images and text styles are silently dropped. Do not
+//! rely on it where fidelity matters.
+//!
 //! # Design
 //!
 //! The writer emits JSON tokens directly to the underlying `Write` as events arrive using

--- a/crates/docspec-pandoc-native-writer/src/lib.rs
+++ b/crates/docspec-pandoc-native-writer/src/lib.rs
@@ -1,6 +1,10 @@
 #![forbid(unsafe_code)]
 
 //! Streaming Pandoc native (block-list) writer for `DocSpec` events.
+//!
+//! **Experimental.** This writer covers paragraphs, headings, text styles, code blocks
+//! and breaks. Lists, tables, links and images are silently dropped. Do not rely on it
+//! where fidelity matters.
 
 mod escape;
 


### PR DESCRIPTION
Closes #356.

HTML output is not broken — it implements a narrow paragraph-only contract. The bug is that top-level surfaces advertised it as a peer of DOCX and BlockNote. Verified against the code, the gap generalizes beyond HTML: **four** formats are experimental.

| Direction | Format | Status | Coverage |
|---|---|---|---|
| Read | DOCX, Markdown | Supported | broad |
| Read | HTML | Experimental | `<p>` and its text only |
| Write | BlockNote JSON | Supported | broad |
| Write | Pandoc native | Experimental | no lists, tables, links, images |
| Write | Markdown | Experimental | paragraphs + headings, text only |
| Write | HTML, oxa.dev JSON | Experimental | paragraphs + text only |

Changes:

- **Root README** — flat format table replaced with the canonical directional matrix and two-tier definitions (Supported / Experimental). Crate READMEs stay authoritative for exact event coverage.
- **CLI `--help`** — the surface the reporter actually used. Every `ValueEnum` variant now states its status and principal limitation. Also corrected a pre-existing error: DOCX input was documented as "paragraphs and text only", badly understating the most capable reader.
- **CLI README** — added the missing output-format section with a worked example of the exact reported behaviour.
- **HTTP README** — extended the existing HTML caveat to cover oxa.dev and Pandoc native.
- **Crate rustdoc** — experimental scope added to the HTML, oxa and Pandoc-native writers.
- **ARCHITECTURE.md** — two claims corrected: "any source can connect to any sink" is protocol compatibility, not fidelity; and fail-fast covers input integrity, not semantic coverage, so an experimental sink can return success while dropping content.

No behaviour change. Runtime loss detection (strict/lossy policy, loss reporting) is deliberately out of scope and filed separately — a warning keyed only on format selection would be noisy and could not tell whether a given document actually lost anything.

Verified by running the binary: the #356 repro reproduces exactly, exit code is `0` on lossy conversion, oxa drops the heading, and pandoc-native keeps `Header 1` but flattens the list to `Para`.

Gates (stable 1.97.1): fmt, `clippy --workspace --all-targets -D warnings` (0 warnings), 2364 tests, `cargo doc -D warnings` — all green.