### PR TITLE
test(html-writer): cover orphan end document

### DIFF
--- a/crates/docspec-html-writer/src/lib.rs
+++ b/crates/docspec-html-writer/src/lib.rs
@@ -331,4 +331,9 @@ mod tests {
             "<html><body></body></html>",
         );
     }
+
+    #[test]
+    fn orphan_end_document_produces_empty_output() {
+        assert_output([Event::EndDocument], "");
+    }
 }


### PR DESCRIPTION
## Summary

- add an exact regression test for an `EndDocument` received before `StartDocument`
- keep production behavior unchanged
- limit this PR to the single surviving `docspec-html-writer` mutant

## Mutation testing

A workspace list survey found 1,601 possible mutants. This PR deliberately focuses on the small HTML-writer gap.

Before the test, `docspec-html-writer` reported 19 mutants: 18 caught and 1 missed. The missed mutation was:

`crates/docspec-html-writer/src/lib.rs:76:33: replace && with ||`

The campaign used `--cap-lints true` because workspace `dead_code` denials can otherwise classify behavior-changing mutants as unviable.

After the test:

- targeted rerun: 1 mutant caught
- full crate rerun: 19 mutants caught, 0 missed

## Verification

- `cargo test -p docspec-html-writer`
- `cargo fmt --all -- --check`
- `just`
- repository pre-push hooks: format, clippy, build, tests, and docs
- five-lane post-implementation review: goal, QA, code quality, security, and context all passed

No production code or dependencies changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for a document-ending event received without a prior document start, confirming it produces no HTML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->