### PR TITLE
fix(http): stream DOCX from a temp file so the server honors constant memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "reqwest",
  "sentry",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "tower",

--- a/crates/docspec-http/Cargo.toml
+++ b/crates/docspec-http/Cargo.toml
@@ -59,6 +59,7 @@ uuid = { version = "1", features = ["v4"], optional = true }
 docspec-core = { workspace = true }
 docspec-json = { workspace = true }
 docspec = { workspace = true, features = ["full"] }
+tempfile = "3"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/docspec-http/src/handlers/conversion/mod.rs
+++ b/crates/docspec-http/src/handlers/conversion/mod.rs
@@ -214,15 +214,53 @@ async fn do_conversion(
     }
 
     let join_result = tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, u64), HttpError> {
+        use std::io::Write as _;
+
         let mut output_buffer = Vec::new();
-        let body_vec: Vec<u8> = body.into();
-        let reader = docspec::AnyReader::from_reader(input_format, std::io::Cursor::new(body_vec))
-            .map_err(|error| {
-                tracing::debug!(error = %error, "reader construction failed");
-                HttpError::Unprocessable {
-                    detail: error.to_string(),
-                }
+
+        // DOCX only streams in constant memory through `from_path`, which reads
+        // `word/document.xml` straight from a file instead of buffering the whole
+        // decompressed part in memory (see `AnyReader::from_path` / `from_reader`).
+        // The request body is in memory, so spill it to a temp file and stream from
+        // there. `spill_guard` keeps that file on disk for the whole conversion and
+        // unlinks it on return (including on an early `?` return). Text formats gain
+        // nothing from a file — their readers buffer regardless — so they keep the
+        // in-memory path.
+        let spill_guard: Option<tempfile::NamedTempFile>;
+        let reader = if matches!(input_format, InputFormat::Docx) {
+            let mut temp_file = tempfile::NamedTempFile::new().map_err(|error| {
+                tracing::warn!(error = %error, "failed to create temp file for docx spill");
+                HttpError::internal(error)
             })?;
+            temp_file.write_all(body.as_ref()).map_err(|error| {
+                tracing::warn!(error = %error, "failed to write docx body to temp file");
+                HttpError::internal(error)
+            })?;
+            temp_file.flush().map_err(|error| {
+                tracing::warn!(error = %error, "failed to flush docx temp file");
+                HttpError::internal(error)
+            })?;
+            let reader =
+                docspec::AnyReader::from_path(input_format, temp_file.path()).map_err(|error| {
+                    tracing::debug!(error = %error, "reader construction failed");
+                    HttpError::Unprocessable {
+                        detail: error.to_string(),
+                    }
+                })?;
+            spill_guard = Some(temp_file);
+            reader
+        } else {
+            spill_guard = None;
+            let body_vec: Vec<u8> = body.into();
+            docspec::AnyReader::from_reader(input_format, std::io::Cursor::new(body_vec)).map_err(
+                |error| {
+                    tracing::debug!(error = %error, "reader construction failed");
+                    HttpError::Unprocessable {
+                        detail: error.to_string(),
+                    }
+                },
+            )?
+        };
         let mut reader = docspec_core::SkipEmptyBlocks::new(reader);
         let mut sink = docspec::AnyWriter::new(output_format, &mut output_buffer);
 
@@ -255,6 +293,9 @@ async fn do_conversion(
             tracing::warn!(error = ?conversion_error, "output size exceeded u64 range");
             HttpError::internal(conversion_error)
         })?;
+
+        // Streaming reads from the spilled DOCX are done; unlink the temp file now.
+        drop(spill_guard);
         Ok((output_buffer, output_bytes))
     })
     .await;


### PR DESCRIPTION
## What

Closes the gap where the HTTP API does **not** stream DOCX. The conversion handler built its reader with `AnyReader::from_reader` over the in-memory body; for DOCX that buffers the entire decompressed `word/document.xml` in RAM, so the constant-memory guarantee didn't hold on the server — a small compressed upload could decompress to gigabytes in the process.

This spills the DOCX body to a temp file and reads it with `AnyReader::from_path`, which streams `word/document.xml` directly from disk in constant memory.

## Proof

Same request each way: a **2.6 MB** DOCX whose `document.xml` decompresses to **1 GiB** (many small comment nodes) and produces an 88-byte result. Measured peak RSS of the running server:

| | Server peak RSS | Response |
| --- | --- | --- |
| Before (`from_reader`, buffers) | **1084 MB** | 200, 88 B |
| After (spill → `from_path`, streams) | **12 MB** | 200, 88 B |

~90× less memory for identical input and output.

## How

In the `spawn_blocking` conversion closure:

- **DOCX** → write the body to a `tempfile::NamedTempFile`, construct the reader with `AnyReader::from_path`, and hold a `spill_guard` that keeps the file on disk for the whole conversion and unlinks it on return (including on an early `?` error).
- **Markdown / HTML** → unchanged in-memory path; their readers buffer regardless, so a temp file would only add I/O.

Adds a `tempfile` dependency to `docspec-http`.

## Scope / composition

- Honors the constant-memory promise on the server for DOCX input.
- Composes with the per-node and table-nesting caps in the docx-reader hardening PR (they bound a single giant node / recursion; this bounds the whole-part buffering).
- Still subject to the request **body limit** for raw upload size — spill-to-disk removes the *decompression* amplification, not the cost of an arbitrarily large raw body. Re-enabling a body limit is tracked separately (#405).
- Note: conversion **output** is still buffered in memory before the response is sent; that's a separate concern from input streaming.

## Not covered by tests

Existing DOCX conversion tests exercise the new spill path end-to-end. The temp-file-failure `map_err` arms (create/write/flush) are infallible-in-practice I/O guards and are not unit-tested.

Refs #410. Found during an external code audit.
