### PR TITLE
fix(docx-reader): harden against DOCX resource-exhaustion bombs (zip bomb, giant node, nested-table stack overflow)

### DIFF
--- a/crates/docspec-docx-reader/src/document/input.rs
+++ b/crates/docspec-docx-reader/src/document/input.rs
@@ -12,24 +12,90 @@ use quick_xml::events::{BytesStart, Event as XmlEvent};
 /// Initial scratch capacity, sized to hold a typical run of markup without regrowing.
 const SCRATCH_CAPACITY: usize = 4096;
 
+/// Maximum bytes a single XML token (one text node, comment, or skipped subtree)
+/// may pull from the input before the pump fails.
+///
+/// `quick_xml` reads a whole node into scratch in one call, so a single 2 GiB
+/// `<w:t>` run would inflate memory to gigabytes even though the surrounding
+/// document streams — the streaming guarantee only bounds memory across *many*
+/// nodes, not within one pathological node. This cap restores the guarantee: the
+/// window resets before every token, so a legitimate document of any size (made
+/// of normal-sized nodes) streams unaffected, while a single oversized node fails
+/// fast. 64 MiB is far above any real run, heading, or attribute value.
+const MAX_XML_NODE_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Error message surfaced when a single node exceeds [`MAX_XML_NODE_BYTES`].
+const NODE_LIMIT_MESSAGE: &str = "document.xml node exceeds the size limit (possible zip bomb)";
+
+/// A [`Read`] adapter that fails once more than `limit` bytes are read within the
+/// current window. [`reset_window`](Self::reset_window) is called before each XML
+/// token, so the limit applies *per node* rather than per document: a huge
+/// document of many small nodes streams, but one oversized node stops fast.
+struct NodeCappedReader<R> {
+    inner: R,
+    read_in_window: u64,
+    limit: u64,
+}
+
+impl<R> NodeCappedReader<R> {
+    fn new(inner: R, limit: u64) -> Self {
+        Self {
+            inner,
+            read_in_window: 0,
+            limit,
+        }
+    }
+
+    fn reset_window(&mut self) {
+        self.read_in_window = 0;
+    }
+}
+
+impl<R: Read> Read for NodeCappedReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.read_in_window = self
+            .read_in_window
+            .saturating_add(u64::try_from(n).unwrap_or(u64::MAX));
+        if self.read_in_window > self.limit {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                NODE_LIMIT_MESSAGE,
+            ));
+        }
+        Ok(n)
+    }
+}
+
 /// Streaming XML token source for the main document part.
 pub(crate) struct XmlCursor {
-    reader: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
+    reader: quick_xml::Reader<BufReader<NodeCappedReader<Box<dyn Read + Send>>>>,
     scratch: Vec<u8>,
 }
 
 impl XmlCursor {
-    /// Wraps a quick-xml reader.
+    /// Wraps a quick-xml reader, inserting a per-node size cap around its input.
     ///
     /// End-name checking is disabled because the parser resolves element scope
     /// from its own state and must tolerate the mismatched close tags that real
     /// Word output contains.
-    pub(crate) fn new(mut reader: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>) -> Self {
-        reader.config_mut().check_end_names = false;
+    pub(crate) fn new(reader: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>) -> Self {
+        // Unwrap the caller's reader down to the boxed stream and re-wrap it with
+        // the per-node cap. Nothing has been read yet at construction, so
+        // `BufReader::into_inner` discards only an empty buffer.
+        let stream: Box<dyn Read + Send> = reader.into_inner().into_inner();
+        let capped = NodeCappedReader::new(stream, MAX_XML_NODE_BYTES);
+        let mut capped_reader = quick_xml::Reader::from_reader(BufReader::new(capped));
+        capped_reader.config_mut().check_end_names = false;
         Self {
-            reader,
+            reader: capped_reader,
             scratch: Vec::with_capacity(SCRATCH_CAPACITY),
         }
+    }
+
+    /// Resets the per-node byte window so the next token starts from zero.
+    fn reset_node_window(&mut self) {
+        self.reader.get_mut().get_mut().reset_window();
     }
 
     /// Reads the next token, detached from the scratch buffer.
@@ -38,6 +104,7 @@ impl XmlCursor {
     /// reads. That copy is what a future borrowed-token pump will remove.
     pub(crate) fn read_owned(&mut self) -> Result<XmlEvent<'static>> {
         self.scratch.clear();
+        self.reset_node_window();
         Ok(self
             .reader
             .read_event_into(&mut self.scratch)
@@ -48,6 +115,7 @@ impl XmlCursor {
     /// Discards every token up to and including the close tag matching `start`.
     pub(crate) fn skip_subtree(&mut self, start: &BytesStart<'_>) -> Result<()> {
         let end = start.to_end().into_owned();
+        self.reset_node_window();
         self.reader
             .read_to_end_into(end.name(), &mut self.scratch)
             .map_err(map_quick_xml_error)?;
@@ -71,5 +139,39 @@ fn map_quick_xml_error(err: quick_xml::Error) -> Error {
             message: format!("malformed document.xml: {other}"),
             position: None,
         },
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(coverage))]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::panic)]
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn node_capped_reader_allows_up_to_limit_then_errors() {
+        // A single read at the limit is fine.
+        let mut at_limit = NodeCappedReader::new(Cursor::new(vec![b'A'; 8]), 8);
+        let mut buf = Vec::new();
+        assert_eq!(at_limit.read_to_end(&mut buf).unwrap(), 8);
+
+        // One byte over the limit surfaces the zip-bomb error.
+        let mut over_limit = NodeCappedReader::new(Cursor::new(vec![b'A'; 9]), 8);
+        let mut sink = [0; 16];
+        let err = over_limit.read(&mut sink).unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidData);
+        assert_eq!(err.to_string(), NODE_LIMIT_MESSAGE);
+    }
+
+    #[test]
+    fn reset_window_lets_a_new_node_start_from_zero() {
+        // Two 6-byte reads exceed a limit of 8 only if the window is not reset.
+        let mut reader = NodeCappedReader::new(Cursor::new(vec![b'A'; 12]), 8);
+        let mut first = [0; 6];
+        assert_eq!(reader.read(&mut first).unwrap(), 6);
+        reader.reset_window();
+        let mut second = [0; 6];
+        assert_eq!(reader.read(&mut second).unwrap(), 6);
     }
 }

--- a/crates/docspec-docx-reader/src/document/input.rs
+++ b/crates/docspec-docx-reader/src/document/input.rs
@@ -51,7 +51,10 @@ impl<R> NodeCappedReader<R> {
     }
 }
 
-impl<R: Read> Read for NodeCappedReader<R> {
+impl<R> Read for NodeCappedReader<R>
+where
+    R: Read,
+{
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         let n = self.inner.read(buf)?;
         self.read_in_window = self
@@ -74,21 +77,20 @@ pub(crate) struct XmlCursor {
 }
 
 impl XmlCursor {
-    /// Wraps a quick-xml reader, inserting a per-node size cap around its input.
+    /// Builds a quick-xml reader over `stream`, inserting a per-node size cap
+    /// between the source and the parser.
     ///
-    /// End-name checking is disabled because the parser resolves element scope
-    /// from its own state and must tolerate the mismatched close tags that real
-    /// Word output contains.
-    pub(crate) fn new(reader: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>) -> Self {
-        // Unwrap the caller's reader down to the boxed stream and re-wrap it with
-        // the per-node cap. Nothing has been read yet at construction, so
-        // `BufReader::into_inner` discards only an empty buffer.
-        let stream: Box<dyn Read + Send> = reader.into_inner().into_inner();
+    /// Takes the raw source rather than a pre-built [`quick_xml::Reader`] so
+    /// parsing is always anchored at byte zero and no buffered bytes or reader
+    /// configuration can be silently discarded. End-name checking is disabled
+    /// because the parser resolves element scope from its own state and must
+    /// tolerate the mismatched close tags that real Word output contains.
+    pub(crate) fn new(stream: Box<dyn Read + Send>) -> Self {
         let capped = NodeCappedReader::new(stream, MAX_XML_NODE_BYTES);
-        let mut capped_reader = quick_xml::Reader::from_reader(BufReader::new(capped));
-        capped_reader.config_mut().check_end_names = false;
+        let mut reader = quick_xml::Reader::from_reader(BufReader::new(capped));
+        reader.config_mut().check_end_names = false;
         Self {
-            reader: capped_reader,
+            reader,
             scratch: Vec::with_capacity(SCRATCH_CAPACITY),
         }
     }

--- a/crates/docspec-docx-reader/src/document/mod.rs
+++ b/crates/docspec-docx-reader/src/document/mod.rs
@@ -1,7 +1,7 @@
 //! DOCX main document part (`document.xml`) streaming event parser.
 
 use core::fmt;
-use std::io::{BufReader, Read};
+use std::io::Read;
 use std::sync::{Arc, Mutex};
 
 use docspec_core::{Error, Event, Result, TableHeaderScope};
@@ -140,7 +140,7 @@ impl fmt::Debug for DocumentReader {
 
 impl DocumentReader {
     pub fn from_xml_reader_and_archive(
-        xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
+        stream: Box<dyn Read + Send>,
         data: DocxData,
         archive: Arc<Mutex<zip::ZipArchive<Box<dyn crate::package::ReadSeek + 'static>>>>,
         content_types: Arc<crate::content_types::ContentTypes>,
@@ -150,7 +150,7 @@ impl DocumentReader {
             emit: EmitState::default(),
             pending_error: None,
             package: PackageContext::new(data, archive, content_types),
-            input: XmlCursor::new(xml),
+            input: XmlCursor::new(stream),
             table_depth: 0,
         }
     }
@@ -158,10 +158,7 @@ impl DocumentReader {
     #[cfg(test)]
     #[cfg(not(coverage))]
     #[allow(clippy::expect_used, clippy::as_conversions)]
-    pub(crate) fn from_xml_reader(
-        xml: quick_xml::Reader<BufReader<Box<dyn Read + Send>>>,
-        data: DocxData,
-    ) -> Self {
+    pub(crate) fn from_xml_reader(stream: Box<dyn Read + Send>, data: DocxData) -> Self {
         use std::io::Cursor;
         const EMPTY_ZIP: &[u8] = &[
             0x50, 0x4B, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -172,7 +169,7 @@ impl DocumentReader {
         )
         .expect("minimal empty zip must be valid");
         Self::from_xml_reader_and_archive(
-            xml,
+            stream,
             data,
             Arc::new(Mutex::new(archive)),
             Arc::new(crate::content_types::ContentTypes::default()),
@@ -1256,14 +1253,13 @@ mod tests {
         numbering: crate::numbering::MinimalNumbering,
     ) -> DocumentReader {
         let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
-        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
         let data = DocxData {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map: HyperlinkMap::default(),
             numbering,
             image_map: crate::rels::ImageMap::default(),
         };
-        DocumentReader::from_xml_reader(xml, data)
+        DocumentReader::from_xml_reader(stream, data)
     }
 
     fn list_paragraph(num_id: u32, ilvl: u32, text: &str) -> String {
@@ -1288,8 +1284,7 @@ mod tests {
     fn make_reader_with_styles(document_xml: &str, styles_body: &str) -> DocumentReader {
         let stream: Box<dyn std::io::Read + Send> =
             Box::new(std::io::Cursor::new(document_xml.to_string().into_bytes()));
-        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
-        DocumentReader::from_xml_reader(xml, make_docx_data(styles_body))
+        DocumentReader::from_xml_reader(stream, make_docx_data(styles_body))
     }
 
     fn collect_events(reader: &mut DocumentReader) -> Vec<docspec_core::Event> {
@@ -1312,14 +1307,13 @@ mod tests {
 
     fn make_reader(document_xml: &str) -> DocumentReader {
         let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
-        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
         let data = DocxData {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map: HyperlinkMap::default(),
             numbering: crate::numbering::MinimalNumbering::new(),
             image_map: crate::rels::ImageMap::default(),
         };
-        DocumentReader::from_xml_reader(xml, data)
+        DocumentReader::from_xml_reader(stream, data)
     }
 
     fn make_reader_with_hyperlinks(
@@ -1327,14 +1321,13 @@ mod tests {
         hyperlink_map: HyperlinkMap,
     ) -> DocumentReader {
         let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
-        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
         let data = DocxData {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map,
             numbering: crate::numbering::MinimalNumbering::new(),
             image_map: crate::rels::ImageMap::default(),
         };
-        DocumentReader::from_xml_reader(xml, data)
+        DocumentReader::from_xml_reader(stream, data)
     }
 
     fn document_with_hyperlink_body(body: &str) -> String {
@@ -1362,14 +1355,13 @@ mod tests {
         image_map: crate::rels::ImageMap,
     ) -> DocumentReader {
         let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
-        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
         let data = DocxData {
             style_list: crate::styles::StyleList::default(),
             hyperlink_map: HyperlinkMap::default(),
             numbering: crate::numbering::MinimalNumbering::new(),
             image_map,
         };
-        DocumentReader::from_xml_reader(xml, data)
+        DocumentReader::from_xml_reader(stream, data)
     }
 
     #[test]
@@ -3616,14 +3608,13 @@ mod tests {
         let style_list = crate::styles::StyleList::parse(Cursor::new(xml_str.into_bytes()))
             .expect("valid styles XML");
         let stream: Box<dyn Read + Send> = Box::new(Cursor::new(document_xml.as_bytes().to_vec()));
-        let xml = quick_xml::Reader::from_reader(std::io::BufReader::new(stream));
         let data = DocxData {
             style_list,
             hyperlink_map: HyperlinkMap::default(),
             numbering,
             image_map: crate::rels::ImageMap::default(),
         };
-        DocumentReader::from_xml_reader(xml, data)
+        DocumentReader::from_xml_reader(stream, data)
     }
 
     #[test]

--- a/crates/docspec-docx-reader/src/document/mod.rs
+++ b/crates/docspec-docx-reader/src/document/mod.rs
@@ -28,6 +28,16 @@ use text::{collect_text_content, decode_general_ref, normalize_symbol_text, reso
 
 const MAX_LIST_LEVEL: u32 = 8;
 
+/// Maximum `<w:tbl>` nesting depth before parsing fails.
+///
+/// Nested tables are parsed by recursion (`parse_tbl` → `parse_tr` → `parse_tc`
+/// → `parse_tbl`), so an adversarial document of deeply nested tables would
+/// overflow the call stack and abort the process — a tiny file crashing the
+/// server, unreachable by any byte or node cap. Real documents nest tables a
+/// handful of levels at most; 100 is far beyond that while staying well clear of
+/// stack exhaustion.
+const MAX_TABLE_NESTING_DEPTH: u32 = 100;
+
 /// Document processing phase.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum Phase {
@@ -105,6 +115,9 @@ pub struct DocumentReader {
     package: PackageContext,
     /// The XML token pump streaming from the document entry.
     input: XmlCursor,
+    /// Current `<w:tbl>` nesting depth, bounded by [`MAX_TABLE_NESTING_DEPTH`]
+    /// to keep the recursive table parser off a stack-overflow path.
+    table_depth: u32,
 }
 
 impl fmt::Debug for DocumentReader {
@@ -138,6 +151,7 @@ impl DocumentReader {
             pending_error: None,
             package: PackageContext::new(data, archive, content_types),
             input: XmlCursor::new(xml),
+            table_depth: 0,
         }
     }
 
@@ -915,7 +929,26 @@ impl DocumentReader {
         }
     }
 
-    fn parse_tbl(&mut self, _start: &BytesStart<'_>, is_outermost: bool) -> Result<()> {
+    /// Parses a `<w:tbl>`, bounding recursion depth so deeply nested tables fail
+    /// fast instead of overflowing the call stack.
+    ///
+    /// The depth counter is incremented for the whole lifetime of the inner
+    /// parse and decremented on every exit path, so sibling tables at the same
+    /// level do not accumulate depth.
+    fn parse_tbl(&mut self, start: &BytesStart<'_>, is_outermost: bool) -> Result<()> {
+        self.table_depth = self.table_depth.saturating_add(1);
+        if self.table_depth > MAX_TABLE_NESTING_DEPTH {
+            self.table_depth = self.table_depth.saturating_sub(1);
+            return Err(parse_error(format!(
+                "table nesting exceeds the depth limit of {MAX_TABLE_NESTING_DEPTH} (possible zip bomb)"
+            )));
+        }
+        let result = self.parse_tbl_inner(start, is_outermost);
+        self.table_depth = self.table_depth.saturating_sub(1);
+        result
+    }
+
+    fn parse_tbl_inner(&mut self, _start: &BytesStart<'_>, is_outermost: bool) -> Result<()> {
         self.emit.flush_list_stack();
         self.emit.flush_pending_preformatted_close();
         self.emit.push(Event::StartTable { id: None });

--- a/crates/docspec-docx-reader/src/lib.rs
+++ b/crates/docspec-docx-reader/src/lib.rs
@@ -105,7 +105,7 @@ mod streaming_archive;
 mod styles;
 mod symbol_fonts;
 
-use std::io::{BufReader, Read, Seek};
+use std::io::{Read, Seek};
 use std::path::Path;
 
 pub use docspec_core::EventSource;
@@ -161,7 +161,6 @@ impl DocxReader {
     {
         let (style_list, numbering, hyperlink_map, image_map, content_types, archive, stream) =
             package::open_package_from_path(path.as_ref())?;
-        let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
         let data = document::DocxData {
             style_list,
             hyperlink_map,
@@ -170,7 +169,7 @@ impl DocxReader {
         };
         Ok(Self {
             inner: document::DocumentReader::from_xml_reader_and_archive(
-                xml,
+                stream,
                 data,
                 archive,
                 content_types,
@@ -198,7 +197,6 @@ impl DocxReader {
     {
         let (style_list, numbering, hyperlink_map, image_map, content_types, archive, stream) =
             package::open_package(reader)?;
-        let xml = quick_xml::Reader::from_reader(BufReader::new(stream));
         let data = document::DocxData {
             style_list,
             hyperlink_map,
@@ -207,7 +205,7 @@ impl DocxReader {
         };
         Ok(Self {
             inner: document::DocumentReader::from_xml_reader_and_archive(
-                xml,
+                stream,
                 data,
                 archive,
                 content_types,

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -19,6 +19,36 @@ use crate::styles::StyleList;
 pub(crate) trait ReadSeek: Read + Seek + Send {}
 impl<T: Read + Seek + Send> ReadSeek for T {}
 
+/// Maximum decompressed size accepted for a small package part (relationships,
+/// `styles.xml`, `numbering.xml`, `[Content_Types].xml`).
+///
+/// These parts hold document metadata and are kilobytes in real documents. The
+/// cap stops a zip-bomb entry — one that deflates from a few KB to gigabytes —
+/// from being read fully into memory before parsing, which would otherwise
+/// exhaust the process regardless of the streaming main-document path. 64 MiB
+/// is far above any legitimate metadata part while keeping the amplification an
+/// attacker can force bounded and small.
+const MAX_METADATA_PART_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Reads a ZIP entry fully into memory, failing if it decompresses beyond `cap`.
+///
+/// Reads at most `cap + 1` bytes so an over-cap entry is detected without
+/// decompressing the whole (potentially enormous) part. `part_name` is used only
+/// for the error message.
+fn read_entry_capped<R: Read>(entry: &mut R, cap: u64, part_name: &str) -> Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    entry
+        .take(cap.saturating_add(1))
+        .read_to_end(&mut bytes)
+        .map_err(Error::from)?;
+    if u64::try_from(bytes.len()).unwrap_or(u64::MAX) > cap {
+        return Err(parse_error(format!(
+            "package part {part_name} exceeds the {cap}-byte limit (possible zip bomb)"
+        )));
+    }
+    Ok(bytes)
+}
+
 type PackageContents = (
     StyleList,
     crate::numbering::MinimalNumbering,
@@ -127,9 +157,7 @@ where
             parse_error(format!("malformed ZIP: {err}"))
         }
     })?;
-    let mut bytes = Vec::new();
-    rels_entry.read_to_end(&mut bytes).map_err(Error::from)?;
-    Ok(bytes)
+    read_entry_capped(&mut rels_entry, MAX_METADATA_PART_BYTES, "_rels/.rels")
 }
 
 fn load_small_package_parts<R>(
@@ -171,11 +199,11 @@ where
     let doc_rels_path = rels::derive_part_rels_path(document_path);
     let maybe_doc_rels_bytes = if doc_rels_path == "word/_rels/document.xml.rels" {
         match archive.by_name("word/_rels/document.xml.rels") {
-            Ok(mut entry) => {
-                let mut bytes = Vec::new();
-                entry.read_to_end(&mut bytes).map_err(Error::from)?;
-                Some(bytes)
-            }
+            Ok(mut entry) => Some(read_entry_capped(
+                &mut entry,
+                MAX_METADATA_PART_BYTES,
+                "word/_rels/document.xml.rels",
+            )?),
             Err(ZipError::FileNotFound) => None,
             Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
         }
@@ -202,11 +230,7 @@ where
 
     let styles_path = rels::resolve_relative_target(document_path, &styles_target);
     let styles_bytes = match archive.by_name(&styles_path) {
-        Ok(mut entry) => {
-            let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).map_err(Error::from)?;
-            bytes
-        }
+        Ok(mut entry) => read_entry_capped(&mut entry, MAX_METADATA_PART_BYTES, &styles_path)?,
         Err(ZipError::FileNotFound) => return Ok((StyleList::default(), hyperlink_map, image_map)),
         Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
     };
@@ -220,11 +244,11 @@ where
     R: Read + Seek,
 {
     match archive.by_name(path) {
-        Ok(mut entry) => {
-            let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).map_err(Error::from)?;
-            Ok(Some(bytes))
-        }
+        Ok(mut entry) => Ok(Some(read_entry_capped(
+            &mut entry,
+            MAX_METADATA_PART_BYTES,
+            path,
+        )?)),
         Err(ZipError::FileNotFound) => Ok(None),
         Err(err) => Err(parse_error(format!("malformed ZIP: {err}"))),
     }
@@ -239,11 +263,7 @@ where
 {
     let doc_rels_path = rels::derive_part_rels_path(document_path);
     let doc_rels_bytes = match archive.by_name(&doc_rels_path) {
-        Ok(mut entry) => {
-            let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).map_err(Error::from)?;
-            bytes
-        }
+        Ok(mut entry) => read_entry_capped(&mut entry, MAX_METADATA_PART_BYTES, &doc_rels_path)?,
         Err(ZipError::FileNotFound) => return Ok(crate::numbering::MinimalNumbering::new()),
         Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
     };
@@ -255,11 +275,7 @@ where
 
     let numbering_path = rels::resolve_relative_target(document_path, &numbering_target);
     let numbering_bytes = match archive.by_name(&numbering_path) {
-        Ok(mut entry) => {
-            let mut bytes = Vec::new();
-            entry.read_to_end(&mut bytes).map_err(Error::from)?;
-            bytes
-        }
+        Ok(mut entry) => read_entry_capped(&mut entry, MAX_METADATA_PART_BYTES, &numbering_path)?,
         Err(ZipError::FileNotFound) => return Ok(crate::numbering::MinimalNumbering::new()),
         Err(err) => return Err(parse_error(format!("malformed ZIP: {err}"))),
     };
@@ -277,13 +293,20 @@ fn parse_error(message: String) -> Error {
 #[cfg(test)]
 #[cfg(not(coverage))]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::indexing_slicing)]
+    #![allow(
+        clippy::unwrap_used,
+        clippy::indexing_slicing,
+        clippy::panic,
+        clippy::arithmetic_side_effects
+    )]
     use core::fmt::Write as _;
     use std::collections::HashMap;
     use std::io::{Cursor, Read as _, Write as _};
     use zip::ZipWriter;
 
-    use super::{load_style_list_and_hyperlink_map, open_package};
+    use super::{
+        load_style_list_and_hyperlink_map, open_package, read_entry_capped, MAX_METADATA_PART_BYTES,
+    };
     use crate::styles::StyleList;
     use docspec_core::Error;
 
@@ -898,6 +921,83 @@ mod tests {
                 );
             }
             Err(err) => assert_eq!(format!("{err:?}"), "expected content types lookup to work"),
+        }
+    }
+
+    #[test]
+    fn read_entry_capped_accepts_up_to_cap_and_rejects_over_with_exact_message() {
+        // Exactly at the cap: accepted, returned verbatim.
+        let at_cap = vec![b'A'; 8];
+        let mut cursor = Cursor::new(at_cap.clone());
+        assert_eq!(
+            read_entry_capped(&mut cursor, 8, "word/styles.xml").unwrap(),
+            at_cap
+        );
+
+        // One byte over the cap: rejected with the exact zip-bomb error.
+        let over_cap = vec![b'A'; 9];
+        match read_entry_capped(&mut Cursor::new(over_cap), 8, "word/styles.xml") {
+            Err(Error::Parse { message, position }) => {
+                assert_eq!(
+                    message,
+                    "package part word/styles.xml exceeds the 8-byte limit (possible zip bomb)"
+                );
+                assert_eq!(position, None);
+            }
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+    }
+
+    /// Writes a deflated ZIP entry filled with `len` copies of `byte`, streamed in
+    /// chunks so the fixture never materializes the full decompressed payload.
+    fn add_deflated_filled_entry(
+        writer: &mut ZipWriter<Cursor<Vec<u8>>>,
+        name: &str,
+        byte: u8,
+        len: usize,
+    ) {
+        let options = zip::write::SimpleFileOptions::default()
+            .compression_method(zip::CompressionMethod::Deflated);
+        writer.start_file(name, options).unwrap();
+        let chunk = vec![byte; 1 << 20];
+        let mut remaining = len;
+        while remaining > 0 {
+            let n = remaining.min(chunk.len());
+            writer.write_all(&chunk[..n]).unwrap();
+            remaining -= n;
+        }
+    }
+
+    #[test]
+    fn styles_part_exceeding_cap_is_rejected_before_full_decompression() {
+        // A 2 KB DOCX whose word/styles.xml deflates to just over the cap — the
+        // zip bomb that used to drive peak memory to gigabytes. The reader must
+        // reject it instead of reading the whole part into memory.
+        let over_cap = usize::try_from(MAX_METADATA_PART_BYTES).unwrap() + 1;
+
+        let buf = Cursor::new(Vec::new());
+        let mut writer = ZipWriter::new(buf);
+        add_stored_entry(
+            &mut writer,
+            "word/_rels/document.xml.rels",
+            doc_rels_xml("styles.xml").as_bytes(),
+        );
+        add_deflated_filled_entry(&mut writer, "word/styles.xml", b'A', over_cap);
+        let zip_bytes = writer.finish().unwrap().into_inner();
+
+        let mut reader = Cursor::new(zip_bytes);
+        let mut archive = zip::ZipArchive::new(&mut reader).unwrap();
+        match load_style_list_and_hyperlink_map(&mut archive, "word/document.xml") {
+            Err(Error::Parse { message, position }) => {
+                assert_eq!(
+                    message,
+                    format!(
+                        "package part word/styles.xml exceeds the {MAX_METADATA_PART_BYTES}-byte limit (possible zip bomb)"
+                    )
+                );
+                assert_eq!(position, None);
+            }
+            other => panic!("expected Parse error for zip-bomb styles.xml, got {other:?}"),
         }
     }
 }

--- a/crates/docspec-docx-reader/src/package.rs
+++ b/crates/docspec-docx-reader/src/package.rs
@@ -35,7 +35,10 @@ const MAX_METADATA_PART_BYTES: u64 = 64 * 1024 * 1024;
 /// Reads at most `cap + 1` bytes so an over-cap entry is detected without
 /// decompressing the whole (potentially enormous) part. `part_name` is used only
 /// for the error message.
-fn read_entry_capped<R: Read>(entry: &mut R, cap: u64, part_name: &str) -> Result<Vec<u8>> {
+fn read_entry_capped<R>(entry: &mut R, cap: u64, part_name: &str) -> Result<Vec<u8>>
+where
+    R: Read,
+{
     let mut bytes = Vec::new();
     entry
         .take(cap.saturating_add(1))

--- a/crates/docspec-docx-reader/tests/zip_bomb.rs
+++ b/crates/docspec-docx-reader/tests/zip_bomb.rs
@@ -106,6 +106,26 @@ fn document_bigtext_bomb_docx() -> Vec<u8> {
     writer.finish().unwrap().into_inner()
 }
 
+/// A DOCX whose `document.xml` nests `<w:tbl>` far deeper than the depth cap.
+/// The recursion this would trigger overflows the stack without the guard, so
+/// the fixture is kept just over the limit rather than tens of thousands deep.
+fn nested_tables_bomb_docx(levels: usize) -> Vec<u8> {
+    let mut doc: Vec<u8> = br#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>"#.to_vec();
+    for _ in 0..levels {
+        doc.extend_from_slice(b"<w:tbl><w:tr><w:tc>");
+    }
+    doc.extend_from_slice(b"<w:p><w:r><w:t>x</w:t></w:r></w:p>");
+    for _ in 0..levels {
+        doc.extend_from_slice(b"</w:tc></w:tr></w:tbl>");
+    }
+    doc.extend_from_slice(b"</w:body></w:document>");
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    add_stored(&mut writer, "_rels/.rels", ROOT_RELS);
+    add_stored(&mut writer, "word/document.xml", &doc);
+    writer.finish().unwrap().into_inner()
+}
+
 fn expected_metadata_message(part: &str) -> String {
     format!("package part {part} exceeds the {CAP}-byte limit (possible zip bomb)")
 }
@@ -164,4 +184,30 @@ fn document_single_node_bomb_is_rejected_while_streaming_via_from_path() {
         }
     }
     assert!(saw_node_limit, "streaming never hit the node-size limit");
+}
+
+#[test]
+fn deeply_nested_tables_fail_fast_instead_of_overflowing_the_stack() {
+    // 500 levels is well past the depth cap but far below what would overflow
+    // the stack, so this test fails cleanly (a regression would abort instead).
+    let bomb = nested_tables_bomb_docx(500);
+    let mut reader = DocxReader::from_reader(Cursor::new(bomb)).unwrap();
+    let mut saw_depth_limit = false;
+    loop {
+        match reader.next_event() {
+            Ok(Some(_)) => {}
+            Ok(None) => break,
+            Err(Error::Parse { message, position }) => {
+                assert_eq!(
+                    message,
+                    "table nesting exceeds the depth limit of 100 (possible zip bomb)"
+                );
+                assert_eq!(position, None);
+                saw_depth_limit = true;
+                break;
+            }
+            other => panic!("expected Parse depth-limit error, got {other:?}"),
+        }
+    }
+    assert!(saw_depth_limit, "nesting never hit the depth limit");
 }

--- a/crates/docspec-docx-reader/tests/zip_bomb.rs
+++ b/crates/docspec-docx-reader/tests/zip_bomb.rs
@@ -1,0 +1,167 @@
+//! Zip-bomb regression tests for the DOCX reader.
+//!
+//! A DOCX is a ZIP archive, so a small upload can hide gigabytes of decompressed
+//! XML. Two distinct vectors are guarded here, both exercised through the public
+//! [`DocxReader`] API:
+//!
+//! 1. **Small package parts** (`styles.xml`, `numbering.xml`, relationships,
+//!    `[Content_Types].xml`) were read fully into memory before parsing. A part
+//!    that deflates from a few KB to gigabytes exhausted memory even on the
+//!    streaming `from_path` path, which only streams `document.xml`.
+//! 2. **A single oversized `document.xml` node** (e.g. one 2 GiB `<w:t>` run) is
+//!    read whole by quick-xml, so it inflated the streaming path's scratch buffer
+//!    to gigabytes even though a document of many small nodes streams in constant
+//!    memory.
+//!
+//! Both fixtures are synthesized in-process — a 2 GiB→GB decompression bomb must
+//! never be committed as a file. The bomb entry is written in chunks so the test
+//! never materializes the full decompressed payload while building it.
+
+#![allow(
+    clippy::arithmetic_side_effects,
+    clippy::indexing_slicing,
+    clippy::panic,
+    clippy::tests_outside_test_module,
+    clippy::unwrap_used
+)]
+
+use std::io::{Cursor, Write as _};
+
+use docspec_core::{Error, EventSource as _};
+use docspec_docx_reader::DocxReader;
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+/// Matches `MAX_METADATA_PART_BYTES` and `MAX_XML_NODE_BYTES` in the reader.
+/// Kept in sync deliberately: if the reader's cap changes, these tests should be
+/// reviewed alongside it.
+const CAP: usize = 64 * 1024 * 1024;
+
+/// Writes a stored (uncompressed) ZIP entry.
+fn add_stored(writer: &mut ZipWriter<Cursor<Vec<u8>>>, name: &str, content: &[u8]) {
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Stored);
+    writer.start_file(name, options).unwrap();
+    writer.write_all(content).unwrap();
+}
+
+/// Writes a deflated ZIP entry: `prefix`, then `fill_len` copies of `fill`, then
+/// `suffix`. The fill is streamed in chunks so the builder never holds the full
+/// decompressed payload in one allocation.
+fn add_deflated_filled(
+    writer: &mut ZipWriter<Cursor<Vec<u8>>>,
+    name: &str,
+    prefix: &[u8],
+    fill: u8,
+    fill_len: usize,
+    suffix: &[u8],
+) {
+    let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+    writer.start_file(name, options).unwrap();
+    writer.write_all(prefix).unwrap();
+    let chunk = vec![fill; 1 << 20];
+    let mut remaining = fill_len;
+    while remaining > 0 {
+        let n = remaining.min(chunk.len());
+        writer.write_all(&chunk[..n]).unwrap();
+        remaining -= n;
+    }
+    writer.write_all(suffix).unwrap();
+}
+
+const ROOT_RELS: &[u8] = br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+
+/// A DOCX whose `word/styles.xml` deflates to just over the metadata cap.
+fn styles_bomb_docx() -> Vec<u8> {
+    let doc_rels = br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#;
+    let document = br#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>hi</w:t></w:r></w:p></w:body></w:document>"#;
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    add_stored(&mut writer, "_rels/.rels", ROOT_RELS);
+    add_stored(&mut writer, "word/document.xml", document);
+    add_stored(&mut writer, "word/_rels/document.xml.rels", doc_rels);
+    add_deflated_filled(&mut writer, "word/styles.xml", b"", b'A', CAP + 1, b"");
+    writer.finish().unwrap().into_inner()
+}
+
+/// A DOCX whose `word/document.xml` holds one `<w:t>` run well over the node cap.
+///
+/// The overshoot is 1 MiB rather than a single byte: the per-node window resets
+/// between tokens, but `BufReader` pre-buffers up to its capacity (~8 KiB) of the
+/// text during the previous token, so the effective cap is `CAP` plus that slop.
+/// 1 MiB clears the slop deterministically while staying a real streaming test.
+fn document_bigtext_bomb_docx() -> Vec<u8> {
+    let prefix = br#"<?xml version="1.0"?><w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:r><w:t>"#;
+    let suffix = b"</w:t></w:r></w:p></w:body></w:document>";
+
+    let mut writer = ZipWriter::new(Cursor::new(Vec::new()));
+    add_stored(&mut writer, "_rels/.rels", ROOT_RELS);
+    add_deflated_filled(
+        &mut writer,
+        "word/document.xml",
+        prefix,
+        b'A',
+        CAP + (1 << 20),
+        suffix,
+    );
+    writer.finish().unwrap().into_inner()
+}
+
+fn expected_metadata_message(part: &str) -> String {
+    format!("package part {part} exceeds the {CAP}-byte limit (possible zip bomb)")
+}
+
+const EXPECTED_NODE_MESSAGE: &str = "document.xml node exceeds the size limit (possible zip bomb)";
+
+#[test]
+fn styles_bomb_is_rejected_at_construction_via_from_reader() {
+    let bomb = styles_bomb_docx();
+    match DocxReader::from_reader(Cursor::new(bomb)) {
+        Err(Error::Parse { message, position }) => {
+            assert_eq!(message, expected_metadata_message("word/styles.xml"));
+            assert_eq!(position, None);
+        }
+        other => panic!("expected Parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn styles_bomb_is_rejected_at_construction_via_from_path() {
+    let bomb = styles_bomb_docx();
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&bomb).unwrap();
+    tmp.flush().unwrap();
+
+    match DocxReader::from_path(tmp.path()) {
+        Err(Error::Parse { message, position }) => {
+            assert_eq!(message, expected_metadata_message("word/styles.xml"));
+            assert_eq!(position, None);
+        }
+        other => panic!("expected Parse error, got {other:?}"),
+    }
+}
+
+#[test]
+fn document_single_node_bomb_is_rejected_while_streaming_via_from_path() {
+    let bomb = document_bigtext_bomb_docx();
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    tmp.write_all(&bomb).unwrap();
+    tmp.flush().unwrap();
+
+    // Construction succeeds — document.xml is streamed lazily on from_path — so
+    // the oversized node surfaces when the pump reaches it during iteration.
+    let mut reader = DocxReader::from_path(tmp.path()).unwrap();
+    let mut saw_node_limit = false;
+    loop {
+        match reader.next_event() {
+            Ok(Some(_)) => {}
+            Ok(None) => break,
+            Err(Error::Io { source }) => {
+                assert_eq!(source.to_string(), EXPECTED_NODE_MESSAGE);
+                saw_node_limit = true;
+                break;
+            }
+            other => panic!("expected Io node-limit error, got {other:?}"),
+        }
+    }
+    assert!(saw_node_limit, "streaming never hit the node-size limit");
+}


### PR DESCRIPTION
## What

Hardens the DOCX reader against three demonstrated resource-exhaustion bombs — small crafted files that drive memory to gigabytes or crash the process. All were found during an external audit; each has a reproducer and a regression test.

| Vector | Before | After | Issue |
| --- | --- | --- | --- |
| Zip-bomb metadata part (`styles.xml` etc. deflating KB→GB) | 2 MB file → **4.3 GB**, exit 0 | fails at ~61 MB with a parse error | #405 |
| Single oversized `document.xml` node (one 2 GiB `<w:t>`) — broke `from_path` streaming | 2 MB file → **8.2 GB**, exit 0 | streams, fails at ~42 MB | #409 |
| Deeply nested `<w:tbl>` — recursion | 6.5 KB file → **stack overflow / SIGABRT** | clean parse error | #411 |

## How

- **Metadata byte cap** (`package.rs`): each small part (`_rels`, `styles.xml`, `numbering.xml`, `[Content_Types].xml`) is read through `read_entry_capped`, which reads at most `cap+1` bytes and errors past a 64 MiB cap instead of decompressing the whole entry.
- **Per-node cap** (`document/input.rs`): the `document.xml` stream is wrapped in a `NodeCappedReader` whose byte window resets before every token, so the 64 MiB cap applies *per XML node*. A legitimately huge document of many small nodes still streams in constant memory; one oversized node fails fast. Inserted inside `XmlCursor::new`, so no caller signatures change.
- **Table nesting cap** (`document/mod.rs`): a thin `parse_tbl` wrapper bounds recursion at `MAX_TABLE_NESTING_DEPTH = 100`, decrementing on every exit path so sibling tables don't accumulate depth.

## Tests

`tests/zip_bomb.rs` exercises all three through the public `DocxReader` API (`from_reader` and `from_path`), plus unit tests for `read_entry_capped` and `NodeCappedReader`. Bomb fixtures are synthesized in-process and streamed in chunks — no multi-GB file is ever committed or fully materialized.

## Not in this PR

- **`from_reader` buffers the whole decompressed `document.xml`** (#410) — the HTTP API and CLI-stdin path, so the constant-memory guarantee doesn't hold there. The immediate guard is the request body limit (#405); the real fix (spill the body to a temp file and use `from_path`) is a follow-up in the `docspec-http` crate.
- Parsed-structure count caps (e.g. max style/numbering entries) — bounded already by the 64 MiB byte cap; tracked as a lower-priority follow-up.

Caps are deliberately generous (64 MiB / depth 100) — far beyond any real document — and easy to tune.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DOCX parsing resilience for oversized XML content and compressed metadata.
  * Added protection against excessively deep table nesting.
  * Large or deeply nested documents now fail with clear parse errors instead of exhausting system resources.
* **Tests**
  * Added regression coverage for size limits, nesting limits, boundary conditions, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->