### PR TITLE
fix(blocknote-writer): close open child paragraph before emitting sibling block

### DIFF
--- a/crates/docspec-blocknote-writer/src/lib.rs
+++ b/crates/docspec-blocknote-writer/src/lib.rs
@@ -393,6 +393,22 @@ impl<W: Write> BlockNoteWriter<W> {
         Ok(())
     }
 
+    /// Terminate a child block still holding an open `content[]` array inside an
+    /// already-open `children[]`.
+    ///
+    /// `children[]` holds `Block[]`, but a child paragraph (auto-opened for text that
+    /// follows an inline image) or code block keeps its `content[]` — an
+    /// `InlineContent[]` array — open until its matching end event. Emitting a sibling
+    /// block while that array is open would nest a block inside `InlineContent[]`, which
+    /// no `BlockNote` schema accepts and which makes an editor throw at document
+    /// construction.
+    fn close_open_child_text_block(&mut self) -> Result<()> {
+        if self.context.in_text_block {
+            return close_text_block!(self);
+        }
+        Ok(())
+    }
+
     fn close_open_list_items(&mut self) -> Result<()> {
         while !self.list_stack.is_empty() {
             self.close_current_list_item_object()?;
@@ -442,7 +458,8 @@ impl<W: Write> BlockNoteWriter<W> {
                     *state = BlockquoteContentState::InChildren;
                 }
             }
-            Some(BlockquoteContentState::InChildren) | None => {}
+            Some(BlockquoteContentState::InChildren) => self.close_open_child_text_block()?,
+            None => {}
         }
         Ok(())
     }
@@ -1192,7 +1209,8 @@ impl<W: Write> BlockNoteWriter<W> {
                 entry.children_array_open = true;
             }
         }
-        Ok(())
+
+        self.close_open_child_text_block()
     }
 
     fn prepare_list_item_children(&mut self) -> Result<()> {

--- a/crates/docspec-blocknote-writer/tests/writer.rs
+++ b/crates/docspec-blocknote-writer/tests/writer.rs
@@ -155,6 +155,18 @@ mod tests {
         }
     }
 
+    fn uri_image(uri: &str) -> Event {
+        Event::Image {
+            source: ImageSource::Uri {
+                uri: uri.to_string(),
+            },
+            alt: None,
+            title: None,
+            decorative: false,
+            id: None,
+        }
+    }
+
     #[test]
     fn empty_document() {
         let json = run_events(&[start_document(), Event::EndDocument]);
@@ -4819,6 +4831,91 @@ mod tests {
         assert_eq!(
             json,
             r#"[{"type":"bulletListItem","content":[{"type":"text","text":"first","styles":{}}],"children":[{"type":"paragraph","content":[{"type":"text","text":"second","styles":{}}],"children":[]},{"type":"image","props":{"url":"https://example.com/leaked.png","caption":"leaked"},"content":null,"children":[]}]}]"#
+        );
+    }
+
+    /// Regression for #345: a DOCX bullet with inline images separated by soft breaks.
+    /// The first image moves emission into `children[]` and the following text auto-opens
+    /// a child paragraph there; the second image must close that paragraph and land as its
+    /// sibling. Inside `paragraph.content[]` (`InlineContent[]`) it makes a real
+    /// `BlockNote` editor throw `RangeError: Invalid content for node paragraph`.
+    #[test]
+    fn image_after_line_break_in_open_child_paragraph_emits_as_bullet_item_sibling() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartUnorderedListItem {
+                id: None,
+                level: 0,
+                style_type: docspec_core::ListStyleType::Disc,
+            },
+            start_paragraph(),
+            text("before ("),
+            uri_image("https://example.com/first.png"),
+            text("):"),
+            Event::LineBreak,
+            uri_image("https://example.com/second.png"),
+            text(" after."),
+            Event::EndParagraph,
+            Event::EndUnorderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"bulletListItem","content":[{"type":"text","text":"before (","styles":{}}],"children":[{"type":"image","props":{"url":"https://example.com/first.png","caption":""},"content":null,"children":[]},{"type":"paragraph","content":[{"type":"text","text":"):","styles":{}},{"type":"text","text":"\n","styles":{}}],"children":[]},{"type":"image","props":{"url":"https://example.com/second.png","caption":""},"content":null,"children":[]},{"type":"paragraph","content":[{"type":"text","text":" after.","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    /// Regression for #345 — same shape as the bullet case, on an ordered list item.
+    #[test]
+    fn image_after_line_break_in_open_child_paragraph_emits_as_ordered_item_sibling() {
+        let json = run_events(&[
+            start_document(),
+            Event::StartOrderedListItem {
+                id: None,
+                level: 0,
+                start: None,
+                style_type: docspec_core::ListStyleType::Decimal,
+            },
+            start_paragraph(),
+            text("before ("),
+            uri_image("https://example.com/first.png"),
+            text("):"),
+            Event::LineBreak,
+            uri_image("https://example.com/second.png"),
+            text(" after."),
+            Event::EndParagraph,
+            Event::EndOrderedListItem,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"numberedListItem","content":[{"type":"text","text":"before (","styles":{}}],"children":[{"type":"image","props":{"url":"https://example.com/first.png","caption":""},"content":null,"children":[]},{"type":"paragraph","content":[{"type":"text","text":"):","styles":{}},{"type":"text","text":"\n","styles":{}}],"children":[]},{"type":"image","props":{"url":"https://example.com/second.png","caption":""},"content":null,"children":[]},{"type":"paragraph","content":[{"type":"text","text":" after.","styles":{}}],"children":[]}]}]"#
+        );
+    }
+
+    /// Regression for #345 — `prepare_blockquote_children` has the same no-op hole as
+    /// `open_current_list_item_children`: once the quote is in children-only mode, a
+    /// child paragraph opened there stays open and swallows the next block.
+    #[test]
+    fn image_after_line_break_in_open_child_paragraph_emits_as_blockquote_sibling() {
+        let json = run_events(&[
+            start_document(),
+            start_blockquote(),
+            start_paragraph(),
+            text("before ("),
+            uri_image("https://example.com/first.png"),
+            Event::EndParagraph,
+            start_paragraph(),
+            text("):"),
+            Event::LineBreak,
+            uri_image("https://example.com/second.png"),
+            Event::EndParagraph,
+            Event::EndBlockQuote,
+            Event::EndDocument,
+        ]);
+        assert_eq!(
+            json,
+            r#"[{"type":"quote","content":[{"type":"text","text":"before (","styles":{}}],"children":[{"type":"image","props":{"url":"https://example.com/first.png","caption":""},"content":null,"children":[]},{"type":"paragraph","content":[{"type":"text","text":"):","styles":{}},{"type":"text","text":"\n","styles":{}}],"children":[]},{"type":"image","props":{"url":"https://example.com/second.png","caption":""},"content":null,"children":[]}]}]"#
         );
     }
 


### PR DESCRIPTION
A child paragraph auto-opened inside `children[]` stayed open, so the next block was written into `paragraph.content[]` (`InlineContent[]`). Real BlockNote editors throw `RangeError: Invalid content for node paragraph` and fail to mount.

Fixed in both `open_current_list_item_children` and `prepare_blockquote_children` — the blockquote path had the same hole and was reproduced before fixing.

Regression tests for bullet, ordered, and blockquote. Verified end-to-end against a DOCX with the reported shape.

Closes #345