### PR TITLE
fix: compile under every reader and writer feature selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # One reader or writer at a time, plus none at all, catches the conditions that go
-      # stale without paying for the whole feature powerset. `--all-targets` because the
-      # tests carry their own feature conditions, which go stale the same way.
+      # stale without paying for the whole feature powerset. Tests and doc examples carry
+      # their own feature conditions and go stale the same way, hence `--all-targets` and
+      # the separate `--doc` run: `--all-targets` does not build doctests.
       - name: Check each feature selection on its own
         run: |
           set -euo pipefail
@@ -43,8 +44,9 @@ jobs:
             blocknote-writer oxa-writer html-writer pandoc-native-writer markdown-writer \
             docx,markdown-writer all-readers all-writers full
           do
-            echo "::group::--no-default-features --features '$features' --all-targets"
+            echo "::group::--no-default-features --features '$features'"
             cargo check -p docspec --no-default-features --features "$features" --all-targets
+            cargo test --doc -p docspec --no-default-features --features "$features"
             echo "::endgroup::"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # One reader or writer at a time, plus none at all, catches the conditions that go
-      # stale without paying for the whole feature powerset.
+      # stale without paying for the whole feature powerset. `--all-targets` because the
+      # tests carry their own feature conditions, which go stale the same way.
       - name: Check each feature selection on its own
         run: |
           set -euo pipefail
@@ -42,8 +43,8 @@ jobs:
             blocknote-writer oxa-writer html-writer pandoc-native-writer markdown-writer \
             docx,markdown-writer all-readers all-writers full
           do
-            echo "::group::--no-default-features --features '$features'"
-            cargo check -p docspec --no-default-features --features "$features"
+            echo "::group::--no-default-features --features '$features' --all-targets"
+            cargo check -p docspec --no-default-features --features "$features" --all-targets
             echo "::endgroup::"
           done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     # are visible. Otherwise the PR job computes the next-version diff against
     # the still-old crates.io baseline and re-includes commits the release job
     # is in the middle of publishing, producing duplicate CHANGELOG entries.
-    needs: [test, clippy, fmt, docker-build, release-plz-release]
+    needs: [test, clippy, fmt, features, docker-build, release-plz-release]
     if: >-
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'
@@ -132,7 +132,7 @@ jobs:
 
   release-plz-release:
     name: Tag and publish crates
-    needs: [test, clippy, fmt, docker-build]
+    needs: [test, clippy, fmt, features, docker-build]
     if: >-
       github.event_name == 'push'
       && github.ref == 'refs/heads/main'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,8 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      # Readers and writers are compiled in individually, so each selection is its own
-      # build. Checking one reader and one writer at a time, plus none at all, covers the
-      # conditions that go stale without paying for the whole feature powerset.
+      # One reader or writer at a time, plus none at all, catches the conditions that go
+      # stale without paying for the whole feature powerset.
       - name: Check each feature selection on its own
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,32 @@ jobs:
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --workspace
 
+  features:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+      # Readers and writers are compiled in individually, so each selection is its own
+      # build. Checking one reader and one writer at a time, plus none at all, covers the
+      # conditions that go stale without paying for the whole feature powerset.
+      - name: Check each feature selection on its own
+        run: |
+          set -euo pipefail
+          for features in \
+            "" markdown html docx json \
+            blocknote-writer oxa-writer html-writer pandoc-native-writer markdown-writer \
+            docx,markdown-writer all-readers all-writers full
+          do
+            echo "::group::--no-default-features --features '$features'"
+            cargo check -p docspec --no-default-features --features "$features"
+            echo "::endgroup::"
+          done
+
   clippy:
     runs-on: ubuntu-latest
     permissions:

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -14,23 +14,21 @@ categories = ["parsing", "encoding"]
 default = ["markdown", "blocknote", "pandoc-native"]
 
 # Format readers (event sources).
-markdown = ["dep:docspec-markdown-reader", "_reader", "_text-reader"]
-html = ["dep:docspec-html-reader", "_reader", "_text-reader"]
-docx = ["dep:docspec-docx-reader", "_reader"]
+markdown = ["dep:docspec-markdown-reader"]
+html = ["dep:docspec-html-reader"]
+docx = ["dep:docspec-docx-reader"]
 
 # Format writers (event sinks).
-blocknote-writer = ["dep:docspec-blocknote-writer", "_writer"]
-oxa-writer = ["dep:docspec-oxa-writer", "_writer"]
-html-writer = ["dep:docspec-html-writer", "_writer"]
-pandoc-native-writer = ["dep:docspec-pandoc-native-writer", "_writer"]
-markdown-writer = ["dep:docspec-markdown-writer", "_writer"]
+blocknote-writer = ["dep:docspec-blocknote-writer"]
+oxa-writer = ["dep:docspec-oxa-writer"]
+html-writer = ["dep:docspec-html-writer"]
+pandoc-native-writer = ["dep:docspec-pandoc-native-writer"]
+markdown-writer = ["dep:docspec-markdown-writer"]
 
-# Internal markers. Never enable these directly: each is set by the features above, so
-# that "is any writer compiled in" is one condition rather than a list repeated at every
-# use. Repeating it by hand is how the conditions drifted apart in the first place.
-_reader = []
-_writer = []
-_text-reader = []
+# "Is any reader / writer compiled in" is a condition the factories need in several places.
+# build.rs derives it from the features above as the `reader`, `text_reader` and `writer`
+# cfgs. Not a marker feature: a feature can be selected on its own, and then claims a
+# reader or writer is compiled in when none is. See build.rs.
 
 # Lower-level primitives for implementing custom writers.
 json = ["dep:docspec-json"]

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -25,10 +25,8 @@ html-writer = ["dep:docspec-html-writer"]
 pandoc-native-writer = ["dep:docspec-pandoc-native-writer"]
 markdown-writer = ["dep:docspec-markdown-writer"]
 
-# "Is any reader / writer compiled in" is a condition the factories need in several places.
-# build.rs derives it from the features above as the `reader`, `text_reader` and `writer`
-# cfgs. Not a marker feature: a feature can be selected on its own, and then claims a
-# reader or writer is compiled in when none is. See build.rs.
+# The factories gate on the `reader`, `text_reader` and `writer` cfgs, which build.rs
+# derives from the features above.
 
 # Lower-level primitives for implementing custom writers.
 json = ["dep:docspec-json"]

--- a/crates/docspec/Cargo.toml
+++ b/crates/docspec/Cargo.toml
@@ -14,16 +14,23 @@ categories = ["parsing", "encoding"]
 default = ["markdown", "blocknote", "pandoc-native"]
 
 # Format readers (event sources).
-markdown = ["dep:docspec-markdown-reader"]
-html = ["dep:docspec-html-reader"]
-docx = ["dep:docspec-docx-reader"]
+markdown = ["dep:docspec-markdown-reader", "_reader", "_text-reader"]
+html = ["dep:docspec-html-reader", "_reader", "_text-reader"]
+docx = ["dep:docspec-docx-reader", "_reader"]
 
 # Format writers (event sinks).
-blocknote-writer = ["dep:docspec-blocknote-writer"]
-oxa-writer = ["dep:docspec-oxa-writer"]
-html-writer = ["dep:docspec-html-writer"]
-pandoc-native-writer = ["dep:docspec-pandoc-native-writer"]
-markdown-writer = ["dep:docspec-markdown-writer"]
+blocknote-writer = ["dep:docspec-blocknote-writer", "_writer"]
+oxa-writer = ["dep:docspec-oxa-writer", "_writer"]
+html-writer = ["dep:docspec-html-writer", "_writer"]
+pandoc-native-writer = ["dep:docspec-pandoc-native-writer", "_writer"]
+markdown-writer = ["dep:docspec-markdown-writer", "_writer"]
+
+# Internal markers. Never enable these directly: each is set by the features above, so
+# that "is any writer compiled in" is one condition rather than a list repeated at every
+# use. Repeating it by hand is how the conditions drifted apart in the first place.
+_reader = []
+_writer = []
+_text-reader = []
 
 # Lower-level primitives for implementing custom writers.
 json = ["dep:docspec-json"]

--- a/crates/docspec/build.rs
+++ b/crates/docspec/build.rs
@@ -1,0 +1,44 @@
+//! Build configuration for `docspec`.
+//!
+//! Derives one cfg per "is any reader / writer compiled in" question, so each feature
+//! list is written down once instead of at every use — the drift between two hand-copied
+//! lists is what broke the non-default feature selections in the first place.
+//!
+//! These started out as Cargo features (`_reader`, `_writer`, `_text-reader`). Cargo
+//! features are public and additive, so `--features _writer` could be selected on its own,
+//! where the marker then claims a writer is compiled in when none is. A cfg derived here
+//! cannot be set from the outside and cannot disagree with the features it is read from.
+
+use std::env;
+
+/// Each derived cfg and the features that imply it, spelled as Cargo puts them in the
+/// environment: `CARGO_FEATURE_` followed by the feature name uppercased, `-` as `_`.
+///
+/// `text_reader` is a subset rather than a shorter spelling of `reader`: the BOM-stripping
+/// reader wraps the text formats, and DOCX is binary.
+const DERIVED_CFGS: [(&str, &[&str]); 3] = [
+    ("reader", &["MARKDOWN", "HTML", "DOCX"]),
+    ("text_reader", &["MARKDOWN", "HTML"]),
+    (
+        "writer",
+        &[
+            "BLOCKNOTE_WRITER",
+            "OXA_WRITER",
+            "HTML_WRITER",
+            "PANDOC_NATIVE_WRITER",
+            "MARKDOWN_WRITER",
+        ],
+    ),
+];
+
+fn main() {
+    for (cfg, features) in DERIVED_CFGS {
+        println!("cargo::rustc-check-cfg=cfg({cfg})");
+        if features
+            .iter()
+            .any(|feature| env::var_os(format!("CARGO_FEATURE_{feature}")).is_some())
+        {
+            println!("cargo::rustc-cfg={cfg}");
+        }
+    }
+}

--- a/crates/docspec/build.rs
+++ b/crates/docspec/build.rs
@@ -1,20 +1,20 @@
 //! Build configuration for `docspec`.
 //!
-//! Derives one cfg per "is any reader / writer compiled in" question, so each feature
-//! list is written down once instead of at every use — the drift between two hand-copied
-//! lists is what broke the non-default feature selections in the first place.
+//! Derives one cfg per "is any reader / writer compiled in" question, so each feature list
+//! is written down once instead of at every use. Drift between two hand-copied lists is
+//! what broke the non-default feature selections.
 //!
-//! These started out as Cargo features (`_reader`, `_writer`, `_text-reader`). Cargo
-//! features are public and additive, so `--features _writer` could be selected on its own,
-//! where the marker then claims a writer is compiled in when none is. A cfg derived here
-//! cannot be set from the outside and cannot disagree with the features it is read from.
+//! These were marker features (`_reader`, `_writer`, `_text-reader`) first. Cargo features
+//! are public and additive, so `--features _writer` could be selected on its own and the
+//! marker then claimed a writer was compiled in when none was. A cfg cannot be set from
+//! the outside.
 
 use std::env;
 
 /// Each derived cfg and the features that imply it, spelled as Cargo puts them in the
-/// environment: `CARGO_FEATURE_` followed by the feature name uppercased, `-` as `_`.
+/// environment: `CARGO_FEATURE_` plus the feature name uppercased, `-` as `_`.
 ///
-/// `text_reader` is a subset rather than a shorter spelling of `reader`: the BOM-stripping
+/// `text_reader` is a subset of `reader`, not a shorter spelling of it: the BOM-stripping
 /// reader wraps the text formats, and DOCX is binary.
 const DERIVED_CFGS: [(&str, &[&str]); 3] = [
     ("reader", &["MARKDOWN", "HTML", "DOCX"]),

--- a/crates/docspec/src/factory/mod.rs
+++ b/crates/docspec/src/factory/mod.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "_text-reader")]
 mod bom_stripping_reader;
 pub mod reader;
 pub mod writer;

--- a/crates/docspec/src/factory/mod.rs
+++ b/crates/docspec/src/factory/mod.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "_text-reader")]
+#[cfg(text_reader)]
 mod bom_stripping_reader;
 pub mod reader;
 pub mod writer;

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -216,7 +216,10 @@ impl EventSource for AnyReader {
     }
 }
 
+// Nothing to assert about until a reader is compiled in. Two attributes rather than
+// `all(test, reader)`: clippy's `tests_outside_test_module` wants a literal `#[cfg(test)]`.
 #[cfg(test)]
+#[cfg(reader)]
 mod send_static_assertions {
     fn assert_send_static<T>()
     where
@@ -225,7 +228,6 @@ mod send_static_assertions {
     }
     #[test]
     fn any_reader_is_send_static() {
-        #[cfg(reader)]
         assert_send_static::<crate::AnyReader>();
     }
     #[cfg(feature = "docx")]

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -56,11 +56,15 @@ impl AnyReader {
     /// # Example
     ///
     /// ```no_run
+    /// # fn main() -> docspec::Result<()> {
+    /// # // The example names a format, so it is only compiled when that format is.
+    /// # #[cfg(feature = "docx")]
+    /// # {
     /// use docspec::AnyReader;
     /// use docspec::InputFormat;
     ///
-    /// # fn main() -> docspec::Result<()> {
     /// let reader = AnyReader::from_path(InputFormat::Docx, "document.docx")?;
+    /// # }
     /// # Ok(())
     /// # }
     /// ```
@@ -108,12 +112,15 @@ impl AnyReader {
     /// # Example
     ///
     /// ```
+    /// # fn main() -> docspec::Result<()> {
+    /// # #[cfg(feature = "markdown")]
+    /// # {
     /// use std::io::Cursor;
     /// use docspec::AnyReader;
     /// use docspec::InputFormat;
     ///
-    /// # fn main() -> docspec::Result<()> {
     /// let reader = AnyReader::from_reader(InputFormat::Markdown, Cursor::new("# Hello"))?;
+    /// # }
     /// # Ok(())
     /// # }
     /// ```
@@ -161,11 +168,14 @@ impl AnyReader {
     /// # Example
     ///
     /// ```
+    /// # fn main() -> docspec::Result<()> {
+    /// # #[cfg(feature = "markdown")]
+    /// # {
     /// use docspec::AnyReader;
     /// use docspec::InputFormat;
     ///
-    /// # fn main() -> docspec::Result<()> {
     /// let reader = AnyReader::from_str(InputFormat::Markdown, "# Hello")?;
+    /// # }
     /// # Ok(())
     /// # }
     /// ```

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -69,12 +69,12 @@ impl AnyReader {
     where
         P: AsRef<std::path::Path>,
     {
-        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
+        #[cfg(not(feature = "_reader"))]
         {
             let _ = path;
             match format {}
         }
-        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+        #[cfg(feature = "_reader")]
         match format {
             #[cfg(feature = "docx")]
             InputFormat::Docx => Ok(Self::Docx(DocxReader::from_path(path.as_ref())?)),
@@ -122,12 +122,12 @@ impl AnyReader {
     where
         R: Read + Seek + Send + 'static,
     {
-        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
+        #[cfg(not(feature = "_reader"))]
         {
             let _ = reader;
             match format {}
         }
-        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+        #[cfg(feature = "_reader")]
         match format {
             #[cfg(feature = "html")]
             InputFormat::Html => {
@@ -171,12 +171,12 @@ impl AnyReader {
     /// ```
     #[inline]
     pub fn from_str(format: InputFormat, input: &str) -> Result<Self> {
-        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
+        #[cfg(not(feature = "_reader"))]
         {
             let _ = input;
             match format {}
         }
-        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+        #[cfg(feature = "_reader")]
         match format {
             #[cfg(feature = "html")]
             InputFormat::Html => {
@@ -200,11 +200,11 @@ impl AnyReader {
 impl EventSource for AnyReader {
     #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
-        #[cfg(not(any(feature = "markdown", feature = "html", feature = "docx")))]
+        #[cfg(not(feature = "_reader"))]
         {
             match *self {}
         }
-        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+        #[cfg(feature = "_reader")]
         match self {
             #[cfg(feature = "html")]
             Self::Html(r) => r.next_event(),
@@ -225,7 +225,7 @@ mod send_static_assertions {
     }
     #[test]
     fn any_reader_is_send_static() {
-        #[cfg(any(feature = "markdown", feature = "html", feature = "docx"))]
+        #[cfg(feature = "_reader")]
         assert_send_static::<crate::AnyReader>();
     }
     #[cfg(feature = "docx")]

--- a/crates/docspec/src/factory/reader.rs
+++ b/crates/docspec/src/factory/reader.rs
@@ -69,12 +69,12 @@ impl AnyReader {
     where
         P: AsRef<std::path::Path>,
     {
-        #[cfg(not(feature = "_reader"))]
+        #[cfg(not(reader))]
         {
             let _ = path;
             match format {}
         }
-        #[cfg(feature = "_reader")]
+        #[cfg(reader)]
         match format {
             #[cfg(feature = "docx")]
             InputFormat::Docx => Ok(Self::Docx(DocxReader::from_path(path.as_ref())?)),
@@ -122,12 +122,12 @@ impl AnyReader {
     where
         R: Read + Seek + Send + 'static,
     {
-        #[cfg(not(feature = "_reader"))]
+        #[cfg(not(reader))]
         {
             let _ = reader;
             match format {}
         }
-        #[cfg(feature = "_reader")]
+        #[cfg(reader)]
         match format {
             #[cfg(feature = "html")]
             InputFormat::Html => {
@@ -171,12 +171,12 @@ impl AnyReader {
     /// ```
     #[inline]
     pub fn from_str(format: InputFormat, input: &str) -> Result<Self> {
-        #[cfg(not(feature = "_reader"))]
+        #[cfg(not(reader))]
         {
             let _ = input;
             match format {}
         }
-        #[cfg(feature = "_reader")]
+        #[cfg(reader)]
         match format {
             #[cfg(feature = "html")]
             InputFormat::Html => {
@@ -200,11 +200,11 @@ impl AnyReader {
 impl EventSource for AnyReader {
     #[inline]
     fn next_event(&mut self) -> Result<Option<Event>> {
-        #[cfg(not(feature = "_reader"))]
+        #[cfg(not(reader))]
         {
             match *self {}
         }
-        #[cfg(feature = "_reader")]
+        #[cfg(reader)]
         match self {
             #[cfg(feature = "html")]
             Self::Html(r) => r.next_event(),
@@ -225,7 +225,7 @@ mod send_static_assertions {
     }
     #[test]
     fn any_reader_is_send_static() {
-        #[cfg(feature = "_reader")]
+        #[cfg(reader)]
         assert_send_static::<crate::AnyReader>();
     }
     #[cfg(feature = "docx")]

--- a/crates/docspec/src/factory/writer.rs
+++ b/crates/docspec/src/factory/writer.rs
@@ -37,8 +37,7 @@ enum AnyWriterInner<W: Write> {
     PandocNative(PandocNativeWriter<W>),
     #[cfg(feature = "markdown-writer")]
     Markdown(MarkdownWriter<W>),
-    /// Consumes `W` when no writer feature is enabled, where the enum is otherwise
-    /// variant-free and the type parameter would be unused.
+    /// Consumes `W` when no writer feature is enabled and the enum has no other variants.
     #[cfg(not(writer))]
     _Phantom(core::marker::PhantomData<W>),
 }

--- a/crates/docspec/src/factory/writer.rs
+++ b/crates/docspec/src/factory/writer.rs
@@ -37,6 +37,10 @@ enum AnyWriterInner<W: Write> {
     PandocNative(PandocNativeWriter<W>),
     #[cfg(feature = "markdown-writer")]
     Markdown(MarkdownWriter<W>),
+    /// Consumes `W` when no writer feature is enabled, where the enum is otherwise
+    /// variant-free and the type parameter would be unused.
+    #[cfg(not(feature = "_writer"))]
+    _Phantom(core::marker::PhantomData<W>),
 }
 
 impl<W: Write> AnyWriter<W> {
@@ -44,24 +48,12 @@ impl<W: Write> AnyWriter<W> {
     #[inline]
     #[must_use]
     pub fn new(format: OutputFormat, writer: W) -> Self {
-        #[cfg(not(any(
-            feature = "blocknote-writer",
-            feature = "oxa-writer",
-            feature = "html-writer",
-            feature = "pandoc-native-writer",
-            feature = "markdown-writer"
-        )))]
+        #[cfg(not(feature = "_writer"))]
         {
             drop(writer);
             match format {}
         }
-        #[cfg(any(
-            feature = "blocknote-writer",
-            feature = "oxa-writer",
-            feature = "html-writer",
-            feature = "pandoc-native-writer",
-            feature = "markdown-writer"
-        ))]
+        #[cfg(feature = "_writer")]
         {
             let inner = match format {
                 #[cfg(feature = "blocknote-writer")]
@@ -97,7 +89,7 @@ impl<W: Write> EventSink for AnyWriterInner<W> {
             Self::PandocNative(w) => w.finish(),
             #[cfg(feature = "markdown-writer")]
             Self::Markdown(w) => w.finish(),
-            #[cfg(not(feature = "blocknote-writer"))]
+            #[cfg(not(feature = "_writer"))]
             Self::_Phantom(_) => Ok(()),
         }
     }
@@ -114,7 +106,7 @@ impl<W: Write> EventSink for AnyWriterInner<W> {
             Self::PandocNative(w) => w.handle_event(event),
             #[cfg(feature = "markdown-writer")]
             Self::Markdown(w) => w.handle_event(event),
-            #[cfg(not(feature = "blocknote-writer"))]
+            #[cfg(not(feature = "_writer"))]
             Self::_Phantom(_) => {
                 let _ = event;
                 Ok(())

--- a/crates/docspec/src/factory/writer.rs
+++ b/crates/docspec/src/factory/writer.rs
@@ -39,7 +39,7 @@ enum AnyWriterInner<W: Write> {
     Markdown(MarkdownWriter<W>),
     /// Consumes `W` when no writer feature is enabled, where the enum is otherwise
     /// variant-free and the type parameter would be unused.
-    #[cfg(not(feature = "_writer"))]
+    #[cfg(not(writer))]
     _Phantom(core::marker::PhantomData<W>),
 }
 
@@ -48,12 +48,12 @@ impl<W: Write> AnyWriter<W> {
     #[inline]
     #[must_use]
     pub fn new(format: OutputFormat, writer: W) -> Self {
-        #[cfg(not(feature = "_writer"))]
+        #[cfg(not(writer))]
         {
             drop(writer);
             match format {}
         }
-        #[cfg(feature = "_writer")]
+        #[cfg(writer)]
         {
             let inner = match format {
                 #[cfg(feature = "blocknote-writer")]
@@ -89,7 +89,7 @@ impl<W: Write> EventSink for AnyWriterInner<W> {
             Self::PandocNative(w) => w.finish(),
             #[cfg(feature = "markdown-writer")]
             Self::Markdown(w) => w.finish(),
-            #[cfg(not(feature = "_writer"))]
+            #[cfg(not(writer))]
             Self::_Phantom(_) => Ok(()),
         }
     }
@@ -106,7 +106,7 @@ impl<W: Write> EventSink for AnyWriterInner<W> {
             Self::PandocNative(w) => w.handle_event(event),
             #[cfg(feature = "markdown-writer")]
             Self::Markdown(w) => w.handle_event(event),
-            #[cfg(not(feature = "_writer"))]
+            #[cfg(not(writer))]
             Self::_Phantom(_) => {
                 let _ = event;
                 Ok(())

--- a/crates/docspec/tests/docx_color_to_blocknote.rs
+++ b/crates/docspec/tests/docx_color_to_blocknote.rs
@@ -7,7 +7,7 @@
 //! - Black `(0,0,0)` text color → filtered (no `"textColor"` key emitted)
 //! - Yellow highlight `(255,255,0)` → `"backgroundColor":"orange"` (counterintuitive palette snap)
 
-#![cfg(feature = "docx")]
+#![cfg(all(feature = "docx", feature = "blocknote-writer"))]
 #![allow(
     clippy::expect_used,
     clippy::unwrap_used,


### PR DESCRIPTION
Closes #383. Closes #397, which is a duplicate of #383 filed before I found it. Related: #398 — the `features` job below is what that issue asks for on the facade; whether the component crates want the same gate is still open there, so it stays open.

`docspec` 1.21.7 builds under `default` and `--all-features` and almost nothing else. Feature trimming is documented as the supported way to keep the footprint small, and it did not produce a library.

Compile-time only. No runtime behaviour changes and no output differs.

## What was broken

**`AnyWriterInner::_Phantom` was matched but did not exist.** `EventSink::finish` and `EventSink::handle_event` both had a `Self::_Phantom(_)` arm gated on `not(feature = "blocknote-writer")`, while the enum had no such variant. Enabling `markdown-writer` without `blocknote-writer` compiled the arm and failed.

Deleting the arms is not the fix: the variant is what consumed `W` when no writer feature is enabled, so removing it swaps `E0599` for `E0392: type parameter W is never used`. It is restored, gated on the condition that actually describes an empty enum.

The two conditions had drifted. The arms said "not blocknote", the enum's emptiness depended on "none of the five writers".

**`BomStrippingReader` was dead code without a text reader.** It is reachable only from the `html` and `markdown` arms of `AnyReader::from_reader`. With neither enabled the crate's lint level turned three dead-code warnings into errors.

## The fix, and why it is slightly more than two lines

Both defects are the same mistake: the feature list written out by hand at every use, drifting out of step with what it describes. `reader.rs` spelled its condition four times; `writer.rs` spelled the writer equivalent two different ways, and one of them was wrong.

Each condition is now written once, in `crates/docspec/build.rs`, and read as a cfg:

```rust
("reader", &["MARKDOWN", "HTML", "DOCX"]),
("text_reader", &["MARKDOWN", "HTML"]),
("writer", &["BLOCKNOTE_WRITER", "OXA_WRITER", /* … */]),
```

```rust
#[cfg(not(writer))]
```

`text_reader` is a subset rather than a shorter spelling of `reader`: the BOM reader wraps `markdown` and `html` but not `docx`, which is a real distinction.

This started out as three marker features (`_reader`, `_writer`, `_text-reader`) set by the real features. That was wrong: Cargo features are public and additive, so `--features _writer` could be selected on its own, and the marker then claimed a writer was compiled in when none was. A cfg emitted by `build.rs` cannot be set from the outside and cannot disagree with the features it is derived from. Build scripts are already used in `docspec-cli` and `docspec-docx-reader`, the latter for `cargo::rustc-check-cfg` as well.

This is the part that stops the bug returning. Two lines would have fixed the symptom and left the next condition free to drift the same way.

## CI

A `features` job checks each selection on its own: none, each reader, each writer, `json`, a realistic pair, and the three meta-features. Fourteen builds, which is what #398 is about, and a fraction of the full powerset while still catching this class.

`release-plz-release` and `release-plz-pr` list `features` in `needs`, so a red feature matrix cannot publish from `main`.

## Verification

Every selection below fails on `main` unless marked, and all pass here.

| Selection | `main` | this branch |
| --- | --- | --- |
| `default` | ok | ok |
| `--all-features` | ok | ok |
| no features | fails | ok |
| `markdown`, `html`, `docx` | fail | ok |
| `json` | fails | ok |
| each of the five writers alone | fail | ok |
| `docx,markdown-writer` | fails | ok |
| `all-readers`, `all-writers`, `full` | fail | ok |
| `_reader`, `_writer`, `_text-reader` | fail | rejected by Cargo, no such feature |

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` are clean, 68 suites passing.

## How this was found

Building a DOCX-to-Markdown path on the facade with `--features docx,markdown-writer`, which is the selection the documentation recommends for a small footprint. That consumer now depends on `docspec-docx-reader`, `docspec-markdown-writer` and `docspec-core` directly and does not need this fix, so there is no rush on my account.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved support for building with individual reader, writer, text-reader, combined, or empty feature configurations.
  * Reader and writer functionality remains consistent across supported feature selections.
  * Improved handling of builds with no writer formats enabled.
  * Added validation across multiple feature combinations to identify configuration issues earlier.
  * Improved compatibility for DOCX color conversion when the required output format is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

